### PR TITLE
Use UTC time in filename

### DIFF
--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -111,7 +111,7 @@ Database drivers: `+strings.Join(database.List(), ", ")+"\n")
 		}()
 	}
 
-	startTime := time.Now()
+	startTime := time.Now().UTC()
 
 	switch flag.Arg(0) {
 	case "create":


### PR DESCRIPTION
I noticed this issue while working in a remote team. I created a migration during the noon, but later on, my colleague in another timezone (-9 from my TZ) create a migration and it was created before mine. However, it was dependant on my migration, so it failed.