### PR TITLE
Document that '-source' is a required parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ __[CLI Documentation](cli)__
 ### Basic usage:
 
 ```
-$ migrate -database postgres://localhost:5432/database up 2
+$ migrate -source file://path/to/migrations -database postgres://localhost:5432/database up 2
 ```
 
 ### Docker usage

--- a/cli/README.md
+++ b/cli/README.md
@@ -78,7 +78,7 @@ Commands:
 So let's say you want to run the first two migrations
 
 ```
-$ migrate -database postgres://localhost:5432/database up 2
+$ migrate -source file://path/to/migrations -database postgres://localhost:5432/database up 2
 ```
 
 If your migrations are hosted on github


### PR DESCRIPTION
It's not clearly stated in the READMEs that `-source schem://path` is a required argument.

Sure, it's pretty obvious when you think about it, but I couldn't figure why it didn't work initially for me. And the error output stated only "no scheme" which is not very helpful. Seems like this is has been around for a while, so let's fix this now.

Fixes https://github.com/mattes/migrate/issues/270
Fixes https://github.com/mattes/migrate/issues/317