### PR TITLE
Disable foreign_key_checks in Drop command for MySQL

### DIFF
--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -352,11 +352,7 @@ func (m *Mysql) Drop() (err error) {
 
 		defer func() {
 			// enable foreign key checks
-			query = `SET foreign_key_checks = 1`
-			if _, errChecks := m.conn.ExecContext(context.Background(), query); errChecks != nil {
-				errChecks = &database.Error{OrigErr: errChecks, Query: []byte(query)}
-				err = multierror.Append(err, errChecks)
-			}
+			m.conn.ExecContext(context.Background(), `SET foreign_key_checks = 1`)
 		}()
 
 		// delete one by one ...

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -352,7 +352,7 @@ func (m *Mysql) Drop() (err error) {
 
 		defer func() {
 			// enable foreign key checks
-			m.conn.ExecContext(context.Background(), `SET foreign_key_checks = 1`)
+			_, _ = m.conn.ExecContext(context.Background(), `SET foreign_key_checks = 1`)
 		}()
 
 		// delete one by one ...

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -345,14 +345,14 @@ func (m *Mysql) Drop() (err error) {
 
 	if len(tableNames) > 0 {
 		// disable checking foreign key constraints until finished
-		query = `SET FOREIGN_KEY_CHECKS = 0`
+		query = `SET foreign_key_checks = 0`
 		if _, err := m.conn.ExecContext(context.Background(), query); err != nil {
 			return &database.Error{OrigErr: err, Query: []byte(query)}
 		}
 
 		defer func() {
 			// enable foreign key checks
-			query = `SET FOREIGN_KEY_CHECKS = 1`
+			query = `SET foreign_key_checks = 1`
 			if _, errChecks := m.conn.ExecContext(context.Background(), query); errChecks != nil {
 				errChecks = &database.Error{OrigErr: errChecks, Query: []byte(query)}
 				err = multierror.Append(err, errChecks)

--- a/testing/docker.go
+++ b/testing/docker.go
@@ -1,4 +1,6 @@
-// Package testing is used in driver tests.
+// Package testing is used in driver tests and should only be used by migrate tests.
+//
+// Deprecated: If you'd like to test using Docker images, use package github.com/dhui/dktest instead
 package testing
 
 import (


### PR DESCRIPTION
Fix for https://github.com/golang-migrate/migrate/issues/223, disabling foreign_key_checks before attempting to drop tables.