### PR TITLE
Refactor cli package to allow `go get` one-liner with a proper binary name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV GO111MODULE=on
 ENV DATABASES="postgres mysql redshift cassandra spanner cockroachdb clickhouse"
 ENV SOURCES="file go_bindata github aws_s3 google_cloud_storage"
 
-RUN go build -a -o build/migrate.linux-386 -ldflags="-X main.Version=${VERSION}" -tags "$DATABASES $SOURCES" ./cli
+RUN go build -a -o build/migrate.linux-386 -ldflags="-X main.Version=${VERSION}" -tags "$DATABASES $SOURCES" ./cmd/migrate
 
 FROM alpine:3.8
 

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ COVERAGE_DIR ?= .coverage
 
 build-cli: clean
 	-mkdir ./cli/build
-	cd ./cli && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o build/migrate.linux-amd64 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
-	cd ./cli && CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -a -o build/migrate.darwin-amd64 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
-	cd ./cli && CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -a -o build/migrate.windows-amd64.exe -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
+	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o ../../cli/build/migrate.linux-amd64 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
+	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -a -o ../../cli/build/migrate.darwin-amd64 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
+	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -a -o ../../cli/build/migrate.windows-amd64.exe -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
 	cd ./cli/build && find . -name 'migrate*' | xargs -I{} tar czf {}.tar.gz {}
 	cd ./cli/build && shasum -a 256 * > sha256sum.txt
 	cat ./cli/build/sha256sum.txt

--- a/cli/README.md
+++ b/cli/README.md
@@ -28,9 +28,7 @@ $ apt-get install -y migrate
 #### With Go toolchain
 
 ```
-$ go get -u -d github.com/golang-migrate/migrate/cli
-$ cd $GOPATH/src/github.com/golang-migrate/migrate/cli
-$ go build -tags 'postgres' -ldflags="-X main.Version=$(git describe --tags)" -o /usr/local/bin/migrate github.com/golang-migrate/migrate/cli
+$ go get -tags 'postgres' -u -d github.com/golang-migrate/migrate/cmd/migrate
 ```
 
 ##### Notes:

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -2,7 +2,6 @@ package main
 
 import "github.com/golang-migrate/migrate/v4/internal/cli"
 
-// Deprecated, please use cmd/migrate
 func main() {
 	cli.Main(Version)
 }

--- a/cmd/migrate/version.go
+++ b/cmd/migrate/version.go
@@ -1,0 +1,4 @@
+package main
+
+// Version is set in Makefile with build flags
+var Version = "dev"

--- a/internal/cli/build_aws-s3.go
+++ b/internal/cli/build_aws-s3.go
@@ -1,6 +1,6 @@
 // +build aws_s3
 
