### PR TITLE
Build binaries statically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ COVERAGE_DIR ?= .coverage
 
 build-cli: clean
 	-mkdir ./cli/build
-	cd ./cli && GOOS=linux GOARCH=amd64 go build -a -o build/migrate.linux-amd64 -ldflags='-X main.Version=$(VERSION)' -tags '$(DATABASE) $(SOURCE)' .
-	cd ./cli && GOOS=darwin GOARCH=amd64 go build -a -o build/migrate.darwin-amd64 -ldflags='-X main.Version=$(VERSION)' -tags '$(DATABASE) $(SOURCE)' .
-	cd ./cli && GOOS=windows GOARCH=amd64 go build -a -o build/migrate.windows-amd64.exe -ldflags='-X main.Version=$(VERSION)' -tags '$(DATABASE) $(SOURCE)' .
+	cd ./cli && GOOS=linux GOARCH=amd64 go build -a -o build/migrate.linux-amd64 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
+	cd ./cli && GOOS=darwin GOARCH=amd64 go build -a -o build/migrate.darwin-amd64 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
+	cd ./cli && GOOS=windows GOARCH=amd64 go build -a -o build/migrate.windows-amd64.exe -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
 	cd ./cli/build && find . -name 'migrate*' | xargs -I{} tar czf {}.tar.gz {}
 	cd ./cli/build && shasum -a 256 * > sha256sum.txt
 	cat ./cli/build/sha256sum.txt


### PR DESCRIPTION
Addresses: https://github.com/golang-migrate/migrate/issues/45

Seems to work locally:
```shell
[dhui:migrate]$ cat Dockerfile.teststaticcli
FROM alpine:latest

ENV MIGRATE_VERSION=3.2.0

WORKDIR /usr/local/bin
COPY cli/build/migrate.linux-amd64 .

RUN ./migrate.linux-amd64
[dhui:migrate]$ make build-cli
rm -r ./cli/build
rm: ./cli/build: No such file or directory
make: [clean] Error 1 (ignored)
mkdir ./cli/build
cd ./cli && GOOS=linux GOARCH=amd64 go build -a -o build/migrate.linux-amd64 -ldflags='-X main.Version=3.2.0-39-g3d1bb8a -extldflags "-static"' -tags 'postgres mysql redshift cassandra spanner cockroachdb clickhouse file go-bindata github aws-s3 google-cloud-storage' .
cd ./cli && GOOS=darwin GOARCH=amd64 go build -a -o build/migrate.darwin-amd64 -ldflags='-X main.Version=3.2.0-39-g3d1bb8a -extldflags "-static"' -tags 'postgres mysql redshift cassandra spanner cockroachdb clickhouse file go-bindata github aws-s3 google-cloud-storage' .
cd ./cli && GOOS=windows GOARCH=amd64 go build -a -o build/migrate.windows-amd64.exe -ldflags='-X main.Version=3.2.0-39-g3d1bb8a -extldflags "-static"' -tags 'postgres mysql redshift cassandra spanner cockroachdb clickhouse file go-bindata github aws-s3 google-cloud-storage' .
cd ./cli/build && find . -name 'migrate*' | xargs -I{} tar czf {}.tar.gz {}
cd ./cli/build && shasum -a 256 * > sha256sum.txt
cat ./cli/build/sha256sum.txt
c85fb1ef519064019e5f8b38188b51e85d24d6cc5ce22bf6b8c8e2cda0e5b1a3  migrate.darwin-amd64
8bf606dad2496efb1d1f50ea686197b4bb3ac9bb2059aab882ff745643c9588b  migrate.darwin-amd64.tar.gz
10ecb61f6bde2400e246bd08d8419aa21419e1d558b03f31d4abceaa08fb2cad  migrate.linux-amd64
6c5ca2fecd30131a28d66ca58b7c3b323b2f5acfa84c61183b9fed6752a7a1e0  migrate.linux-amd64.tar.gz
c442dec0e3ccf91f1aa3450ced8d4972573a86aada56ebc7da1e29df50f28acc  migrate.windows-amd64.exe
57cadd5ba28c75aafe1ebece449d6e9fecaefff6e1df2bd43a3094ff968dee6e  migrate.windows-amd64.exe.tar.gz
[dhui:migrate]$ docker build -f Dockerfile.teststaticcli .
Sending build context to Docker daemon  116.6MB
Step 1/5 : FROM alpine:latest
 ---> 3fd9065eaf02
Step 2/5 : ENV MIGRATE_VERSION=3.2.0
 ---> Running in 4ab7078bcccf
Removing intermediate container 4ab7078bcccf
 ---> 19d4a35fe6a4
Step 3/5 : WORKDIR /usr/local/bin
Removing intermediate container fb416a84d330
 ---> da0652c58b04
Step 4/5 : COPY cli/build/migrate.linux-amd64 .
 ---> d438e6f913fa
Step 5/5 : RUN ./migrate.linux-amd64
 ---> Running in 7142a5104718
Usage: migrate OPTIONS COMMAND [arg...]
       migrate [ -version | -help ]

Options:
  -source          Location of the migrations (driver://url)
  -path            Shorthand for -source=file://path
  -database        Run migrations against this database (driver://url)
  -prefetch N      Number of migrations to load in advance before executing (default 10)
  -lock-timeout N  Allow N seconds to acquire database lock (default 15)
  -verbose         Print verbose logging
  -version         Print version
  -help            Print usage

Commands:
  create [-ext E] [-dir D] [-seq] [-digits N] [-format] NAME
			   Create a set of timestamped up/down migrations titled NAME, in directory D with extension E.
			   Use -seq option to generate sequential up/down migrations with N digits.
			   Use -format option to specify a Go time format string.
  goto V       Migrate to version V
  up [N]       Apply all or N up migrations
  down [N]     Apply all or N down migrations
  drop         Drop everyting inside database
  force V      Set version V but don't run migration (ignores dirty state)
  version      Print current migration version
Removing intermediate container 7142a5104718
 ---> 21554f55780d
Successfully built 21554f55780d
[dhui:migrate]$
```