### PR TITLE
fix(clickhouse): fix db name issue

### DIFF
--- a/database/clickhouse/clickhouse.go
+++ b/database/clickhouse/clickhouse.go
@@ -180,7 +180,7 @@ func (ch *ClickHouse) ensureVersionTable() (err error) {
 
 	var (
 		table string
-		query = "SHOW TABLES FROM " + ch.config.DatabaseName + " LIKE '" + ch.config.MigrationsTable + "'"
+		query = "SHOW TABLES FROM `" + ch.config.DatabaseName + "` LIKE '" + ch.config.MigrationsTable + "'"
 	)
 	// check if migration table exists
 	if err := ch.conn.QueryRow(query).Scan(&table); err != nil {


### PR DESCRIPTION
Fix case when db name with a hyphen throws error 
```
Syntax error: failed at position 28: -service-staging LIKE 'schema_migrations'. Expected one of: LIMIT, SETTINGS, FORMAT, NOT, LIKE, INTO OUTFILE in line 0: SHOW TABLES FROM super-service-staging LIKE 'schema_migrations'
```