### PR TITLE
Add arm binaries to the build-cli phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,8 @@ deploy:
       tags: true
     file:
       - cli/build/migrate.linux-amd64.tar.gz
+      - cli/build/migrate.linux-armv7.tar.gz
+      - cli/build/migrate.linux-arm64.tar.gz
       - cli/build/migrate.darwin-amd64.tar.gz
       - cli/build/migrate.windows-amd64.exe.tar.gz
       - cli/build/sha256sum.txt

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ COVERAGE_DIR ?= .coverage
 build-cli: clean
 	-mkdir ./cli/build
 	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o ../../cli/build/migrate.linux-amd64 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
+	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -a -o ../../cli/build/migrate.linux-armv7 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
+	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -o ../../cli/build/migrate.linux-arm64 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
 	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -a -o ../../cli/build/migrate.darwin-amd64 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
 	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -a -o ../../cli/build/migrate.windows-amd64.exe -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
 	cd ./cli/build && find . -name 'migrate*' | xargs -I{} tar czf {}.tar.gz {}


### PR DESCRIPTION
Simply because I need them.

I'm not changing anything in the release process per se, so there's still the same packages being released. Just that now we will also have armv7 and arm64 binaries available in the releases folder.