### PR TITLE
Allow DB connection URLs to contain encoded reserved URL characters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ test-with-flags:
 
 	@go test $(TEST_FLAGS) .
 	@go test $(TEST_FLAGS) ./cli/...
+	@go test $(TEST_FLAGS) ./database
 	@go test $(TEST_FLAGS) ./testing/...
 
 	@echo -n '$(SOURCE)' | tr -s ' ' '\n' | xargs -I{} go test $(TEST_FLAGS) ./source/{}

--- a/README.md
+++ b/README.md
@@ -39,6 +39,25 @@ Database drivers run migrations. [Add a new database?](database/driver.go)
   * [CockroachDB](database/cockroachdb)
   * [ClickHouse](database/clickhouse)
 
+### Database URLs
+
+Database connection strings are specified via URLs. The URL format is driver dependent but generally has the form: `dbdriver://username:password@host:port/dbname?option1=true&option2=false`
+
+Any [reserved URL characters](https://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_reserved_characters) need to be escaped. Note, the `%` character also [needs to be escaped](https://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_the_percent_character)
+
+Explicitly, the following characters need to be escaped:
+`!`, `#`, `$`, `%`, `&`, `'`, `(`, `)`, `*`, `+`, `,`, `/`, `:`, `;`, `=`, `?`, `@`, `[`, `]`
+
+It's easiest to always run the URL parts of your DB connection URL (e.g. username, password, etc) through an URL encoder. See the example Python helpers below:
+```bash
+$ python3 -c 'import urllib.parse; print(urllib.parse.quote(input("String to encode: "), ""))'
+String to encode: FAKEpassword!#$%&'()*+,/:;=?@[]
+FAKEpassword%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D
+$ python2 -c 'import urllib; print urllib.quote(raw_input("String to encode: "), "")'
+String to encode: FAKEpassword!#$%&'()*+,/:;=?@[]
+FAKEpassword%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D
+$
+```
 
 ## Migration Sources
 

--- a/database/driver.go
+++ b/database/driver.go
@@ -81,7 +81,8 @@ type Driver interface {
 func Open(url string) (Driver, error) {
 	u, err := nurl.Parse(url)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Unable to parse URL. Did you escape all reserved URL characters? "+
+			"See: https://github.com/golang-migrate/migrate#database-urls Error: %v", err)
 	}
 
 	if u.Scheme == "" {

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -90,7 +90,6 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 }
 
 func (m *Mysql) Open(url string) (database.Driver, error) {
-	url = strings.TrimPrefix(url, "mysql://")
 	purl, err := nurl.Parse(url)
 	if err != nil {
 		return nil, err
@@ -100,7 +99,8 @@ func (m *Mysql) Open(url string) (database.Driver, error) {
 	q.Set("multiStatements", "true")
 	purl.RawQuery = q.Encode()
 
-	db, err := sql.Open("mysql", migrate.FilterCustomQuery(purl).String())
+	db, err := sql.Open("mysql", strings.Replace(
+		migrate.FilterCustomQuery(purl).String(), "mysql://", "", 1))
 	if err != nil {
 		return nil, err
 	}

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -13,8 +13,13 @@ import (
 	nurl "net/url"
 	"strconv"
 	"strings"
+)
 
+import (
 	"github.com/go-sql-driver/mysql"
+)
+
+import (
 	"github.com/golang-migrate/migrate"
 	"github.com/golang-migrate/migrate/database"
 )
@@ -89,6 +94,25 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 	return mx, nil
 }
 
+// urlToMySQLConfig takes a net/url URL and returns a go-sql-driver/mysql Config.
+// Manually sets username and password to avoid net/url from url-encoding the reserved URL characters
+func urlToMySQLConfig(u nurl.URL) (*mysql.Config, error) {
+	origUserInfo := u.User
+	u.User = nil
+
+	c, err := mysql.ParseDSN(strings.TrimPrefix(u.String(), "mysql://"))
+	if err != nil {
+		return nil, err
+	}
+	if origUserInfo != nil {
+		c.User = origUserInfo.Username()
+		if p, ok := origUserInfo.Password(); ok {
+			c.Passwd = p
+		}
+	}
+	return c, nil
+}
+
 func (m *Mysql) Open(url string) (database.Driver, error) {
 	purl, err := nurl.Parse(url)
 	if err != nil {
@@ -99,8 +123,11 @@ func (m *Mysql) Open(url string) (database.Driver, error) {
 	q.Set("multiStatements", "true")
 	purl.RawQuery = q.Encode()
 
-	db, err := sql.Open("mysql", strings.Replace(
-		migrate.FilterCustomQuery(purl).String(), "mysql://", "", 1))
+	c, err := urlToMySQLConfig(*migrate.FilterCustomQuery(purl))
+	if err != nil {
+		return nil, err
+	}
+	db, err := sql.Open("mysql", c.FormatDSN())
 	if err != nil {
 		return nil, err
 	}

--- a/database/parse_test.go
+++ b/database/parse_test.go
@@ -1,0 +1,244 @@
+package database_test
+
+import (
+	"encoding/hex"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+const reservedChars = "!#$%&'()*+,/:;=?@[]"
+
+// TestUserUnencodedReservedURLChars documents the behavior of using unencoded reserved characters in usernames with
+// net/url Parse()
+func TestUserUnencodedReservedURLChars(t *testing.T) {
+	scheme := "database://"
+	baseUsername := "username"
+	urlSuffix := "password@localhost:12345/myDB?someParam=true"
+	urlSuffixAndSep := ":" + urlSuffix
+
+	testcases := []struct {
+		char             string
+		parses           bool
+		expectedUsername string // empty string means that the username failed to parse
+		encodedURL       string
+	}{
+		{char: "!", parses: true, expectedUsername: baseUsername + "!",
+			encodedURL: scheme + baseUsername + "%21" + urlSuffixAndSep},
+		{char: "#", parses: true, expectedUsername: "",
+			encodedURL: scheme + baseUsername + "#" + urlSuffixAndSep},
+		{char: "$", parses: true, expectedUsername: baseUsername + "$",
+			encodedURL: scheme + baseUsername + "$" + urlSuffixAndSep},
+		{char: "%", parses: false},
+		{char: "&", parses: true, expectedUsername: baseUsername + "&",
+			encodedURL: scheme + baseUsername + "&" + urlSuffixAndSep},
+		{char: "'", parses: true, expectedUsername: "username'",
+			encodedURL: scheme + baseUsername + "%27" + urlSuffixAndSep},
+		{char: "(", parses: true, expectedUsername: "username(",
+			encodedURL: scheme + baseUsername + "%28" + urlSuffixAndSep},
+		{char: ")", parses: true, expectedUsername: "username)",
+			encodedURL: scheme + baseUsername + "%29" + urlSuffixAndSep},
+		{char: "*", parses: true, expectedUsername: "username*",
+			encodedURL: scheme + baseUsername + "%2A" + urlSuffixAndSep},
+		{char: "+", parses: true, expectedUsername: "username+",
+			encodedURL: scheme + baseUsername + "+" + urlSuffixAndSep},
+		{char: ",", parses: true, expectedUsername: "username,",
+			encodedURL: scheme + baseUsername + "," + urlSuffixAndSep},
+		{char: "/", parses: true, expectedUsername: "",
+			encodedURL: scheme + baseUsername + "/" + urlSuffixAndSep},
+		{char: ":", parses: true, expectedUsername: "username",
+			encodedURL: scheme + baseUsername + ":%3A" + urlSuffix},
+		{char: ";", parses: true, expectedUsername: "username;",
+			encodedURL: scheme + baseUsername + ";" + urlSuffixAndSep},
+		{char: "=", parses: true, expectedUsername: "username=",
+			encodedURL: scheme + baseUsername + "=" + urlSuffixAndSep},
+		{char: "?", parses: true, expectedUsername: "",
+			encodedURL: scheme + baseUsername + "?" + urlSuffixAndSep},
+		{char: "@", parses: true, expectedUsername: "username@",
+			encodedURL: scheme + baseUsername + "%40" + urlSuffixAndSep},
+		{char: "[", parses: false},
+		{char: "]", parses: false},
+	}
+
+	testedChars := make([]string, 0, len(reservedChars))
+	for _, tc := range testcases {
+		testedChars = append(testedChars, tc.char)
+		t.Run("reserved char "+tc.char, func(t *testing.T) {
+			s := scheme + baseUsername + tc.char + urlSuffixAndSep
+			u, err := url.Parse(s)
+			if err == nil {
+				if !tc.parses {
+					t.Error("Unexpectedly parsed reserved character. url:", s)
+					return
+				}
+				var username string
+				if u.User != nil {
+					username = u.User.Username()
+				}
+				if username != tc.expectedUsername {
+					t.Error("Got unexpected username:", username, "!=", tc.expectedUsername)
+				}
+				if s := u.String(); s != tc.encodedURL {
+					t.Error("Got unexpected encoded URL:", s, "!=", tc.encodedURL)
+				}
+			} else {
+				if tc.parses {
+					t.Error("Failed to parse reserved character. url:", s)
+				}
+			}
+		})
+	}
+
+	t.Run("All reserved chars tested", func(t *testing.T) {
+		if s := strings.Join(testedChars, ""); s != reservedChars {
+			t.Error("Not all reserved URL characters were tested:", s, "!=", reservedChars)
+		}
+	})
+}
+
+func TestUserEncodedReservedURLChars(t *testing.T) {
+	scheme := "database://"
+	baseUsername := "username"
+	urlSuffix := "password@localhost:12345/myDB?someParam=true"
+	urlSuffixAndSep := ":" + urlSuffix
+
+	for _, c := range reservedChars {
+		c := string(c)
+		t.Run("reserved char "+c, func(t *testing.T) {
+			encodedChar := "%" + hex.EncodeToString([]byte(c))
+			s := scheme + baseUsername + encodedChar + urlSuffixAndSep
+			expectedUsername := baseUsername + c
+			u, err := url.Parse(s)
+			if err != nil {
+				t.Fatal("Failed to parse url with encoded reserved character. url:", s)
+			}
+			if u.User == nil {
+				t.Fatal("Failed to parse userinfo with encoded reserve character. url:", s)
+			}
+			if username := u.User.Username(); username != expectedUsername {
+				t.Fatal("Got unexpected username:", username, "!=", expectedUsername)
+			}
+		})
+	}
+}
+
+// TestPasswordUnencodedReservedURLChars documents the behavior of using unencoded reserved characters in passwords
+// with net/url Parse()
+func TestPasswordUnencodedReservedURLChars(t *testing.T) {
+	username := "username"
+	schemeAndUsernameAndSep := "database://" + username + ":"
+	basePassword := "password"
+	urlSuffixAndSep := "@localhost:12345/myDB?someParam=true"
+
+	testcases := []struct {
+		char             string
+		parses           bool
+		expectedUsername string // empty string means that the username failed to parse
+		expectedPassword string // empty string means that the password failed to parse
+		encodedURL       string
+	}{
+		{char: "!", parses: true, expectedUsername: username, expectedPassword: basePassword + "!",
+			encodedURL: schemeAndUsernameAndSep + basePassword + "%21" + urlSuffixAndSep},
+		{char: "#", parses: true, expectedUsername: "", expectedPassword: "",
+			encodedURL: schemeAndUsernameAndSep + basePassword + "#" + urlSuffixAndSep},
+		{char: "$", parses: true, expectedUsername: username, expectedPassword: basePassword + "$",
+			encodedURL: schemeAndUsernameAndSep + basePassword + "$" + urlSuffixAndSep},
+		{char: "%", parses: false},
+		{char: "&", parses: true, expectedUsername: username, expectedPassword: basePassword + "&",
+			encodedURL: schemeAndUsernameAndSep + basePassword + "&" + urlSuffixAndSep},
+		{char: "'", parses: true, expectedUsername: username, expectedPassword: "password'",
+			encodedURL: schemeAndUsernameAndSep + basePassword + "%27" + urlSuffixAndSep},
+		{char: "(", parses: true, expectedUsername: username, expectedPassword: "password(",
+			encodedURL: schemeAndUsernameAndSep + basePassword + "%28" + urlSuffixAndSep},
+		{char: ")", parses: true, expectedUsername: username, expectedPassword: "password)",
+			encodedURL: schemeAndUsernameAndSep + basePassword + "%29" + urlSuffixAndSep},
+		{char: "*", parses: true, expectedUsername: username, expectedPassword: "password*",
+			encodedURL: schemeAndUsernameAndSep + basePassword + "%2A" + urlSuffixAndSep},
+		{char: "+", parses: true, expectedUsername: username, expectedPassword: "password+",
+			encodedURL: schemeAndUsernameAndSep + basePassword + "+" + urlSuffixAndSep},
+		{char: ",", parses: true, expectedUsername: username, expectedPassword: "password,",
+			encodedURL: schemeAndUsernameAndSep + basePassword + "," + urlSuffixAndSep},
+		{char: "/", parses: true, expectedUsername: "", expectedPassword: "",
+			encodedURL: schemeAndUsernameAndSep + basePassword + "/" + urlSuffixAndSep},
+		{char: ":", parses: true, expectedUsername: username, expectedPassword: "password:",
+			encodedURL: schemeAndUsernameAndSep + basePassword + "%3A" + urlSuffixAndSep},
+		{char: ";", parses: true, expectedUsername: username, expectedPassword: "password;",
+			encodedURL: schemeAndUsernameAndSep + basePassword + ";" + urlSuffixAndSep},
+		{char: "=", parses: true, expectedUsername: username, expectedPassword: "password=",
+			encodedURL: schemeAndUsernameAndSep + basePassword + "=" + urlSuffixAndSep},
+		{char: "?", parses: true, expectedUsername: "", expectedPassword: "",
+			encodedURL: schemeAndUsernameAndSep + basePassword + "?" + urlSuffixAndSep},
+		{char: "@", parses: true, expectedUsername: username, expectedPassword: "password@",
+			encodedURL: schemeAndUsernameAndSep + basePassword + "%40" + urlSuffixAndSep},
+		{char: "[", parses: false},
+		{char: "]", parses: false},
+	}
+
+	testedChars := make([]string, 0, len(reservedChars))
+	for _, tc := range testcases {
+		testedChars = append(testedChars, tc.char)
+		t.Run("reserved char "+tc.char, func(t *testing.T) {
+			s := schemeAndUsernameAndSep + basePassword + tc.char + urlSuffixAndSep
+			u, err := url.Parse(s)
+			if err == nil {
+				if !tc.parses {
+					t.Error("Unexpectedly parsed reserved character. url:", s)
+					return
+				}
+				var username, password string
+				if u.User != nil {
+					username = u.User.Username()
+					password, _ = u.User.Password()
+				}
+				if username != tc.expectedUsername {
+					t.Error("Got unexpected username:", username, "!=", tc.expectedUsername)
+				}
+				if password != tc.expectedPassword {
+					t.Error("Got unexpected password:", password, "!=", tc.expectedPassword)
+				}
+				if s := u.String(); s != tc.encodedURL {
+					t.Error("Got unexpected encoded URL:", s, "!=", tc.encodedURL)
+				}
+			} else {
+				if tc.parses {
+					t.Error("Failed to parse reserved character. url:", s)
+				}
+			}
+		})
+	}
+
+	t.Run("All reserved chars tested", func(t *testing.T) {
+		if s := strings.Join(testedChars, ""); s != reservedChars {
+			t.Error("Not all reserved URL characters were tested:", s, "!=", reservedChars)
+		}
+	})
+}
+
+func TestPasswordEncodedReservedURLChars(t *testing.T) {
+	username := "username"
+	schemeAndUsernameAndSep := "database://" + username + ":"
+	basePassword := "password"
+	urlSuffixAndSep := "@localhost:12345/myDB?someParam=true"
+
+	for _, c := range reservedChars {
+		c := string(c)
+		t.Run("reserved char "+c, func(t *testing.T) {
+			encodedChar := "%" + hex.EncodeToString([]byte(c))
+			s := schemeAndUsernameAndSep + basePassword + encodedChar + urlSuffixAndSep
+			expectedPassword := basePassword + c
+			u, err := url.Parse(s)
+			if err != nil {
+				t.Fatal("Failed to parse url with encoded reserved character. url:", s)
+			}
+			if u.User == nil {
+				t.Fatal("Failed to parse userinfo with encoded reserve character. url:", s)
+			}
+			if n := u.User.Username(); n != username {
+				t.Fatal("Got unexpected username:", n, "!=", username)
+			}
+			if p, _ := u.User.Password(); p != expectedPassword {
+				t.Fatal("Got unexpected password:", p, "!=", expectedPassword)
+			}
+		})
+	}
+}

--- a/database/util.go
+++ b/database/util.go
@@ -7,7 +7,7 @@ import (
 
 const advisoryLockIdSalt uint = 1486364155
 
-// inspired by rails migrations, see https://goo.gl/8o9bCT
+// GenerateAdvisoryLockId inspired by rails migrations, see https://goo.gl/8o9bCT
 func GenerateAdvisoryLockId(databaseName string) (string, error) {
 	sum := crc32.ChecksumIEEE([]byte(databaseName))
 	sum = sum * uint32(advisoryLockIdSalt)

--- a/database/util_test.go
+++ b/database/util_test.go
@@ -1,12 +1,28 @@
 package database
 
+import (
+	"testing"
+)
+
 func TestGenerateAdvisoryLockId(t *testing.T) {
-	id, err := p.generateAdvisoryLockId("database_name")
-	if err != nil {
-		t.Errorf("expected err to be nil, got %v", err)
+	testcases := []struct {
+		dbname     string
+		expectedID string // empty string signifies that an error is expected
+	}{
+		{dbname: "database_name", expectedID: "1764327054"},
 	}
-	if len(id) == 0 {
-		t.Errorf("expected generated id not to be empty")
+
+	for _, tc := range testcases {
+		t.Run(tc.dbname, func(t *testing.T) {
+			if id, err := GenerateAdvisoryLockId("database_name"); err == nil {
+				if id != tc.expectedID {
+					t.Error("Generated incorrect ID:", id, "!=", tc.expectedID)
+				}
+			} else {
+				if tc.expectedID != "" {
+					t.Error("Got unexpected error:", err)
+				}
+			}
+		})
 	}
-	t.Logf("generated id: %v", id)
 }


### PR DESCRIPTION
Special case usernames and passwords and MySQL DSN e.g. don't url encode reserved characters

Addresses: https://github.com/golang-migrate/migrate/issues/77 and https://github.com/golang-migrate/migrate/pull/69

