### PR TITLE
Add -f option to drop command

### DIFF
--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -227,15 +227,25 @@ Database drivers: `+strings.Join(database.List(), ", ")+"\n")
 		}
 
 	case "drop":
-		log.Println("Are you sure you want to drop the entire database schema? [y/N]")
-		var response string
-		fmt.Scanln(&response)
-		response = strings.ToLower(strings.TrimSpace(response))
+		dropFlagSet := flag.NewFlagSet("drop", flag.ExitOnError)
+		responseYes := dropFlagSet.Bool("y", false, "Drop the entire database schema")
 
-		if response == "y" {
-			log.Println("Dropping the entire database schema")
-		} else {
-			log.fatal("Aborted dropping the entire database schema")
+		args := flag.Args()[1:]
+		if err := dropFlagSet.Parse(args); err != nil {
+			log.fatalErr(err)
+		}
+
+		if !*responseYes {
+			log.Println("Are you sure you want to drop the entire database schema? [y/N]")
+			var response string
+			fmt.Scanln(&response)
+			response = strings.ToLower(strings.TrimSpace(response))
+
+			if response == "y" {
+				log.Println("Dropping the entire database schema")
+			} else {
+				log.fatal("Aborted dropping the entire database schema")
+			}
 		}
 
 		if migraterErr != nil {

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -228,7 +228,7 @@ Database drivers: `+strings.Join(database.List(), ", ")+"\n")
 
 	case "drop":
 		dropFlagSet := flag.NewFlagSet("drop", flag.ExitOnError)
-		forceDrop := dropFlagSet.Bool("f", false, "Drop the entire database schema")
+		forceDrop := dropFlagSet.Bool("f", false, "Force the drop command by bypassing the confirmation prompt")
 
 		args := flag.Args()[1:]
 		if err := dropFlagSet.Parse(args); err != nil {

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -228,14 +228,14 @@ Database drivers: `+strings.Join(database.List(), ", ")+"\n")
 
 	case "drop":
 		dropFlagSet := flag.NewFlagSet("drop", flag.ExitOnError)
-		responseYes := dropFlagSet.Bool("y", false, "Drop the entire database schema")
+		forceDrop := dropFlagSet.Bool("f", false, "Drop the entire database schema")
 
 		args := flag.Args()[1:]
 		if err := dropFlagSet.Parse(args); err != nil {
 			log.fatalErr(err)
 		}
 
-		if !*responseYes {
+		if !*forceDrop {
 			log.Println("Are you sure you want to drop the entire database schema? [y/N]")
 			var response string
 			fmt.Scanln(&response)


### PR DESCRIPTION
Hi,

This https://github.com/golang-migrate/migrate/pull/360 change caused that the y/n prompt will appears when dropping the database, it has made inoperable our database drop job of kubernetes.
I think that the drop command should have `-y` option for CI/CD operations (Of course, we can also use the yes command, but it is so painful).