### PR TITLE
Update Cassandra SSL options

### DIFF
--- a/database/cassandra/cassandra.go
+++ b/database/cassandra/cassandra.go
@@ -121,16 +121,25 @@ func (c *Cassandra) Open(url string) (database.Driver, error) {
 		cluster.Timeout = timeout
 	}
 
-	if len(u.Query().Get("sslmode")) > 0 && len(u.Query().Get("sslrootcert")) > 0 && len(u.Query().Get("sslcert")) > 0 && len(u.Query().Get("sslkey")) > 0 {
+	if len(u.Query().Get("sslmode")) > 0 {
 		if u.Query().Get("sslmode") != "disable" {
-			cluster.SslOpts = &gocql.SslOptions{
-				CaPath:   u.Query().Get("sslrootcert"),
-				CertPath: u.Query().Get("sslcert"),
-				KeyPath:  u.Query().Get("sslkey"),
+			sslOpts := &gocql.SslOptions{}
+
+			if len(u.Query().Get("sslrootcert")) > 0 {
+				sslOpts.CaPath = u.Query().Get("sslrootcert")
 			}
+			if len(u.Query().Get("sslcert")) > 0 {
+				sslOpts.CertPath = u.Query().Get("sslcert")
+			}
+			if len(u.Query().Get("sslkey")) > 0 {
+				sslOpts.KeyPath = u.Query().Get("sslkey")
+			}
+
 			if u.Query().Get("sslmode") == "verify-full" {
-				cluster.SslOpts.EnableHostVerification = true
+				sslOpts.EnableHostVerification = true
 			}
+
+			cluster.SslOpts = sslOpts
 		}
 	}
 


### PR DESCRIPTION
# Cassandra
#### Problem Description
I've run into a problem where if I wanted to just pass the query parameter for [`sslrootcert`](https://github.com/golang-migrate/migrate/tree/master/database/cassandra#usage), I would get a `connection reset by peer` error. This happens because [when the query parameters are parsed by the Cassandra driver](https://github.com/golang-migrate/migrate/blob/master/database/cassandra/cassandra.go#L124), their existence as a whole is verified before any configuration can take place. This is improper, the query parameters should be parsed/verified individually and have their respective SSL options set individually.

