### PR TITLE
-datetime option to create files in yyyymmddhhmmss format

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -49,10 +49,10 @@ func nextSeq(matches []string, dir string, seqDigits int) (string, error) {
 	return nextSeqStr, nil
 }
 
-func createCmd(dir string, timestamp int64, name string, ext string, seq bool, seqDigits int, datetime bool) {
+func createCmd(dir string, timestamp int64, format string, name string, ext string, seq bool, seqDigits int) {
 	var base string
-	if seq && datetime {
-		log.fatalErr(errors.New("seq and datetime options are mutually exclusive"))
+	if seq && len(format) > 0 {
+		log.fatalErr(errors.New("The seq and format options are mutually exclusive"))
 	}
 	if seq {
 		if seqDigits <= 0 {
@@ -67,20 +67,29 @@ func createCmd(dir string, timestamp int64, name string, ext string, seq bool, s
 			log.fatalErr(err)
 		}
 		base = fmt.Sprintf("%v%v_%v.", dir, nextSeqStr, name)
-	} else if datetime {
-		now := time.Now();
-		year, month, day := now.Date();
-		var m = int(month);
-		hr, min, sec := now.Clock();
-		base = fmt.Sprintf("%04d%02d%02d%02d%02d%02d_%v.",year,m,day, hr, min, sec, name)
 	} else {
-		base = fmt.Sprintf("%v%v_%v.", dir, timestamp, name)
+		if len(format) > 0 {
+			t := time.Unix(timestamp, 0)
+			version := t.Format(format)
+			base = fmt.Sprintf("%v%v_%v.", dir, version, name)
+		} else {
+			log.Println("Time format not specified")
+			base = fmt.Sprintf("%v%v_%v.", dir, timestamp, name)
+		}
 	}
 
 	os.MkdirAll(dir, os.ModePerm)
 	createFile(base + "up" + ext)
 	createFile(base + "down" + ext)
 }
+
+/*else if datetime {
+		now := time.Now();
+		year, month, day := now.Date();
+		var m = int(month);
+		hr, min, sec := now.Clock();
+		base = fmt.Sprintf("%04d%02d%02d%02d%02d%02d_%v.",year,m,day, hr, min, sec, name)
+	} */
 
 func createFile(fname string) {
 	if _, err := os.Create(fname); err != nil {

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -83,14 +83,6 @@ func createCmd(dir string, timestamp int64, format string, name string, ext stri
 	createFile(base + "down" + ext)
 }
 
-/*else if datetime {
-		now := time.Now();
-		year, month, day := now.Date();
-		var m = int(month);
-		hr, min, sec := now.Clock();
-		base = fmt.Sprintf("%04d%02d%02d%02d%02d%02d_%v.",year,m,day, hr, min, sec, name)
-	} */
-
 func createFile(fname string) {
 	if _, err := os.Create(fname); err != nil {
 		log.fatalErr(err)

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func nextSeq(matches []string, dir string, seqDigits int) (string, error) {
@@ -48,8 +49,11 @@ func nextSeq(matches []string, dir string, seqDigits int) (string, error) {
 	return nextSeqStr, nil
 }
 
-func createCmd(dir string, timestamp int64, name string, ext string, seq bool, seqDigits int) {
+func createCmd(dir string, timestamp int64, name string, ext string, seq bool, seqDigits int, datetime bool) {
 	var base string
+	if seq && datetime {
+		log.fatalErr(errors.New("seq and datetime options are mutually exclusive"))
+	}
 	if seq {
 		if seqDigits <= 0 {
 			log.fatalErr(errors.New("Digits must be positive"))
@@ -63,6 +67,12 @@ func createCmd(dir string, timestamp int64, name string, ext string, seq bool, s
 			log.fatalErr(err)
 		}
 		base = fmt.Sprintf("%v%v_%v.", dir, nextSeqStr, name)
+	} else if datetime {
+		now := time.Now();
+		year, month, day := now.Date();
+		var m = int(month);
+		hr, min, sec := now.Clock();
+		base = fmt.Sprintf("%04d%02d%02d%02d%02d%02d_%v.",year,m,day, hr, min, sec, name)
 	} else {
 		base = fmt.Sprintf("%v%v_%v.", dir, timestamp, name)
 	}

--- a/cli/main.go
+++ b/cli/main.go
@@ -42,10 +42,10 @@ Options:
   -help            Print usage
 
 Commands:
-  create [-ext E] [-dir D] [-seq] [-digits N] [-datetime] NAME
+  create [-ext E] [-dir D] [-seq] [-digits N] [-format] NAME
 			   Create a set of timestamped up/down migrations titled NAME, in directory D with extension E.
 			   Use -seq option to generate sequential up/down migrations with N digits.
-			   Use -datetime option to generate migrations where the version is yyyymmddhhmmss.
+			   Use -format option to specify a Go time format string.
   goto V       Migrate to version V
   up [N]       Apply all or N up migrations
   down [N]     Apply all or N down migrations
@@ -110,14 +110,13 @@ Commands:
 		args := flag.Args()[1:]
 		seq := false
 		seqDigits := 6
-		datetime := false
 
 		createFlagSet := flag.NewFlagSet("create", flag.ExitOnError)
 		extPtr := createFlagSet.String("ext", "", "File extension")
 		dirPtr := createFlagSet.String("dir", "", "Directory to place file in (default: current working directory)")
+		formatPtr := createFlagSet.String("format", "", "Specify the format of the version using a Go time format string.  For yyyymmddhhmmss use format of 20060102150405.  If not specified the version will be the unix timestamp.")
 		createFlagSet.BoolVar(&seq, "seq", seq, "Use sequential numbers instead of timestamps (default: false)")
 		createFlagSet.IntVar(&seqDigits, "digits", seqDigits, "The number of digits to use in sequences (default: 6)")
-		createFlagSet.BoolVar(&datetime, "datetime", datetime, "Generate migrations where the version is yyyymmddhhmmss")
 		createFlagSet.Parse(args)
 
 		if createFlagSet.NArg() == 0 {
@@ -134,7 +133,7 @@ Commands:
 
 		timestamp := startTime.Unix()
 
-		createCmd(*dirPtr, timestamp, name, *extPtr, seq, seqDigits, datetime)
+		createCmd(*dirPtr, timestamp, *formatPtr, name, *extPtr, seq, seqDigits)
 
 	case "goto":
 		if migraterErr != nil {

--- a/cli/main.go
+++ b/cli/main.go
@@ -42,9 +42,10 @@ Options:
   -help            Print usage
 
 Commands:
-  create [-ext E] [-dir D] [-seq] [-digits N] NAME
+  create [-ext E] [-dir D] [-seq] [-digits N] [-datetime] NAME
 			   Create a set of timestamped up/down migrations titled NAME, in directory D with extension E.
 			   Use -seq option to generate sequential up/down migrations with N digits.
+			   Use -datetime option to generate migrations where the version is yyyymmddhhmmss.
   goto V       Migrate to version V
   up [N]       Apply all or N up migrations
   down [N]     Apply all or N down migrations
@@ -109,12 +110,14 @@ Commands:
 		args := flag.Args()[1:]
 		seq := false
 		seqDigits := 6
+		datetime := false
 
 		createFlagSet := flag.NewFlagSet("create", flag.ExitOnError)
 		extPtr := createFlagSet.String("ext", "", "File extension")
 		dirPtr := createFlagSet.String("dir", "", "Directory to place file in (default: current working directory)")
 		createFlagSet.BoolVar(&seq, "seq", seq, "Use sequential numbers instead of timestamps (default: false)")
 		createFlagSet.IntVar(&seqDigits, "digits", seqDigits, "The number of digits to use in sequences (default: 6)")
+		createFlagSet.BoolVar(&datetime, "datetime", datetime, "Generate migrations where the version is yyyymmddhhmmss")
 		createFlagSet.Parse(args)
 
 		if createFlagSet.NArg() == 0 {
@@ -131,7 +134,7 @@ Commands:
 
 		timestamp := startTime.Unix()
 
-		createCmd(*dirPtr, timestamp, name, *extPtr, seq, seqDigits)
+		createCmd(*dirPtr, timestamp, name, *extPtr, seq, seqDigits, datetime)
 
 	case "goto":
 		if migraterErr != nil {


### PR DESCRIPTION
Added -datetime option to create up/down migration files where the version is in yyyymmddhhmmss format similar to Ruby on Rails migration files.  This option is mutually exclusive with -seq.