-package main
+package cli
 
 import (
 	_ "github.com/golang-migrate/migrate/v4/source/aws_s3"

--- a/internal/cli/build_cassandra.go
+++ b/internal/cli/build_cassandra.go
@@ -1,6 +1,6 @@
 // +build cassandra
 
-package main
+package cli
 
 import (
 	_ "github.com/golang-migrate/migrate/v4/database/cassandra"

--- a/internal/cli/build_clickhouse.go
+++ b/internal/cli/build_clickhouse.go
@@ -1,6 +1,6 @@
 // +build clickhouse
 
-package main
+package cli
 
 import (
 	_ "github.com/golang-migrate/migrate/v4/database/clickhouse"

--- a/internal/cli/build_cockroachdb.go
+++ b/internal/cli/build_cockroachdb.go
@@ -1,6 +1,6 @@
 // +build cockroachdb
 
-package main
+package cli
 
 import (
 	_ "github.com/golang-migrate/migrate/v4/database/cockroachdb"

--- a/internal/cli/build_github.go
+++ b/internal/cli/build_github.go
@@ -1,6 +1,6 @@
 // +build github
 
-package main
+package cli
 
 import (
 	_ "github.com/golang-migrate/migrate/v4/source/github"

--- a/internal/cli/build_go-bindata.go
+++ b/internal/cli/build_go-bindata.go
@@ -1,6 +1,6 @@
 // +build go_bindata
 
-package main
+package cli
 
 import (
 	_ "github.com/golang-migrate/migrate/v4/source/go_bindata"

--- a/internal/cli/build_godoc-vfs.go
+++ b/internal/cli/build_godoc-vfs.go
@@ -1,6 +1,6 @@
 // +build godoc_vfs
 
-package main
+package cli
 
 import (
 	_ "github.com/golang-migrate/migrate/v4/source/godoc_vfs"

--- a/internal/cli/build_google-cloud-storage.go
+++ b/internal/cli/build_google-cloud-storage.go
@@ -1,6 +1,6 @@
 // +build google_cloud_storage
 
-package main
+package cli
 
 import (
 	_ "github.com/golang-migrate/migrate/v4/source/google_cloud_storage"

--- a/internal/cli/build_mysql.go
+++ b/internal/cli/build_mysql.go
@@ -1,6 +1,6 @@
 // +build mysql
 
-package main
+package cli
 
 import (
 	_ "github.com/golang-migrate/migrate/v4/database/mysql"

--- a/internal/cli/build_postgres.go
+++ b/internal/cli/build_postgres.go
@@ -1,6 +1,6 @@
 // +build postgres
 
-package main
+package cli
 
 import (
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"

--- a/internal/cli/build_ql.go
+++ b/internal/cli/build_ql.go
@@ -1,6 +1,6 @@
 // +build ql
 
-package main
+package cli
 
 import (
 	_ "github.com/golang-migrate/migrate/v4/database/ql"

--- a/internal/cli/build_redshift.go
+++ b/internal/cli/build_redshift.go
@@ -1,6 +1,6 @@
 // +build redshift
 
-package main
+package cli
 
 import (
 	_ "github.com/golang-migrate/migrate/v4/database/redshift"

--- a/internal/cli/build_spanner.go
+++ b/internal/cli/build_spanner.go
@@ -1,6 +1,6 @@
 // +build spanner
 
-package main
+package cli
 
 import (
 	_ "github.com/golang-migrate/migrate/v4/database/spanner"

--- a/internal/cli/build_sqlite3.go
+++ b/internal/cli/build_sqlite3.go
@@ -1,6 +1,6 @@
 // +build sqlite3
 
-package main
+package cli
 
 import (
 	_ "github.com/golang-migrate/migrate/v4/database/sqlite3"

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"errors"

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"testing"

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"fmt"

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -1,0 +1,250 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/database"
+	"github.com/golang-migrate/migrate/v4/source"
+)
+
+const defaultTimeFormat = "20060102150405"
+
+// set main log
+var log = &Log{}
+
+func Main(version string) {
+	helpPtr := flag.Bool("help", false, "")
+	versionPtr := flag.Bool("version", false, "")
+	verbosePtr := flag.Bool("verbose", false, "")
+	prefetchPtr := flag.Uint("prefetch", 10, "")
+	lockTimeoutPtr := flag.Uint("lock-timeout", 15, "")
+	pathPtr := flag.String("path", "", "")
+	databasePtr := flag.String("database", "", "")
+	sourcePtr := flag.String("source", "", "")
+
+	flag.Usage = func() {
+		fmt.Fprint(os.Stderr,
+			`Usage: migrate OPTIONS COMMAND [arg...]
+       migrate [ -version | -help ]
+
+Options:
+  -source          Location of the migrations (driver://url)
+  -path            Shorthand for -source=file://path 
+  -database        Run migrations against this database (driver://url)
+  -prefetch N      Number of migrations to load in advance before executing (default 10)
+  -lock-timeout N  Allow N seconds to acquire database lock (default 15)
+  -verbose         Print verbose logging
+  -version         Print version
+  -help            Print usage
+
+Commands:
+  create [-ext E] [-dir D] [-seq] [-digits N] [-format] NAME
+			   Create a set of timestamped up/down migrations titled NAME, in directory D with extension E.
+			   Use -seq option to generate sequential up/down migrations with N digits.
+			   Use -format option to specify a Go time format string.
+  goto V       Migrate to version V
+  up [N]       Apply all or N up migrations
+  down [N]     Apply all or N down migrations
+  drop         Drop everyting inside database
+  force V      Set version V but don't run migration (ignores dirty state)
+  version      Print current migration version
+
+Source drivers: `+strings.Join(source.List(), ", ")+`
+Database drivers: `+strings.Join(database.List(), ", ")+"\n")
+	}
+
+	flag.Parse()
+
+	// initialize logger
+	log.verbose = *verbosePtr
+
+	// show cli version
+	if *versionPtr {
+		fmt.Fprintln(os.Stderr, version)
+		os.Exit(0)
+	}
+
+	// show help
+	if *helpPtr {
+		flag.Usage()
+		os.Exit(0)
+	}
+
+	// translate -path into -source if given
+	if *sourcePtr == "" && *pathPtr != "" {
+		*sourcePtr = fmt.Sprintf("file://%v", *pathPtr)
+	}
+
+	// initialize migrate
+	// don't catch migraterErr here and let each command decide
+	// how it wants to handle the error
+	migrater, migraterErr := migrate.New(*sourcePtr, *databasePtr)
+	defer func() {
+		if migraterErr == nil {
+			migrater.Close()
+		}
+	}()
+	if migraterErr == nil {
+		migrater.Log = log
+		migrater.PrefetchMigrations = *prefetchPtr
+		migrater.LockTimeout = time.Duration(int64(*lockTimeoutPtr)) * time.Second
+
+		// handle Ctrl+c
+		signals := make(chan os.Signal, 1)
+		signal.Notify(signals, syscall.SIGINT)
+		go func() {
+			for range signals {
+				log.Println("Stopping after this running migration ...")
+				migrater.GracefulStop <- true
+				return
+			}
+		}()
+	}
+
+	startTime := time.Now()
+
+	switch flag.Arg(0) {
+	case "create":
+		args := flag.Args()[1:]
+		seq := false
+		seqDigits := 6
+
+		createFlagSet := flag.NewFlagSet("create", flag.ExitOnError)
+		extPtr := createFlagSet.String("ext", "", "File extension")
+		dirPtr := createFlagSet.String("dir", "", "Directory to place file in (default: current working directory)")
+		formatPtr := createFlagSet.String("format", defaultTimeFormat, `The Go time format string to use. If the string "unix" or "unixNano" is specified, then the seconds or nanoseconds since January 1, 1970 UTC respectively will be used. Caution, due to the behavior of time.Time.Format(), invalid format strings will not error`)
+		createFlagSet.BoolVar(&seq, "seq", seq, "Use sequential numbers instead of timestamps (default: false)")
+		createFlagSet.IntVar(&seqDigits, "digits", seqDigits, "The number of digits to use in sequences (default: 6)")
+		createFlagSet.Parse(args)
+
+		if createFlagSet.NArg() == 0 {
+			log.fatal("error: please specify name")
+		}
+		name := createFlagSet.Arg(0)
+
+		if *extPtr == "" {
+			log.fatal("error: -ext flag must be specified")
+		}
+		*extPtr = "." + strings.TrimPrefix(*extPtr, ".")
+
+		if *dirPtr != "" {
+			*dirPtr = strings.Trim(*dirPtr, "/") + "/"
+		}
+
+		createCmd(*dirPtr, startTime, *formatPtr, name, *extPtr, seq, seqDigits)
+
+	case "goto":
+		if migraterErr != nil {
+			log.fatalErr(migraterErr)
+		}
+
+		if flag.Arg(1) == "" {
+			log.fatal("error: please specify version argument V")
+		}
+
+		v, err := strconv.ParseUint(flag.Arg(1), 10, 64)
+		if err != nil {
+			log.fatal("error: can't read version argument V")
+		}
+
+		gotoCmd(migrater, uint(v))
+
+		if log.verbose {
+			log.Println("Finished after", time.Now().Sub(startTime))
+		}
+
+	case "up":
+		if migraterErr != nil {
+			log.fatalErr(migraterErr)
+		}
+
+		limit := -1
+		if flag.Arg(1) != "" {
+			n, err := strconv.ParseUint(flag.Arg(1), 10, 64)
+			if err != nil {
+				log.fatal("error: can't read limit argument N")
+			}
+			limit = int(n)
+		}
+
+		upCmd(migrater, limit)
+
+		if log.verbose {
+			log.Println("Finished after", time.Now().Sub(startTime))
+		}
+
+	case "down":
+		if migraterErr != nil {
+			log.fatalErr(migraterErr)
+		}
+
+		limit := -1
+		if flag.Arg(1) != "" {
+			n, err := strconv.ParseUint(flag.Arg(1), 10, 64)
+			if err != nil {
+				log.fatal("error: can't read limit argument N")
+			}
+			limit = int(n)
+		}
+
+		downCmd(migrater, limit)
+
+		if log.verbose {
+			log.Println("Finished after", time.Now().Sub(startTime))
+		}
+
+	case "drop":
+		if migraterErr != nil {
+			log.fatalErr(migraterErr)
+		}
+
+		dropCmd(migrater)
+
+		if log.verbose {
+			log.Println("Finished after", time.Now().Sub(startTime))
+		}
+
+	case "force":
+		if migraterErr != nil {
+			log.fatalErr(migraterErr)
+		}
+
+		if flag.Arg(1) == "" {
+			log.fatal("error: please specify version argument V")
+		}
+
+		v, err := strconv.ParseInt(flag.Arg(1), 10, 64)
+		if err != nil {
+			log.fatal("error: can't read version argument V")
+		}
+
+		if v < -1 {
+			log.fatal("error: argument V must be >= -1")
+		}
+
+		forceCmd(migrater, int(v))
+
+		if log.verbose {
+			log.Println("Finished after", time.Now().Sub(startTime))
+		}
+
+	case "version":
+		if migraterErr != nil {
+			log.fatalErr(migraterErr)
+		}
+
+		versionCmd(migrater)
+
+	default:
+		flag.Usage()
+		os.Exit(0)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/golang-migrate/migrate/issues/70.

* Copy cli main package under migrate directory,
* Keep deprecated original main package for backwards compatibility