### PR TITLE
Proof-of-concept of passing an interface rather than *sql.DB to database drivers

### DIFF
--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -41,17 +41,40 @@ type Config struct {
 	StatementTimeout time.Duration
 }
 
+type SQLWrapper struct {
+	*sql.DB
+}
+
+func (w *SQLWrapper) Conn(ctx context.Context) (Conn, error) {
+	return w.DB.Conn(ctx)
+}
+
+type Conn interface {
+	Close() error
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
+}
+
+type DB interface {
+	Close() error
+	Ping() error
+	QueryRow(query string, args ...interface{}) *sql.Row
+	Conn(ctx context.Context) (Conn, error)
+}
+
 type Postgres struct {
 	// Locking and unlocking need to use the same connection
-	conn     *sql.Conn
-	db       *sql.DB
+	conn     Conn
+	db       DB
 	isLocked bool
 
 	// Open and WithInstance need to guarantee that config is never nil
 	config *Config
 }
 
-func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
+func WithInterface(instance DB, config *Config) (database.Driver, error) {
 	if config == nil {
 		return nil, ErrNilConfig
 	}
@@ -109,6 +132,10 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 	}
 
 	return px, nil
+}
+
+func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
+	return WithInterface(&SQLWrapper{instance}, config)
 }
 
 func (p *Postgres) Open(url string) (database.Driver, error) {


### PR DESCRIPTION
Hey all,

In our application, we encapsulate our `sql.DB` handles behind an interface so that we can wrap an actual `*sql.DB` with a type that handles things such as logging, collecting metrics, and reporting errors. We'd like to use this same wrapped handle with `golang-migrate` but the fact that the `postgres` driver take a literal `*sql.DB` type makes this not possible.

As a proof-of-concept, I've updated the `database/postgres` driver to have a `WithInterface()` method which takes a `postgres.DB` interface type instead of an `*sql.DB`. I'm curious to get any feedback on this approach. If you like it, I can polish it a little more and update the documentation.

I did not that the drivers packages seem independent (they just return something satisfying the `driver.Driver` interface, so it seems like we could make this change just in the Postgres driver for now (which is the one we depend on).

Thanks!