### PR TITLE
Allow passing in your own aws s3client object

### DIFF
--- a/source/aws_s3/s3.go
+++ b/source/aws_s3/s3.go
@@ -51,9 +51,14 @@ func (s *s3Driver) Open(folder string) (source.Driver, error) {
 		}
 	}
 
+	prefix := strings.Trim(u.Path, "/") + "/"
+	if prefix == "/" {
+		prefix = ""
+	}
+
 	driver := s3Driver{
 		bucket:     u.Host,
-		prefix:     strings.Trim(u.Path, "/") + "/",
+		prefix:     prefix,
 		s3client:   s3.New(awsSession),
 		migrations: source.NewMigrations(),
 	}

--- a/source/aws_s3/s3.go
+++ b/source/aws_s3/s3.go
@@ -43,10 +43,10 @@ func (s *s3Driver) Open(folder string) (source.Driver, error) {
 	return driver, nil
 }
 
-func WithInstance(sess *session.Session, config *Config) (source.Driver, error) {
+func WithInstance(s3client s3iface.S3API, config *Config) (source.Driver, error) {
 	driver := &s3Driver{
 		config:     config,
-		s3client:   s3.New(sess),
+		s3client:   s3client,
 		migrations: source.NewMigrations(),
 	}
 

--- a/source/aws_s3/s3.go
+++ b/source/aws_s3/s3.go
@@ -31,12 +31,12 @@ type Config struct {
 }
 
 func (s *s3Driver) Open(folder string) (source.Driver, error) {
-	sess, err := session.NewSession()
+	config, err := parseURI(folder)
 	if err != nil {
 		return nil, err
 	}
 
-	config, err := parseURI(folder)
+	sess, err := session.NewSession()
 	if err != nil {
 		return nil, err
 	}

--- a/source/aws_s3/s3_test.go
+++ b/source/aws_s3/s3_test.go
@@ -40,43 +40,40 @@ func Test(t *testing.T) {
 	st.Test(t, driver)
 }
 
-func TestNewS3Driver(t *testing.T) {
+func TestParseURI(t *testing.T) {
 	const expectedBucket = "migration-bucket"
-	const expectedPrefix = "production/"
 
-	driver, err := newS3Driver(fmt.Sprintf("s3://%s/%s", expectedBucket, expectedPrefix))
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Run("With prefix", func(t *testing.T) {
+		const expectedPrefix = "production/"
 
-	if driver.config.Bucket != expectedBucket {
-		t.Errorf("Expected: %s; actual: %s", expectedBucket, driver.config.Bucket)
-	}
+		config, err := parseURI(fmt.Sprintf("s3://%s/%s", expectedBucket, expectedPrefix))
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if driver.config.Prefix != expectedPrefix {
-		t.Errorf("Expected: %s; actual: %s", expectedPrefix, driver.config.Prefix)
-	}
+		if config.Bucket != expectedBucket {
+			t.Errorf("Expected: %s; actual: %s", expectedBucket, config.Bucket)
+		}
 
-	if driver.s3client == nil {
-		t.Error("S3 client is not initialized")
-	}
+		if config.Prefix != expectedPrefix {
+			t.Errorf("Expected: %s; actual: %s", expectedPrefix, config.Prefix)
+		}
+	})
 
-	if driver.migrations == nil {
-		t.Error("Migration source is not initialized")
-	}
+	t.Run("Without prefix", func(t *testing.T) {
+		config, err := parseURI(fmt.Sprintf("s3://%s", expectedBucket))
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	driver, err = newS3Driver(fmt.Sprintf("s3://%s", expectedBucket))
-	if err != nil {
-		t.Fatal(err)
-	}
+		if config.Bucket != expectedBucket {
+			t.Errorf("Expected: %s; actual: %s", expectedBucket, config.Bucket)
+		}
 
-	if driver.config.Bucket != expectedBucket {
-		t.Errorf("Expected: %s; actual: %s", expectedBucket, driver.config.Bucket)
-	}
-
-	if driver.config.Prefix != "" {
-		t.Errorf("Prefix should be empty; actual: %s", driver.config.Prefix)
-	}
+		if config.Prefix != "" {
+			t.Errorf("Prefix should be empty; actual: %s", config.Prefix)
+		}
+	})
 }
 
 type fakeS3 struct {

--- a/source/aws_s3/s3_test.go
+++ b/source/aws_s3/s3_test.go
@@ -3,13 +3,13 @@ package awss3
 import (
 	"errors"
 	"io/ioutil"
-	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	st "github.com/golang-migrate/migrate/v4/source/testing"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test(t *testing.T) {
@@ -83,9 +83,7 @@ func TestParseURI(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !reflect.DeepEqual(actual, test.config) {
-				t.Errorf("parseURI() = %v, expected %v", actual, test.config)
-			}
+			assert.Equal(t, test.config, actual)
 		})
 	}
 }

--- a/source/aws_s3/s3_test.go
+++ b/source/aws_s3/s3_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/golang-migrate/migrate/v4/source"
 	st "github.com/golang-migrate/migrate/v4/source/testing"
@@ -41,6 +42,20 @@ func Test(t *testing.T) {
 		t.Fatal(err)
 	}
 	st.Test(t, &driver)
+}
+
+func TestSetAWSSession(t *testing.T) {
+	customSession, err := session.NewSession(&aws.Config{
+		Endpoint:         aws.String("http://localhost:4572"),
+		S3ForcePathStyle: aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	SetAWSSession(customSession)
+	if customSession != awsSession {
+		t.Error("Custom AWS session was not saved")
+	}
 }
 
 type fakeS3 struct {

--- a/source/aws_s3/s3_test.go
+++ b/source/aws_s3/s3_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/golang-migrate/migrate/v4/source"
 	st "github.com/golang-migrate/migrate/v4/source/testing"
@@ -33,8 +32,10 @@ func Test(t *testing.T) {
 		},
 	}
 	driver := s3Driver{
-		bucket:     "some-bucket",
-		prefix:     "prod/migrations/",
+		config: &Config{
+			Bucket: "some-bucket",
+			Prefix: "prod/migrations/",
+		},
 		migrations: source.NewMigrations(),
 		s3client:   &s3Client,
 	}
@@ -43,21 +44,6 @@ func Test(t *testing.T) {
 		t.Fatal(err)
 	}
 	st.Test(t, &driver)
-}
-
-func TestSetAWSSession(t *testing.T) {
-	customSession, err := session.NewSession(&aws.Config{
-		Endpoint:         aws.String("http://localhost:4572"),
-		S3ForcePathStyle: aws.Bool(true),
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	SetAWSSession(customSession)
-	if customSession != awsSession {
-		t.Error("Custom AWS session was not saved")
-	}
 }
 
 func TestNewS3Driver(t *testing.T) {
@@ -69,12 +55,12 @@ func TestNewS3Driver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if driver.bucket != expectedBucket {
-		t.Errorf("Expected: %s; actual: %s", expectedBucket, driver.bucket)
+	if driver.config.Bucket != expectedBucket {
+		t.Errorf("Expected: %s; actual: %s", expectedBucket, driver.config.Bucket)
 	}
 
-	if driver.prefix != expectedPrefix {
-		t.Errorf("Expected: %s; actual: %s", expectedPrefix, driver.prefix)
+	if driver.config.Prefix != expectedPrefix {
+		t.Errorf("Expected: %s; actual: %s", expectedPrefix, driver.config.Prefix)
 	}
 
 	if driver.s3client == nil {
@@ -90,12 +76,12 @@ func TestNewS3Driver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if driver.bucket != expectedBucket {
-		t.Errorf("Expected: %s; actual: %s", expectedBucket, driver.bucket)
+	if driver.config.Bucket != expectedBucket {
+		t.Errorf("Expected: %s; actual: %s", expectedBucket, driver.config.Bucket)
 	}
 
-	if driver.prefix != "" {
-		t.Errorf("Prefix should be empty")
+	if driver.config.Prefix != "" {
+		t.Errorf("Prefix should be empty; actual: %s", driver.config.Prefix)
 	}
 }
 

--- a/source/aws_s3/s3_test.go
+++ b/source/aws_s3/s3_test.go
@@ -2,6 +2,7 @@ package awss3
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -52,9 +53,49 @@ func TestSetAWSSession(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	SetAWSSession(customSession)
 	if customSession != awsSession {
 		t.Error("Custom AWS session was not saved")
+	}
+}
+
+func TestNewS3Driver(t *testing.T) {
+	const expectedBucket = "migration-bucket"
+	const expectedPrefix = "production/"
+
+	driver, err := newS3Driver(fmt.Sprintf("s3://%s/%s", expectedBucket, expectedPrefix))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if driver.bucket != expectedBucket {
+		t.Errorf("Expected: %s; actual: %s", expectedBucket, driver.bucket)
+	}
+
+	if driver.prefix != expectedPrefix {
+		t.Errorf("Expected: %s; actual: %s", expectedPrefix, driver.prefix)
+	}
+
+	if driver.s3client == nil {
+		t.Error("S3 client is not initialized")
+	}
+
+	if driver.migrations == nil {
+		t.Error("Migration source is not initialized")
+	}
+
+	driver, err = newS3Driver(fmt.Sprintf("s3://%s", expectedBucket))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if driver.bucket != expectedBucket {
+		t.Errorf("Expected: %s; actual: %s", expectedBucket, driver.bucket)
+	}
+
+	if driver.prefix != "" {
+		t.Errorf("Prefix should be empty")
 	}
 }
 

--- a/source/aws_s3/s3_test.go
+++ b/source/aws_s3/s3_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/golang-migrate/migrate/v4/source"
 	st "github.com/golang-migrate/migrate/v4/source/testing"
 )
 
@@ -31,19 +30,14 @@ func Test(t *testing.T) {
 			"prod/migrations/0-random-stuff/whatever.txt": "",
 		},
 	}
-	driver := s3Driver{
-		config: &Config{
-			Bucket: "some-bucket",
-			Prefix: "prod/migrations/",
-		},
-		migrations: source.NewMigrations(),
-		s3client:   &s3Client,
-	}
-	err := driver.loadMigrations()
+	driver, err := WithInstance(&s3Client, &Config{
+		Bucket: "some-bucket",
+		Prefix: "prod/migrations/",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	st.Test(t, &driver)
+	st.Test(t, driver)
 }
 
 func TestNewS3Driver(t *testing.T) {


### PR DESCRIPTION
Addresses https://github.com/golang-migrate/migrate/issues/333

~~Introduces a new function `SetAWSSession` in package `awss3` that allows someone to set their own aws session object. As talked about it the issue #333, someone might want to use their own aws session object to connect to a localstack instance instead of real AWS infrastructure when doing local development or testing.~~

~~To accomplish this, we have to move the session object to a private global variable and introduce a mutex to protect access to it.~~

Introduces a WithInstance function allowing someone to pass in their own aws s3 client object. This provides the ability to pass in a mocked s3client (for unit testing). Or passing in a real s3 client object that is configured to connect to a localstack instance (for local development or integration testing). There are probably other usecases that require passing in a customized aws s3 client object.

I also fixed a bug that I noticed when attempting to load migrations that are at the root of the bucket (so no prefix). The original code was setting the prefix value to `/` when it should be empty string.

This PR is backwards compatible as the `Open` function continues to function exactly the same. Calling the new `WithInstance` function is completely optional.