### PR TITLE
Add Windows install instructions using scoop

### DIFF
--- a/cmd/migrate/README.md
+++ b/cmd/migrate/README.md
@@ -16,6 +16,14 @@ $ curl -L https://github.com/golang-migrate/migrate/releases/download/$version/m
 $ brew install golang-migrate
 ```
 
+### Windows
+
+Using [scoop](https://scoop.sh/)
+
+```bash
+$ scoop install migrate
+```
+
 ### Linux (*.deb package)
 
 ```bash


### PR DESCRIPTION
migrate was included in the windows package manager scoop in https://github.com/ScoopInstaller/Main/pull/808