### PR TITLE
Register mongodb+srv scheme

### DIFF
--- a/database/mongodb/README.md
+++ b/database/mongodb/README.md
@@ -7,7 +7,7 @@
 
 # Usage
 
-`mongodb://user:password@host:port/dbname?query`
+`mongodb://user:password@host:port/dbname?query` (`mongodb+srv://` work, too)
 
 | URL Query  | WithInstance Config | Description |
 |------------|---------------------|-------------|

--- a/database/mongodb/README.md
+++ b/database/mongodb/README.md
@@ -7,7 +7,7 @@
 
 # Usage
 
-`mongodb://user:password@host:port/dbname?query` (`mongodb+srv://` work, too)
+`mongodb://user:password@host:port/dbname?query` (`mongodb+srv://` also works, but behaves a bit differently. See [docs](https://docs.mongodb.com/manual/reference/connection-string/#dns-seedlist-connection-format) for more information)
 
 | URL Query  | WithInstance Config | Description |
 |------------|---------------------|-------------|

--- a/database/mongodb/mongodb.go
+++ b/database/mongodb/mongodb.go
@@ -16,7 +16,9 @@ import (
 )
 
 func init() {
-	database.Register("mongodb", &Mongo{})
+	db := Mongo{}
+	database.Register("mongodb", &db)
+	database.Register("mongodb+srv", &db)
 }
 
 var DefaultMigrationsCollection = "schema_migrations"


### PR DESCRIPTION
Hi,

`mongodb+srv://` is available as MongoDB URL's scheme, so I added.

See also: https://docs.mongodb.com/manual/reference/connection-string/#dns-seedlist-connection-format
