### PR TITLE
Fix Broken Markdown in cli/README.md

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -119,7 +119,7 @@ $ migrate -database "$(cat config.json | jq '.database')"
 
 ##### YAML files
 
-````
+```
 $ migrate -database "$(cat config/database.yml | ruby -ryaml -e "print YAML.load(STDIN.read)['database']")"
 $ migrate -database "$(cat config/database.yml | python -c 'import yaml,sys;print yaml.safe_load(sys.stdin)["database"]')"
 ```


### PR DESCRIPTION
# Overview
Removes an extraneous back-tick that messed up the formatting in the `cli/README.md`. 

<img width="754" alt="Screen Shot 2019-05-16 at 11 30 17 AM" src="https://user-images.githubusercontent.com/5942769/57878068-191fe600-77ce-11e9-8531-17bdca4a17e6.png">
