### PR TITLE
Do not match files ending with dot or having mulitple extensions

### DIFF
--- a/source/parse.go
+++ b/source/parse.go
@@ -18,7 +18,7 @@ var (
 // Regex matches the following pattern:
 //  123_name.up.ext
 //  123_name.down.ext
-var Regex = regexp.MustCompile(`^([0-9]+)_(.*)\.(` + string(Down) + `|` + string(Up) + `)\.(.*)$`)
+var Regex = regexp.MustCompile(`^([0-9]+)_(.*)\.(` + string(Down) + `|` + string(Up) + `)\.(\w+){1}$`)
 
 // Parse returns Migration for matching Regex pattern.
 func Parse(raw string) (*Migration, error) {

--- a/source/parse_test.go
+++ b/source/parse_test.go
@@ -90,6 +90,21 @@ func TestParse(t *testing.T) {
 			expectErr:       ErrParse,
 			expectMigration: nil,
 		},
+		{
+			name:            "1_foobar.down.",
+			expectErr:       ErrParse,
+			expectMigration: nil,
+		},
+		{
+			name:            "1_foobar.down.sql.",
+			expectErr:       ErrParse,
+			expectMigration: nil,
+		},
+		{
+			name:            "1_foobar.down.sql.tar",
+			expectErr:       ErrParse,
+			expectMigration: nil,
+		},
 	}
 
 	for i, v := range tt {


### PR DESCRIPTION
Files that were matched previously are:

```
123_something.up.sql.tar.gz
123_something.down.sql.backup
123_something.up.sql.
```

Those are now ignored.