### PR TITLE
Support for multiple statements in Cassandra cql migration files

### DIFF
--- a/database/cassandra/README.md
+++ b/database/cassandra/README.md
@@ -3,7 +3,9 @@
 * Drop command will not work on Cassandra 2.X because it rely on
 system_schema table which comes with 3.X
 * Other commands should work properly but are **not tested**
-* The Cassandra driver (gocql) does not natively support executing multipe statements in a single query. To allow for multiple statements in a single migration, you can use the `x-multi-statement` param. Note that this simply splits the migration into separately-executed statements by a semi-colon ';'. The queries are also not executed in any sort of transaction/batch, meaning you are responsible for fixing partial migrations.
+* The Cassandra driver (gocql) does not natively support executing multipe statements in a single query. To allow for multiple statements in a single migration, you can use the `x-multi-statement` param. There are two important caveats:
+  * This mode splits the migration text into separately-executed statements by a semi-colon `;`. Thus `x-multi-statement` cannot be used when a statement in the migration contains a string with a semi-colon.
+  * The queries are not executed in any sort of transaction/batch, meaning you are responsible for fixing partial migrations.
 
 
 ## Usage

--- a/database/cassandra/README.md
+++ b/database/cassandra/README.md
@@ -3,6 +3,7 @@
 * Drop command will not work on Cassandra 2.X because it rely on
 system_schema table which comes with 3.X
 * Other commands should work properly but are **not tested**
+* The Cassandra driver (gocql) does not natively support executing multipe statements in a single query. To allow for multiple statements in a single migration, you can use the `x-multi-statement` param. Note that this simply splits the migration into separately-executed statements by a semi-colon ';'. The queries are also not executed in any sort of transaction/batch, meaning you are responsible for fixing partial migrations.
 
 
 ## Usage
@@ -12,6 +13,7 @@ system_schema table which comes with 3.X
 | URL Query  | Default value | Description |
 |------------|-------------|-----------|
 | `x-migrations-table` | schema_migrations | Name of the migrations table |
+| `x-multi-statement` | false | Enable multiple statements to be ran in a single migration (See note above) |
 | `port` | 9042 | The port to bind to  |
 | `consistency` | ALL | Migration consistency
 | `protocol` |  | Cassandra protocol version (3 or 4)

--- a/database/cassandra/cassandra.go
+++ b/database/cassandra/cassandra.go
@@ -155,9 +155,17 @@ func (c *Cassandra) Run(migration io.Reader) error {
 	}
 	// run migration
 	query := string(migr[:])
-	if err := c.session.Query(query).Exec(); err != nil {
-		// TODO: cast to Cassandra error and get line number
-		return database.Error{OrigErr: err, Err: "migration failed", Query: migr}
+
+	// split query by semi-colon
+	queries := strings.Split(query, ";\n")
+
+	for _, q := range(queries) {
+		tq := strings.TrimSpace(q)
+		if (tq == "") { continue }
+		if err := c.session.Query(tq).Exec(); err != nil {
+			// TODO: cast to Cassandra error and get line number
+			return database.Error{OrigErr: err, Err: "migration failed", Query: migr}
+		}
 	}
 
 	return nil

--- a/database/cassandra/cassandra.go
+++ b/database/cassandra/cassandra.go
@@ -170,13 +170,13 @@ func (c *Cassandra) Run(migration io.Reader) error {
 				return database.Error{OrigErr: err, Err: "migration failed", Query: migr}
 			}
 		}
-	} else {
-		if err := c.session.Query(query).Exec(); err != nil {
-			// TODO: cast to Cassandra error and get line number
-			return database.Error{OrigErr: err, Err: "migration failed", Query: migr}
-		}
+		return nil
 	}
 
+	if err := c.session.Query(query).Exec(); err != nil {
+		// TODO: cast to Cassandra error and get line number
+		return database.Error{OrigErr: err, Err: "migration failed", Query: migr}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Currently you cannot include multiple statements in the CQL migration files due to Cassandra only allowing 1 statement per query. This makes creating multiple tables or indices in a single migration difficult. This change splits the CQL migration script by a semi-colon and newline pattern, and iterates them 1 by 1, allowing multiple statements per migration.