### PR TITLE
Add support for TLS on Cassandra.

### DIFF
--- a/database/cassandra/README.md
+++ b/database/cassandra/README.md
@@ -22,7 +22,10 @@ system_schema table which comes with 3.X
 | `timeout` | 1 minute | Migration timeout
 | `username` | nil | Username to use when authenticating. |
 | `password` | nil | Password to use when authenticating. |
-
+| `sslcert` | | Cert file location. The file must contain PEM encoded data. |
+| `sslkey` | | Key file location. The file must contain PEM encoded data. |
+| `sslrootcert` | | The location of the root certificate file. The file must contain PEM encoded data. |
+| `sslmode` | | Whether or not to use SSL (disable\|require\|verify-ca\|verify-full) |
 
 `timeout` is parsed using [time.ParseDuration(s string)](https://golang.org/pkg/time/#ParseDuration)
 

--- a/database/cassandra/cassandra.go
+++ b/database/cassandra/cassandra.go
@@ -120,6 +120,19 @@ func (c *Cassandra) Open(url string) (database.Driver, error) {
 		cluster.Timeout = timeout
 	}
 
+	if len(u.Query().Get("sslmode")) > 0 && len(u.Query().Get("sslrootcert")) > 0 && len(u.Query().Get("sslcert")) > 0 && len(u.Query().Get("sslkey")) > 0 {
+		if u.Query().Get("sslmode") != "disable" {
+			cluster.SslOpts = &gocql.SslOptions{
+				CaPath:   u.Query().Get("sslrootcert"),
+				CertPath: u.Query().Get("sslcert"),
+				KeyPath:  u.Query().Get("sslkey"),
+			}
+			if u.Query().Get("sslmode") == "verify-full" {
+				cluster.SslOpts.EnableHostVerification = true
+			}
+		}
+	}
+
 	session, err := cluster.CreateSession()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I'd like to submit a PR to address an issue that I have already tested against an existing ScyllaDB cluster, described next.

**Steps to reproduce**

*TL;DR*
To recreate one needs a ScyllaDB node/cluster secured with TLS, following are steps in creating certificates as an example and the ScyllaDB documentation concerned with [client to node](https://docs.scylladb.com/operating-scylla/security/client_node_encryption/) and [node to node](https://docs.scylladb.com/operating-scylla/security/node_node_encryption/) encryption.

**Output**

```
migrate -verbose -path . -database 'cassandra://<host>:9042/<keyspace>?timeout=60s&protocol=3&sslmode=verify-full&sslrootcert=~/ca/certs/ca.crt&sslcert=~/ca/certs/cassandra.crt.pem&sslkey=~/ca/private/cassandra.key.pem' up
2018/10/16 07:28:24 gocql: unable to dial control conn <host>: EOF
2018/10/16 07:28:24 error: gocql: unable to create session: control: unable to connect to initial hosts: EOF
```

**Root cause**
The `migrate/database/cassandra` package uses "github.com/gocql/gocql" which provides support for TLS through the [`gocql.SslOptions`](https://godoc.org/github.com/gocql/gocql#SslOptions) type but it is not utilised in `migrate/database/cassandra/cassandra.go`'s [`Open`](https://github.com/golang-migrate/migrate/blob/master/database/cassandra/cassandra.go#L72) function.

**Suggestion**

I suggest to make this available in the same way as was done for `migrate/database/cassandra/cockroachdb` via the URL parameters

| URL Query  | WithInstance Config | Description |
|------------|---------------------|-------------|
| `sslcert` | | Cert file location. The file must contain PEM encoded data. |
| `sslkey` | | Key file location. The file must contain PEM encoded data. |
| `sslrootcert` | | The location of the root certificate file. The file must contain PEM encoded data. |
| `sslmode` | | Whether or not to use SSL (disable\|require\|verify-ca\|verify-full) |

**Detailed information to reproduce error if needed**
Create a set of certificates against a certification authority (CA).

## Create CA

Create some directory structure for your CA and certificates

```
mkdir ~/ca/
cd ~/ca/
mkdir certs crl csr private
chmod 640 private
touch index.txt
echo 1000 > serial
```

Expected

```
weszeloos@dev:~$ mkdir ~/ca/
weszeloos@dev:~$ cd ~/ca/
weszeloos@dev:~/ca$ mkdir certs crl private
weszeloos@dev:~/ca$ chmod 640 private
weszeloos@dev:~/ca$ touch index.txt
weszeloos@dev:~/ca$ echo 1000 > serial
weszeloos@dev:~/ca$ ls -la
total 24
drwxrwxr-x  5 weszeloos weszeloos 4096 Oct 16 08:44 .
drwxr-xr-x 23 weszeloos weszeloos 4096 Oct 16 08:43 ..
drwxrwxr-x  2 weszeloos weszeloos 4096 Oct 16 08:43 certs
drwxrwxr-x  2 weszeloos weszeloos 4096 Oct 16 08:43 crl
-rw-rw-r--  1 weszeloos weszeloos    0 Oct 16 08:44 index.txt
drw-r-----  2 weszeloos weszeloos 4096 Oct 16 08:43 private
-rw-rw-r--  1 weszeloos weszeloos    5 Oct 16 08:44 serial
```

Create the CA private key - (Keep this safe)

*NOTE*:  Select and save a password for the key file, it is used later on the sign new certificates

```
sudo openssl genrsa -aes256 -out private/ca.key.pem 4096
chmod 400 private/ca.key.pem
```

Create the CA certificates

Get the [openssl.cnf](https://github.com/openssl/openssl/blob/master/apps/openssl.cnf) file and store in `~/ca/`

```
sudo openssl req -config openssl.cnf -key private/ca.key.pem -new -x509 -days 7300 -sha256 -extensions v3_ca -out certs/ca.crt.pem
sudo chmod 444 certs/ca.crt.pem
```

Verify the certificate

```
openssl x509 -noout -text -in certs/ca.crt.pem
```

Expected

```
weszeloos@dev:~/ca$ ls -la certs/
total 12
drwxrwxr-x 2 weszeloos weszeloos 4096 Oct 16 08:52 .
drwxrwxr-x 5 weszeloos weszeloos 4096 Oct 16 08:51 ..
-r--r--r-- 1 root      root      1923 Oct 16 08:52 ca.crt.pem
```

## Create a private key/certificate set from the generated certificate authority (CA)

Create a configuration file, call it `cassandra.cnf`

Edit the following section

```
[ CA_default ]

dir        = .        # Where everything is kept
certs        = $dir/certs        # Where the issued certs are kept
crl_dir        = $dir/crl        # Where the issued crl are kept
database    = $dir/index.txt    # database index file.
#unique_subject    = no            # Set to 'no' to allow creation of
                    # several certs with same subject.
new_certs_dir    = $dir/certs        # default place for new certs.

certificate    = $dir/certs/ca.crt.pem     # The CA certificate
serial        = $dir/serial         # The current serial number
crlnumber    = $dir/crlnumber    # the current crl number
                    # must be commented out to leave a V1 CRL
crl        = $dir/crl.pem         # The current CRL
private_key    = $dir/private/ca.key.pem# The private key

x509_extensions    = usr_cert        # The extensions to add to the cert
```

Create the key/certificate set

*NOTE*: when creating the CSR, remember to set the Common Name, to say, `localhost`

```
sudo openssl genrsa -out private/cassandra.key.pem 4096
sudo openssl req -config cassandra.cnf -key private/cassandra.key.pem -new -out csr/cassandra.csr.pem
sudo openssl ca -config cassandra.cnf -notext -in csr/cassandra.csr.pem -out certs/cassandra.crt.pem -extensions 'usr_cert'
```

Now we have a CA signed key/certificate pair in private/cassandra.key.pem and certs/cassandra.crt.pem

## Create the `~/.cassandra/cqlshrc` file if it doesn't exist yet and edit it to configuration

```
[connection]
hostname = 127.0.0.1
port = 9042
factory = cqlshlib.ssl.ssl_transport_factory

[ssl]
version=SSLv23
certfile = ~/ca/certs/ca.crt.pem
validate = true
userkey = ~/ca/private/cassandra.com.key.pem
usercert = ~/ca/certs/cassandra.com.crt.pem
```

In our example we are using the migrate tool with a ScyllaDB cluster, utilising the fact that the migrate tool supports Cassandra.