### PR TITLE
Move migrate binary to /usr/local/bin in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /usr/local/lib/libseabolt* /lib/
 
-COPY --from=builder /go/src/github.com/golang-migrate/migrate/build/migrate.linux-386 /migrate
+COPY --from=builder /go/src/github.com/golang-migrate/migrate/build/migrate.linux-386 /usr/local/bin/migrate
+RUN ln -s /usr/local/bin/migrate /migrate
 
-ENTRYPOINT ["/migrate"]
+ENTRYPOINT ["migrate"]
 CMD ["--help"]


### PR DESCRIPTION
Move the migrate binary to `/usr/local/bin` in Dockerfile, so it
can be invoked from anywhere - this makes it easier to write
entrypoint scripts that call `migrate` that can can be used
consistently both locally and in Docker containers.