### PR TITLE
Allow empty SSLOpts to support Azure cosmos DB Cassandra

### DIFF
--- a/database/cassandra/cassandra.go
+++ b/database/cassandra/cassandra.go
@@ -120,13 +120,13 @@ func (c *Cassandra) Open(url string) (database.Driver, error) {
 		}
 		cluster.Timeout = timeout
 	}
-
-	if len(u.Query().Get("sslmode")) > 0 && len(u.Query().Get("sslrootcert")) > 0 && len(u.Query().Get("sslcert")) > 0 && len(u.Query().Get("sslkey")) > 0 {
+	if len(u.Query().Get("sslmode")) > 0 {
 		if u.Query().Get("sslmode") != "disable" {
-			cluster.SslOpts = &gocql.SslOptions{
-				CaPath:   u.Query().Get("sslrootcert"),
-				CertPath: u.Query().Get("sslcert"),
-				KeyPath:  u.Query().Get("sslkey"),
+			cluster.SslOpts = &gocql.SslOptions{}
+			if len(u.Query().Get("sslrootcert")) > 0 && len(u.Query().Get("sslcert")) > 0 && len(u.Query().Get("sslkey")) > 0 {
+				cluster.SslOpts.CaPath = u.Query().Get("sslrootcert")
+				cluster.SslOpts.CertPath = u.Query().Get("sslcert")
+				cluster.SslOpts.KeyPath = u.Query().Get("sslkey")
 			}
 			if u.Query().Get("sslmode") == "verify-full" {
 				cluster.SslOpts.EnableHostVerification = true

--- a/database/cassandra/cassandra.go
+++ b/database/cassandra/cassandra.go
@@ -197,12 +197,9 @@ func (c *Cassandra) Run(migration io.Reader) error {
 }
 
 func (c *Cassandra) SetVersion(version int, dirty bool) error {
-	query := `TRUNCATE "` + c.config.MigrationsTable + `"`
-	if err := c.session.Query(query).Exec(); err != nil {
-		return &database.Error{OrigErr: err, Query: []byte(query)}
-	}
+
 	if version >= 0 {
-		query = `INSERT INTO "` + c.config.MigrationsTable + `" (version, dirty) VALUES (?, ?)`
+		query := `INSERT INTO "` + c.config.MigrationsTable + `" (version, dirty) VALUES (?, ?)`
 		if err := c.session.Query(query, version, dirty).Exec(); err != nil {
 			return &database.Error{OrigErr: err, Query: []byte(query)}
 		}

--- a/database/cassandra/cassandra.go
+++ b/database/cassandra/cassandra.go
@@ -197,6 +197,14 @@ func (c *Cassandra) Run(migration io.Reader) error {
 }
 
 func (c *Cassandra) SetVersion(version int, dirty bool) error {
+	query := `DROP TABLE "` + c.config.MigrationsTable + `"`
+	if err := c.session.Query(query).Exec(); err != nil {
+		return &database.Error{OrigErr: err, Query: []byte(query)}
+	}
+
+	if err := c.createMigrationTable(); err != nil {
+		return &database.Error{OrigErr: err, Query: []byte(query)}
+	}
 
 	if version >= 0 {
 		query := `INSERT INTO "` + c.config.MigrationsTable + `" (version, dirty) VALUES (?, ?)`
@@ -260,7 +268,7 @@ func (c *Cassandra) ensureVersionTable() (err error) {
 		}
 	}()
 
-	err = c.session.Query(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (version bigint, dirty boolean, PRIMARY KEY(version))", c.config.MigrationsTable)).Exec()
+	err = c.createMigrationTable()
 	if err != nil {
 		return err
 	}
@@ -285,4 +293,9 @@ func parseConsistency(consistencyStr string) (consistency gocql.Consistency, err
 	consistency = gocql.ParseConsistency(consistencyStr)
 
 	return consistency, nil
+}
+
+// createMigrationTable creates migration table
+func (c *Cassandra) createMigrationTable() error {
+	return c.session.Query(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (version bigint, dirty boolean, PRIMARY KEY(version))", c.config.MigrationsTable)).Exec()
 }


### PR DESCRIPTION
For Azure cosmos DB Cassandra.
It require ssl and set `SSL_VALIDATE=false`
Reference from azure cosmos DB cassandra quick start guide
```
export SSL_VERSION=TLSv1_2
export SSL_VALIDATE=false

cqlsh service.cassandra.cosmos.azure.com 10350 -u username -p password --ssl
```