### PR TITLE
Postgres Driver should wait to unlock and set a unlock timer.

### DIFF
--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -131,7 +131,7 @@ func (p *Postgres) Lock() error {
 
 	// This will either obtain the lock immediately and return true,
 	// or return false if the lock cannot be acquired immediately.
-	query := `SELECT pg_try_advisory_lock($1)`
+	query := `SELECT pg_advisory_lock($1)`
 	var success bool
 	if err := p.conn.QueryRowContext(context.Background(), query, aid).Scan(&success); err != nil {
 		return &database.Error{OrigErr: err, Err: "try lock failed", Query: []byte(query)}


### PR DESCRIPTION
Hello,

It seems the postgres driver wasn't following convention as the Lock method will wait for the timeout before stopping the operation.  But the driver was using `postgres_try_advisory_lock` which immediately errors if it cant acquire instead of waiting.  This fixes that.

I also saw a bug comment about a deadlock for unlocking so I just replicated the same timing functions that the lock function does.  If you would prefer this in a different MR or a different way of doing it then we can pick that commit out of this MR and just use this one for the postgres change.