### PR TITLE
Changed clickhouse migrations table struct

### DIFF
--- a/database/clickhouse/clickhouse.go
+++ b/database/clickhouse/clickhouse.go
@@ -175,7 +175,7 @@ func (ch *ClickHouse) ensureVersionTable() error {
 	// if not, create the empty migration table
 	query = `
 		CREATE TABLE ` + ch.config.MigrationsTable + ` (
-			version    UInt32, 
+			version    Int64, 
 			dirty      UInt8,
 			sequence   UInt64
 		) Engine=TinyLog


### PR DESCRIPTION
Changed migrations table struct of field `version` to fix support `database.NilVersion` and default version format.