### PR TITLE
Add support for multi-schema migrations in Postgres

### DIFF
--- a/database/util.go
+++ b/database/util.go
@@ -1,21 +1,19 @@
 package database
 
 import (
-	"bytes"
 	"fmt"
 	"hash/crc32"
+	"strings"
 )
 
 const advisoryLockIdSalt uint = 1486364155
 
 // GenerateAdvisoryLockId inspired by rails migrations, see https://goo.gl/8o9bCT
 func GenerateAdvisoryLockId(databaseName string, additionalNames ...string) (string, error) {
-	buf := bytes.NewBufferString(databaseName)
-	for _, name := range additionalNames {
-		buf.WriteByte(0)
-		buf.WriteString(name)
+	if len(additionalNames) > 0 {
+		databaseName = strings.Join(append(additionalNames, databaseName), "\x00")
 	}
-	sum := crc32.ChecksumIEEE(buf.Bytes())
+	sum := crc32.ChecksumIEEE([]byte(databaseName))
 	sum = sum * uint32(advisoryLockIdSalt)
 	return fmt.Sprintf("%v", sum), nil
 }

--- a/database/util.go
+++ b/database/util.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"bytes"
 	"fmt"
 	"hash/crc32"
 )
@@ -8,8 +9,13 @@ import (
 const advisoryLockIdSalt uint = 1486364155
 
 // GenerateAdvisoryLockId inspired by rails migrations, see https://goo.gl/8o9bCT
-func GenerateAdvisoryLockId(databaseName string) (string, error) {
-	sum := crc32.ChecksumIEEE([]byte(databaseName))
+func GenerateAdvisoryLockId(databaseName string, additionalNames ...string) (string, error) {
+	buf := bytes.NewBufferString(databaseName)
+	for _, name := range additionalNames {
+		buf.WriteByte(0)
+		buf.WriteString(name)
+	}
+	sum := crc32.ChecksumIEEE(buf.Bytes())
 	sum = sum * uint32(advisoryLockIdSalt)
 	return fmt.Sprintf("%v", sum), nil
 }

--- a/database/util_test.go
+++ b/database/util_test.go
@@ -7,21 +7,33 @@ import (
 func TestGenerateAdvisoryLockId(t *testing.T) {
 	testcases := []struct {
 		dbname     string
-		schema     string
+		additional []string
 		expectedID string // empty string signifies that an error is expected
 	}{
-		{dbname: "database_name", expectedID: "1764327054"},
-		{dbname: "database_name", schema: "schema_name_1", expectedID: "3244152297"},
-		{dbname: "database_name", schema: "schema_name_2", expectedID: "810103531"},
+		{
+			dbname:     "database_name",
+			expectedID: "1764327054",
+		},
+		{
+			dbname:     "database_name",
+			additional: []string{"schema_name_1"},
+			expectedID: "2453313553",
+		},
+		{
+			dbname:     "database_name",
+			additional: []string{"schema_name_2"},
+			expectedID: "235207038",
+		},
+		{
+			dbname:     "database_name",
+			additional: []string{"schema_name_1", "schema_name_2"},
+			expectedID: "3743845847",
+		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.dbname, func(t *testing.T) {
-			names := []string{}
-			if len(tc.schema) > 0 {
-				names = append(names, tc.schema)
-			}
-			if id, err := GenerateAdvisoryLockId(tc.dbname, names...); err == nil {
+			if id, err := GenerateAdvisoryLockId(tc.dbname, tc.additional...); err == nil {
 				if id != tc.expectedID {
 					t.Error("Generated incorrect ID:", id, "!=", tc.expectedID)
 				}

--- a/database/util_test.go
+++ b/database/util_test.go
@@ -7,14 +7,21 @@ import (
 func TestGenerateAdvisoryLockId(t *testing.T) {
 	testcases := []struct {
 		dbname     string
+		schema     string
 		expectedID string // empty string signifies that an error is expected
 	}{
 		{dbname: "database_name", expectedID: "1764327054"},
+		{dbname: "database_name", schema: "schema_name_1", expectedID: "3244152297"},
+		{dbname: "database_name", schema: "schema_name_2", expectedID: "810103531"},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.dbname, func(t *testing.T) {
-			if id, err := GenerateAdvisoryLockId("database_name"); err == nil {
+			names := []string{}
+			if len(tc.schema) > 0 {
+				names = append(names, tc.schema)
+			}
+			if id, err := GenerateAdvisoryLockId(tc.dbname, names...); err == nil {
 				if id != tc.expectedID {
 					t.Error("Generated incorrect ID:", id, "!=", tc.expectedID)
 				}


### PR DESCRIPTION
I've save interface of function `GenerateAdvisoryLockId` with variadic params. So I've just add test to ensure that lock id depend on this additional parameters.