### PR TITLE
PROBLEM: postgres migration broken

### DIFF
--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -255,14 +255,14 @@ func (p *Postgres) SetVersion(version int, dirty bool) error {
 		return &database.Error{OrigErr: err, Err: "transaction start failed"}
 	}
 
-	query := `TRUNCATE "` + p.config.MigrationsTable + `"`
+	query := `TRUNCATE public."` + p.config.MigrationsTable + `"`
 	if _, err := tx.Exec(query); err != nil {
 		tx.Rollback()
 		return &database.Error{OrigErr: err, Query: []byte(query)}
 	}
 
 	if version >= 0 {
-		query = `INSERT INTO "` + p.config.MigrationsTable + `" (version, dirty) VALUES ($1, $2)`
+		query = `INSERT INTO public."` + p.config.MigrationsTable + `" (version, dirty) VALUES ($1, $2)`
 		if _, err := tx.Exec(query, version, dirty); err != nil {
 			tx.Rollback()
 			return &database.Error{OrigErr: err, Query: []byte(query)}


### PR DESCRIPTION
When i try to run migrate from upstream master i run into the following
problem:
```bash
kj@vrrr:~/repos/migrate-upstream/cli/build> ./migrate.linux-amd64 -source file:///home/kj/work/cncenter.git/behav-api/sql/ -database postgres://postgres:postgres@172.33.0.1:5432/?sslmode=disable -verbose up 1
2019/01/31 18:35:11 Start buffering 1/u initialize_db
2019/01/31 18:35:12 Read and execute 1/u initialize_db
2019/01/31 18:35:12 error: pq: relation "schema_migrations" does not exist in line 0: TRUNCATE "schema_migrations"
```
Postres is complaining:
```
2019-01-31 17:35:12.440 UTC [61] ERROR:  relation "schema_migrations" does not exist
2019-01-31 17:35:12.440 UTC [61] STATEMENT:  TRUNCATE "schema_migrations"
```
I am running postgres like this:
`docker run --rm --net=behavnet --name postgres -p 5432:5432 -v /home/kj/temp:/tmp:rw postgres:10.6`

I found an old closed issue
https://github.com/golang-migrate/migrate/issues/93
which suggested that i might need priviliges:
```bash
postgres=# \du
                                   List of roles
 Role name |                         Attributes                         | Member of
-----------+------------------------------------------------------------+-----------
 postgres  | Superuser, Create role, Create DB, Replication, Bypass RLS | {}
```
Other than that, there was no other suggestion or resolution of that
issue.

With this commit built, i have no more problems:
```bash
kj@vrrr:~/repos/migrate/cli/build> ./migrate.linux-amd64 -source file:///home/kj/work/cncenter.git/behav-api/sql/ -database postgres://postgres:postgres@172.33.0.1:5432/?sslmode=disable -verbose up 1
2019/01/31 18:42:06 Start buffering 1/u initialize_db
2019/01/31 18:42:06 Read and execute 1/u initialize_db
2019/01/31 18:42:06 Finished 1/u initialize_db (read 12.662008ms, ran 155.706703ms)
2019/01/31 18:42:06 Finished after 169.958723ms
2019/01/31 18:42:06 Closing source and database
```

No more errors in postgres log.