### PR TITLE
Add ErrNoChange check when using Up.

### DIFF
--- a/migrate_test.go
+++ b/migrate_test.go
@@ -70,7 +70,7 @@ func ExampleNew() {
 	}
 
 	// Migrate all the way up ...
-	if err := m.Up(); err != nil {
+	if err := m.Up(); err != nil && err != ErrNoChange {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
Since not checking ErrNoChange on `Up` function could cause errors and I encountered it. I updated this code to help others.
https://github.com/golang-migrate/migrate/issues/100