### PR TITLE
Trim statement leading and trailing whitespace.

### DIFF
--- a/database/spanner/spanner.go
+++ b/database/spanner/spanner.go
@@ -309,6 +309,7 @@ func migrationStatements(migration []byte) []string {
 	allStatements := strings.Split(migrationString, ";")
 	nonEmptyStatements := allStatements[:0]
 	for _, s := range allStatements {
+		s = strings.TrimSpace(s)
 		if s != "" {
 			nonEmptyStatements = append(nonEmptyStatements, s)
 		}

--- a/database/spanner/spanner_test.go
+++ b/database/spanner/spanner_test.go
@@ -102,7 +102,7 @@ func TestMultistatementSplit(t *testing.T) {
 CREATE INDEX table_name_id_idx ON table_name (id);`,
 			expected: []string{`CREATE TABLE table_name (
 	id STRING(255) NOT NULL,
-) PRIMARY KEY(id)`, "\n\nCREATE INDEX table_name_id_idx ON table_name (id)"},
+) PRIMARY KEY(id)`, "CREATE INDEX table_name_id_idx ON table_name (id)"},
 		},
 		{
 			name: "multi statement, no trailing semicolon",
@@ -114,7 +114,7 @@ CREATE INDEX table_name_id_idx ON table_name (id);`,
 CREATE INDEX table_name_id_idx ON table_name (id)`,
 			expected: []string{`CREATE TABLE table_name (
 	id STRING(255) NOT NULL,
-) PRIMARY KEY(id)`, "\n\nCREATE INDEX table_name_id_idx ON table_name (id)"},
+) PRIMARY KEY(id)`, "CREATE INDEX table_name_id_idx ON table_name (id)"},
 		},
 	}
 


### PR DESCRIPTION
The changes herein make sure Spanner DDL statements have leading and
trailing whitespace characters trimmed.