### PR TITLE
prevent net/url encoding the user password

### DIFF
--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -90,6 +90,7 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 }
 
 func (m *Mysql) Open(url string) (database.Driver, error) {
+	url = strings.TrimPrefix(url, "mysql://")
 	purl, err := nurl.Parse(url)
 	if err != nil {
 		return nil, err
@@ -99,8 +100,7 @@ func (m *Mysql) Open(url string) (database.Driver, error) {
 	q.Set("multiStatements", "true")
 	purl.RawQuery = q.Encode()
 
-	db, err := sql.Open("mysql", strings.Replace(
-		migrate.FilterCustomQuery(purl).String(), "mysql://", "", 1))
+	db, err := sql.Open("mysql", migrate.FilterCustomQuery(purl).String())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is a cherry-pick fix from https://github.com/mattes/migrate/pull/324. This should fix https://github.com/mattes/migrate/issues/256

cc @RyanDeng

-------

According to net/url

```
// A URL represents a parsed URL (technically, a URI reference).
//
// The general form represented is:
//
//	[scheme:][//[userinfo@]host][/]path[?query][#fragment]
//
// URLs that do not start with a slash after the scheme are interpreted as:
//
//	scheme:opaque[?query][#fragment]
//
```

If the url starts with a slash after the scheme, the url.String() func will do url encode for the userinfo. In this case, password that has non-alphanumeric char will be url encoded and mysql auth will fail.

Probably the best fix should be in Open() func of database/driver.go. However I'm using mysql and not familiar with other drivers, so make a tiny fix in the mysql driver