### PR TITLE
cli: Update README.md with MacOS install info

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -12,9 +12,9 @@ $ curl -L https://github.com/golang-migrate/migrate/releases/download/$version/m
 
 #### MacOS
 
-We have not released support for homebrew yet, but there is a live issue here: [todo #156](https://github.com/mattes/migrate/issues/156)
-
-Any help to make this happen would be appreciated!
+```
+$ brew install golang-migrate
+```
 
 #### Linux (*.deb package)
 


### PR DESCRIPTION
Document in MacOS install section of README.md that brew packag is now available. References mattes/migrate#156 https://github.com/Homebrew/homebrew-core/pull/30032