### PR TITLE
Fixed unkeyed fields in file.go for GoogleAppEngine

### DIFF
--- a/source/file/file.go
+++ b/source/file/file.go
@@ -82,7 +82,7 @@ func (f *File) Close() error {
 
 func (f *File) First() (version uint, err error) {
 	if v, ok := f.migrations.First(); !ok {
-		return 0, &os.PathError{"first", f.path, os.ErrNotExist}
+		return 0, &os.PathError{Op: "first", Path: f.path, Err: os.ErrNotExist}
 	} else {
 		return v, nil
 	}
@@ -90,7 +90,7 @@ func (f *File) First() (version uint, err error) {
 
 func (f *File) Prev(version uint) (prevVersion uint, err error) {
 	if v, ok := f.migrations.Prev(version); !ok {
-		return 0, &os.PathError{fmt.Sprintf("prev for version %v", version), f.path, os.ErrNotExist}
+		return 0, &os.PathError{Op: fmt.Sprintf("prev for version %v", version), Path: f.path, Err: os.ErrNotExist}
 	} else {
 		return v, nil
 	}
@@ -98,7 +98,7 @@ func (f *File) Prev(version uint) (prevVersion uint, err error) {
 
 func (f *File) Next(version uint) (nextVersion uint, err error) {
 	if v, ok := f.migrations.Next(version); !ok {
-		return 0, &os.PathError{fmt.Sprintf("next for version %v", version), f.path, os.ErrNotExist}
+		return 0, &os.PathError{Op: fmt.Sprintf("next for version %v", version), Path: f.path, Err: os.ErrNotExist}
 	} else {
 		return v, nil
 	}
@@ -112,7 +112,7 @@ func (f *File) ReadUp(version uint) (r io.ReadCloser, identifier string, err err
 		}
 		return r, m.Identifier, nil
 	}
-	return nil, "", &os.PathError{fmt.Sprintf("read version %v", version), f.path, os.ErrNotExist}
+	return nil, "", &os.PathError{Op: fmt.Sprintf("read version %v", version), Path: f.path, Err: os.ErrNotExist}
 }
 
 func (f *File) ReadDown(version uint) (r io.ReadCloser, identifier string, err error) {
@@ -123,5 +123,5 @@ func (f *File) ReadDown(version uint) (r io.ReadCloser, identifier string, err e
 		}
 		return r, m.Identifier, nil
 	}
-	return nil, "", &os.PathError{fmt.Sprintf("read version %v", version), f.path, os.ErrNotExist}
+	return nil, "", &os.PathError{Op: fmt.Sprintf("read version %v", version), Path: f.path, Err: os.ErrNotExist}
 }


### PR DESCRIPTION
Hi there.
When I deploy into GooleAppEngine. The following errors occured.

```
File upload done.
Updating service [default]...failed.
ERROR: (gcloud.app.deploy) Error Response: [9] Deployment contains files that cannot be compiled: Compile failed:
go-app-builder: Failed parsing input (5 errors)
github.com/golang-migrate/migrate/source/file/file.go:85:14: composite struct literal os.PathError with unkeyed fields
github.com/golang-migrate/migrate/source/file/file.go:93:14: composite struct literal os.PathError with unkeyed fields
github.com/golang-migrate/migrate/source/file/file.go:101:14: composite struct literal os.PathError with unkeyed fields
github.com/golang-migrate/migrate/source/file/file.go:115:19: composite struct literal os.PathError with unkeyed fields
github.com/golang-migrate/migrate/source/file/file.go:126:19: composite struct literal os.PathError with unkeyed fields
```

Can you please merge this?

Thank you.