### PR TITLE
Change exit status to 2 on command error

### DIFF
--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -262,6 +262,6 @@ Database drivers: `+strings.Join(database.List(), ", ")+"\n")
 
 	default:
 		flag.Usage()
-		os.Exit(0)
+		os.Exit(2)
 	}
 }

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -262,6 +262,9 @@ Database drivers: `+strings.Join(database.List(), ", ")+"\n")
 
 	default:
 		flag.Usage()
+
+		// If a command is not found we exit with a status 2 to match the behavior
+		// of flag.Parse() with flag.ExitOnError when parsing an invalid flag.
 		os.Exit(2)
 	}
 }


### PR DESCRIPTION
The default exit status when a command cannot be found was 0. This can cause migrate to fail silently in case of typos i.e. `migrate -path . -source "..." pu`. Obviously, the program would still output the usage/help text but you'd typically check the exit status to know whether the program succeeded or not (`[ $? -eq 0 ] && echo Success
`).
Given that providing an invalid flag causes the program to exit with a exit status set to 2, the default exit status was also set to 2.