### PR TITLE
use URL.Opaque when available

### DIFF
--- a/source/file/file.go
+++ b/source/file/file.go
@@ -30,7 +30,10 @@ func (f *File) Open(url string) (source.Driver, error) {
 
 	// concat host and path to restore full path
 	// host might be `.`
-	p := u.Host + u.Path
+	p := u.Opaque
+	if len(p) == 0 {
+		p = u.Host + u.Path
+	}
 
 	if len(p) == 0 {
 		// default to current directory if no path


### PR DESCRIPTION
This change will cause all of the following to be handled correctly:

```
file:relpath/to/thing
file:/abspath/to/thing
file://relpath/to/thing
file:///abspath/to/thing
```

The parsed URL with have _either_ `u.Opaque` _or_ `u.Path`, never both.

> A URL represents a parsed URL (technically, a URI reference).
>
> The general form represented is:
> 
>     [scheme:][//[userinfo@]host][/]path[?query][#fragment]
>
> URLs that do not start with a slash after the scheme are interpreted as:
>
>     scheme:opaque[?query][#fragment]