### PR TITLE
Fixes MySQL custom TLS connection failure.

### DIFF
--- a/database/mysql/README.md
+++ b/database/mysql/README.md
@@ -10,6 +10,7 @@
 | `password` | | The user's password | 
 | `host` | | The host to connect to. |
 | `port` | | The port to bind to. |
+| `tls`  | | The custom TLS config name, use with `x-tls-` queries. |
 | `x-tls-ca` | | The location of the root certificate file. |
 | `x-tls-cert` | | Cert file location. |
 | `x-tls-key` | | Key file location. | 

--- a/database/mysql/README.md
+++ b/database/mysql/README.md
@@ -11,9 +11,9 @@
 | `host` | | The host to connect to. |
 | `port` | | The port to bind to. |
 | `tls`  | | TLS / SSL encrypted connection parameter; see [go-sql-driver](https://github.com/go-sql-driver/mysql#tls). Use any name (e.g. `migrate`) if you want to use a custom TLS config (`x-tls-` queries). |
-| `x-tls-ca` | | The location of the root certificate file. |
-| `x-tls-cert` | | Cert file location. |
-| `x-tls-key` | | Key file location. | 
+| `x-tls-ca` | | The location of the CA (certificate authority) file. |
+| `x-tls-cert` | | The location of the client certicicate file. Must be used with `x-tls-key`. |
+| `x-tls-key` | | The location of the private key file. Must be used with `x-tls-cert`. |
 | `x-tls-insecure-skip-verify` | | Whether or not to use SSL (true\|false) | 
 
 ## Use with existing client

--- a/database/mysql/README.md
+++ b/database/mysql/README.md
@@ -10,7 +10,7 @@
 | `password` | | The user's password | 
 | `host` | | The host to connect to. |
 | `port` | | The port to bind to. |
-| `tls`  | | The custom TLS config name, use with `x-tls-` queries. |
+| `tls`  | | TLS / SSL encrypted connection parameter; see [go-sql-driver](https://github.com/go-sql-driver/mysql#tls). Use any name (e.g. `migrate`) if you want to use a custom TLS config (`x-tls-` queries). |
 | `x-tls-ca` | | The location of the root certificate file. |
 | `x-tls-cert` | | Cert file location. |
 | `x-tls-key` | | Key file location. | 

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -143,8 +143,8 @@ func (m *Mysql) Open(url string) (database.Driver, error) {
 			}
 
 			clientCert := make([]tls.Certificate, 0, 1)
-			if purl.Query().Get("x-tls-cert") != "" && purl.Query().Get("x-tls-key") != "" {
-				certs, err := tls.LoadX509KeyPair(purl.Query().Get("x-tls-cert"), purl.Query().Get("x-tls-key"))
+			if ccert, ckey := purl.Query().Get("x-tls-cert"), purl.Query().Get("x-tls-key"); ccert != "" || ckey != "" {
+				certs, err := tls.LoadX509KeyPair(ccert, ckey)
 				if err != nil {
 					return nil, err
 				}

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -35,6 +35,7 @@ var (
 	ErrNilConfig      = fmt.Errorf("no config")
 	ErrNoDatabaseName = fmt.Errorf("no database name")
 	ErrAppendPEM      = fmt.Errorf("failed to append PEM")
+	ErrTLSCertKeyConfig = fmt.Errorf("To use TLS client authentication, both x-tls-cert and x-tls-key must not be empty")
 )
 
 type Config struct {
@@ -144,6 +145,9 @@ func (m *Mysql) Open(url string) (database.Driver, error) {
 
 			clientCert := make([]tls.Certificate, 0, 1)
 			if ccert, ckey := purl.Query().Get("x-tls-cert"), purl.Query().Get("x-tls-key"); ccert != "" || ckey != "" {
+				if ccert == "" || ckey == "" {
+					return nil, ErrTLSCertKeyConfig
+				}
 				certs, err := tls.LoadX509KeyPair(ccert, ckey)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
Hi,
I couldn't connect Amazon RDS MySQL via TLS, with Amazon's Root CA, by migrate 3.4.0.
It was failed by checking tls name before registering at `mysql.RegisterTLSConfig`.

By this patch,  custom TLS Query like `?tls=rds&x-tls-ca=rds-combined-ca-bundle.pem` works correctly.
