### PR TITLE
Update README to fix source code typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ func main() {
     db, err := sql.Open("postgres", "postgres://localhost:5432/database?sslmode=enable")
     driver, err := postgres.WithInstance(db, &postgres.Config{})
     m, err := migrate.NewWithDatabaseInstance(
-        "file:///migrations",
+        "file://migrations",
         "postgres", driver)
     m.Steps(2)
 }


### PR DESCRIPTION
Removed an extra `/` in the file path in the go code example.