### PR TITLE
migrate down less destructive

### DIFF
--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -182,3 +182,28 @@ func versionCmd(m *migrate.Migrate) {
 		log.Println(v)
 	}
 }
+
+// numDownMigrationsFromArgs returns an int for number of migrations to apply
+// and a bool indicating if we need a confirm before applying
+func numDownMigrationsFromArgs(applyAll bool, args []string) (int, bool, error) {
+	if applyAll {
+		if len(args) > 0 {
+			return 0, false, errors.New("-all cannot be used with other arguments")
+		}
+		return -1, false, nil
+	}
+
+	switch len(args) {
+	case 0:
+		return -1, true, nil
+	case 1:
+		downValue := args[0]
+		n, err := strconv.ParseUint(downValue, 10, 64)
+		if err != nil {
+			return 0, false, errors.New("can't read limit argument N")
+		}
+		return int(n), false, nil
+	default:
+		return 0, false, errors.New("too many arguments")
+	}
+}

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -78,3 +78,41 @@ func TestNextSeq(t *testing.T) {
 		})
 	}
 }
+
+func TestNumDownFromArgs(t *testing.T) {
+	cases := []struct {
+		name                string
+		args                []string
+		applyAll            bool
+		expectedNeedConfirm bool
+		expectedNum         int
+		expectedErrStr      string
+	}{
+		{"no args", []string{}, false, true, -1, ""},
+		{"down all", []string{}, true, false, -1, ""},
+		{"down 5", []string{"5"}, false, false, 5, ""},
+		{"down N", []string{"N"}, false, false, 0, "can't read limit argument N"},
+		{"extra arg after -all", []string{"5"}, true, false, 0, "-all cannot be used with other arguments"},
+		{"extra arg before -all", []string{"5", "-all"}, false, false, 0, "too many arguments"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			num, needsConfirm, err := numDownMigrationsFromArgs(c.applyAll, c.args)
+			if needsConfirm != c.expectedNeedConfirm {
+				t.Errorf("Incorrect needsConfirm was: %v wanted %v", needsConfirm, c.expectedNeedConfirm)
+			}
+
+			if num != c.expectedNum {
+				t.Errorf("Incorrect num was: %v wanted %v", num, c.expectedNum)
+			}
+
+			if err != nil {
+				if err.Error() != c.expectedErrStr {
+					t.Error("Incorrect error: " + err.Error() + " != " + c.expectedErrStr)
+				}
+			} else if c.expectedErrStr != "" {
+				t.Error("Expected error: " + c.expectedErrStr + " but got nil instead")
+			}
+		})
+	}
+}


### PR DESCRIPTION
default behaviour for down is to apply all down migrations, which is
comparable to dropping a database - and usually not the desired default
action.

proposed changes:

 * `down` prompts for a confirm `y` before applying all down migrations, defaulting to doing nothing
 * `down --all` does the current behaviour, applying all down migrations
 * `down N` is unchanged