### PR TITLE
Change TRUNCATE to DELETE FROM in postgres database

### DIFF
--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -10,6 +10,7 @@ import (
 	nurl "net/url"
 
 	"context"
+
 	"github.com/golang-migrate/migrate"
 	"github.com/golang-migrate/migrate/database"
 	"github.com/lib/pq"
@@ -185,7 +186,7 @@ func (p *Postgres) SetVersion(version int, dirty bool) error {
 		return &database.Error{OrigErr: err, Err: "transaction start failed"}
 	}
 
-	query := `TRUNCATE "` + p.config.MigrationsTable + `"`
+	query := `DELETE FROM "` + p.config.MigrationsTable + `"`
 	if _, err := tx.Exec(query); err != nil {
 		tx.Rollback()
 		return &database.Error{OrigErr: err, Query: []byte(query)}


### PR DESCRIPTION
This actually isn't a problem for postgres but is a problem for cockroach.
Internally cockroach drops the table when running a truncate which causes the insert to fail inside of this transaction. I added repro steps to mattes/migrate#320 which this PR should close.

Closes: https://github.com/mattes/migrate/issues/320

Signed-off-by: Elliott Davis <elliott@excellent.io>