### PR TITLE
Add NewDB to spanner.go

### DIFF
--- a/database/spanner/spanner.go
+++ b/database/spanner/spanner.go
@@ -55,6 +55,13 @@ type DB struct {
 	data  *spanner.Client
 }
 
+func NewDB(admin sdb.DatabaseAdminClient, data spanner.Client) *DB {
+	return &DB{
+		admin: &admin,
+		data:  &data,
+	}
+}
+
 // WithInstance implements database.Driver
 func WithInstance(instance *DB, config *Config) (database.Driver, error) {
 	if config == nil {


### PR DESCRIPTION
ref https://github.com/golang-migrate/migrate/issues/117
It worked with GAE / SE go111 runtime
Can you please merge this?