### PR TITLE
[cli] Improve migration creation

### DIFF
--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -2,78 +2,90 @@ package cli
 
 import (
 	"testing"
+	"time"
 )
 
-func TestCleanDir(t *testing.T) {
+func TestNextSeqVersion(t *testing.T) {
 	cases := []struct {
-		dir              string
-		expectedCleanDir string
+		name        string
+		matches     []string
+		seqDigits   int
+		expected    string
+		expectedErr string
 	}{
-		{dir: "", expectedCleanDir: ""},
-		{dir: ".", expectedCleanDir: ""},
-		{dir: "/", expectedCleanDir: "/"},
-		{dir: "./", expectedCleanDir: ""},
-		{dir: ".test", expectedCleanDir: ".test/"},
-		{dir: ".test/", expectedCleanDir: ".test/"},
-		{dir: "test", expectedCleanDir: "test/"},
-		{dir: "test/", expectedCleanDir: "test/"},
-		{dir: "./test", expectedCleanDir: "test/"},
-		{dir: "./test/", expectedCleanDir: "test/"},
-		{dir: "test/test", expectedCleanDir: "test/test/"},
-		{dir: "test/test/", expectedCleanDir: "test/test/"},
-		{dir: "./test/test", expectedCleanDir: "test/test/"},
-		{dir: "./test/test/", expectedCleanDir: "test/test/"},
+		{"Bad digits", []string{}, 0, "", errInvalidSequenceWidth.Error()},
+		{"Single digit initialize", []string{}, 1, "1", ""},
+		{"Single digit malformed", []string{"bad"}, 1, "", "Malformed migration filename: bad"},
+		{"Single digit no int", []string{"bad_bad"}, 1, "", `strconv.ParseUint: parsing "bad": invalid syntax`},
+		{"Single digit negative seq", []string{"-5_test"}, 1, "", `strconv.ParseUint: parsing "-5": invalid syntax`},
+		{"Single digit increment", []string{"3_test", "4_test"}, 1, "5", ""},
+		{"Single digit overflow", []string{"9_test"}, 1, "", "Next sequence number 10 too large. At most 1 digits are allowed"},
+		{"Zero-pad initialize", []string{}, 6, "000001", ""},
+		{"Zero-pad malformed", []string{"bad"}, 6, "", "Malformed migration filename: bad"},
+		{"Zero-pad no int", []string{"bad_bad"}, 6, "", `strconv.ParseUint: parsing "bad": invalid syntax`},
+		{"Zero-pad negative seq", []string{"-000005_test"}, 6, "", `strconv.ParseUint: parsing "-000005": invalid syntax`},
+		{"Zero-pad increment", []string{"000003_test", "000004_test"}, 6, "000005", ""},
+		{"Zero-pad overflow", []string{"999999_test"}, 6, "", "Next sequence number 1000000 too large. At most 6 digits are allowed"},
+		{"dir absolute path", []string{"/migrationDir/000001_test"}, 6, "000002", ""},
+		{"dir relative path", []string{"migrationDir/000001_test"}, 6, "000002", ""},
+		{"dir dot prefix", []string{"./migrationDir/000001_test"}, 6, "000002", ""},
+		{"dir parent prefix", []string{"../migrationDir/000001_test"}, 6, "000002", ""},
+		{"dir no prefix", []string{"000001_test"}, 6, "000002", ""},
 	}
 
 	for _, c := range cases {
-		t.Run(c.dir, func(t *testing.T) {
-			cleanedDir := cleanDir(c.dir)
-			if cleanedDir != c.expectedCleanDir {
-				t.Error("Incorrectly cleaned dir: " + cleanedDir + " != " + c.expectedCleanDir)
+		t.Run(c.name, func(t *testing.T) {
+			v, err := nextSeqVersion(c.matches, c.seqDigits)
+
+			if err == nil {
+				if c.expectedErr != "" {
+					t.Errorf("Expected error: %q, but got nil instead.", c.expectedErr)
+				} else {
+					if v != c.expected {
+						t.Errorf("Incorrect version %q. Expected %q.", v, c.expected)
+					}
+				}
+			} else {
+				if err.Error() != c.expectedErr {
+					t.Errorf("Incorrect error %q. Expected: %q.", err.Error(), c.expectedErr)
+				}
 			}
 		})
 	}
 }
 
-func TestNextSeq(t *testing.T) {
+func TestTimeVersion(t *testing.T) {
+	ts := time.Date(2000, 12, 25, 00, 01, 02, 3456789, time.UTC)
+
 	cases := []struct {
-		name           string
-		matches        []string
-		dir            string
-		seqDigits      int
-		expected       string
-		expectedErrStr string
+		name        string
+		time        time.Time
+		format      string
+		expected    string
+		expectedErr string
 	}{
-		{"Bad digits", []string{}, "migrationDir/", 0, "", "Digits must be positive"},
-		{"Single digit initialize", []string{}, "migrationDir/", 1, "1", ""},
-		{"Single digit malformed", []string{"bad"}, "migrationDir/", 1, "", "Malformed migration filename: bad"},
-		{"Single digit no int", []string{"bad_bad"}, "migrationDir/", 1, "", "strconv.Atoi: parsing \"bad\": invalid syntax"},
-		{"Single digit negative seq", []string{"-5_test"}, "migrationDir/", 1, "", "Next sequence number must be positive"},
-		{"Single digit increment", []string{"3_test", "4_test"}, "migrationDir/", 1, "5", ""},
-		{"Single digit overflow", []string{"9_test"}, "migrationDir/", 1, "", "Next sequence number 10 too large. At most 1 digits are allowed"},
-		{"Zero-pad initialize", []string{}, "migrationDir/", 6, "000001", ""},
-		{"Zero-pad malformed", []string{"bad"}, "migrationDir/", 6, "", "Malformed migration filename: bad"},
-		{"Zero-pad no int", []string{"bad_bad"}, "migrationDir/", 6, "", "strconv.Atoi: parsing \"bad\": invalid syntax"},
-		{"Zero-pad negative seq", []string{"-000005_test"}, "migrationDir/", 6, "", "Next sequence number must be positive"},
-		{"Zero-pad increment", []string{"000003_test", "000004_test"}, "migrationDir/", 6, "000005", ""},
-		{"Zero-pad overflow", []string{"999999_test"}, "migrationDir/", 6, "", "Next sequence number 1000000 too large. At most 6 digits are allowed"},
-		{"dir - no trailing slash", []string{"migrationDir/000001_test"}, "migrationDir", 6, "", `strconv.Atoi: parsing "/000001": invalid syntax`},
-		{"dir - with dot prefix success", []string{"migrationDir/000001_test"}, "./migrationDir/", 6, "", `strconv.Atoi: parsing "migrationDir/000001": invalid syntax`},
-		{"dir - no dir prefix", []string{"000001_test"}, "migrationDir/", 6, "000002", ""},
-		{"dir - strip success", []string{"migrationDir/000001_test"}, "migrationDir/", 6, "000002", ""},
+		{"Bad format", ts, "", "", errInvalidTimeFormat.Error()},
+		{"unix", ts, "unix", "977702462", ""},
+		{"unixNano", ts, "unixNano", "977702462003456789", ""},
+		{"custom ymthms", ts, "20060102150405", "20001225000102", ""},
 	}
+
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			nextSeq, err := nextSeq(c.matches, c.dir, c.seqDigits)
-			if nextSeq != c.expected {
-				t.Error("Incorrect nextSeq: " + nextSeq + " != " + c.expected)
-			}
-			if err != nil {
-				if err.Error() != c.expectedErrStr {
-					t.Error("Incorrect error: " + err.Error() + " != " + c.expectedErrStr)
+			v, err := timeVersion(c.time, c.format)
+
+			if err == nil {
+				if c.expectedErr != "" {
+					t.Errorf("Expected error: %q, but got nil instead.", c.expectedErr)
+				} else {
+					if v != c.expected {
+						t.Errorf("Incorrect version %q. Expected %q.", v, c.expected)
+					}
 				}
-			} else if c.expectedErrStr != "" {
-				t.Error("Expected error: " + c.expectedErrStr + " but got nil instead")
+			} else {
+				if err.Error() != c.expectedErr {
+					t.Errorf("Incorrect error %q. Expected: %q.", err.Error(), c.expectedErr)
+				}
 			}
 		})
 	}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -137,9 +137,10 @@ Database drivers: `+strings.Join(database.List(), ", ")+"\n")
 		if *extPtr == "" {
 			log.fatal("error: -ext flag must be specified")
 		}
-		*extPtr = "." + strings.TrimPrefix(*extPtr, ".")
 
-		createCmd(*dirPtr, startTime, *formatPtr, name, *extPtr, seq, seqDigits)
+		if err := createCmd(*dirPtr, startTime, *formatPtr, name, *extPtr, seq, seqDigits, true); err != nil {
+			log.fatalErr(err)
+		}
 
 	case "goto":
 		if migraterErr != nil {


### PR DESCRIPTION
This PR adds validation to migration versions when creating migrations and improves/refactors creation in general. As a "side-effect", it fixes #238.

## Rationale

`migrate create` doesn't validate migration versions when creating files. This causes issues when creating files that results in same-version migrations. It's easy to replicate this behavior:

```
# created sequentially too fast (unix format)

$ for name in same_second_one same_second_two; do
$   migrate create -dir migs -ext sql -format "unix" "$name"
$ done
$ ls -1 migs
1575445236_same_second_one.down.sql
1575445236_same_second_one.up.sql
1575445236_same_second_two.down.sql
1575445236_same_second_two.up.sql

# low precision time format (stupid, but valid format)

$ migrate create -dir migs -ext sql -format "20060102" same_day_one
$ migrate create -dir migs -ext sql -format "20060102" same_day_two
$ ls -1 migs
20191204_same_day_one.down.sql
20191204_same_day_one.up.sql
20191204_same_day_two.down.sql
20191204_same_day_two.up.sql
```

I accidentally hit the first case when converting an already existing database schema into migrations, using a very similar loop, iterating over table names, creating migrations and redirecting the output of `pg_dump -st $table` into each "up" migration. It didn't occur to me that versions would be colliding. When I tried to run `migrate up`, a very obscure ["unable to parse file"](https://github.com/golang-migrate/migrate/blob/41b578a45e9ee45589dd72599113d6253c409d1a/source/file/file.go#L74) error popped up. Reading the source code explained it.

Since it's much harder to refactor the whole `source` package to show useful error messages ([Migrations.Append()](https://github.com/golang-migrate/migrate/blob/41b578a45e9ee45589dd72599113d6253c409d1a/source/migration.go#L48) isn't supposed to return `error` with useful messages instead of `bool`?), I went for the simpler "warn the kids that the stove is hot" solution.

## Solution & Improvements

* Validate migration version on creation, to avoid creation of duplicated versions

A refactoring of the migration creation code first generates the `version` component and then checks if any files with that version already exists on disk.

Here's the corresponding outputs to the commands above, using the fixed version:

```
$ go build -o /tmp/migrate ./cmd/migrate
$ cd "$(mktemp -d)"

$ /tmp/migrate create -dir migs -ext sql -format "20060102" same_day_one
migs/20191204_same_day_one.up.sql
migs/20191204_same_day_one.down.sql

$ /tmp/migrate create -dir migs -ext sql -format "20060102" same_day_two
error: duplicate migration version: 20191204

$ ls -1 migs
20191204_same_day_one.down.sql
20191204_same_day_one.up.sql
```

* Use `os.OpenFile` with `O_CREATE|O_EXCL` to create files to avoid file collisions

This would be very difficult to cause, but I can imagine some bogus uses of `parallel` + `migrate` that would case this to happen (in cases someone want to generate hundreds of migrations faster, but the script contains bugs, for example).

* Use `filepath` functions to manipulate paths, making `cleanPath()` not necessary

I see that in the discussion of #238 and the proposed fix for it in 9f6c7e5fc9ec3c682bb84701f344bb9a51e58aa2 and #250, there's a lot of string manipulation gymnastics to handle cross-platform path manipulation. `filepath` is the cross-platform solution for this and all its functions should be used when doing real, on disk, OS specific, path manipulation.

So this PR properly fixes #238 and supersedes #250.

* Prints generated filenames

This can be debatable, but popular migration generators (active record, django, etc) print the filenames out, so the developer knows which file was created. It's also convenient to simply copy-paste the name of the file to open it for editing.

## Tests

The PR updates the migration creation tests, but I'm not able to run the whole suite because I'm on Fedora 31 which ships the kernel with cgroupsv2 enabled and docker doesn't work with it (as of now).

`go test ./internal/cli/...` does work though.

And I quickly tested the built CLI on a Windows VM: https://gist.github.com/13k/1483f0c377991252b486fd604fd5acee