### PR TITLE
Updated README for go-bindata

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $
 Source drivers read migrations from local or remote sources. [Add a new source?](source/driver.go)
 
   * [Filesystem](source/file) - read from fileystem
-  * [Go-Bindata](source/go_bindata) - read from embedded binary data ([jteeuwen/go-bindata](https://github.com/jteeuwen/go-bindata))
+  * [Go-Bindata](source/go_bindata) - read from embedded binary data ([go-bindata/go-bindata](https://github.com/go-bindata/go-bindata))
   * [Github](source/github) - read from remote Github repositories
   * [Gitlab](source/gitlab) - read from remote Gitlab repositories
   * [AWS S3](source/aws_s3) - read from Amazon Web Services S3

--- a/source/go_bindata/README.md
+++ b/source/go_bindata/README.md
@@ -1,4 +1,4 @@
-# go_bindata
+# go-bindata integation
 
 ## Usage
 
@@ -7,7 +7,7 @@
 ### Read bindata with NewWithSourceInstance
 
 ```shell
-go get -u github.com/jteeuwen/go-bindata/...
+go get -u github.com/go-bindata/go-bindata/...
 cd examples/migrations && go-bindata -pkg migrations .
 ```
 
@@ -20,11 +20,8 @@ import (
 
 func main() {
   // wrap assets into Resource
-  s := bindata.Resource(migrations.AssetNames(),
-    func(name string) ([]byte, error) {
-      return migrations.Asset(name)
-    })
-    
+  s := bindata.Resource(migrations.AssetNames(), migrations.Asset)
+
   d, err := bindata.WithInstance(s)
   m, err := migrate.NewWithSourceInstance("go-bindata", d, "database://foobar")
   m.Up() // run your migrations and handle the errors above of course
@@ -36,8 +33,6 @@ func main() {
 This will restore the assets in a tmp directory and then
 proxy to source/file. go-bindata must be in your `$PATH`.
 
-```
+```shell
 migrate -source go-bindata://examples/migrations/bindata.go
 ```
-
-


### PR DESCRIPTION
- go-bindata now maintained by github organization "go-bindata"
- go-critic linter claimed abot lambda for migrations.Asset, so removed this lambda