### PR TITLE
Add go1.12 versioning support

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -32,6 +32,11 @@ $ apt-get install -y migrate
 $ go get -tags 'postgres' -u github.com/golang-migrate/migrate/cmd/migrate
 ```
 
+##### Versioned with Go Modules (go1.12)
+```
+$ GO111MODULE=on go get -tags 'postgres' -u github.com/golang-migrate/migrate/cmd/migrate@v4.2.4
+```
+
 ##### Versioned
 
 ```

--- a/cmd/migrate/mod_version.go
+++ b/cmd/migrate/mod_version.go
@@ -1,0 +1,11 @@
+// +build go1.12
+
+package main
+
+func init() {
+	if info, available := debug.ReadBuildInfo(); available {
+		if Version == "dev" {
+			Version = info.Main.Version
+		}
+	}
+}


### PR DESCRIPTION
With upcoming `go1.12` we can now embed version information without `LDFLAGS`. This PR uses [`debug.ReadBuildInfo()`](https://godoc.org/github.com/golang/go/src/runtime/debug#ReadBuildInfo) to simplify versioning with `go get`.

Here is a working example
```
GO111MODULE=on go1.12rc1 get github.com/vearutop/go-versioning-example@v0.0.1
```

```
go-versioning-example
Build info: &{Path:github.com/vearutop/go-versioning-example Main:{Path:github.com/vearutop/go-versioning-example Version:v0.0.1 Sum:h1:RtKk8SiukO2jrjtkz+0mYQ6bQjUcom3UUqTdBpGAk5o= Replace:<nil>} Deps:[0xc0000a02c0 0xc0000a0300]}
2019-02-12T11:11:20.447+0100	INFO	go-versioning-example@v0.0.1/main.go:9	App Version: v0.0.1
```