### PR TITLE
postgres - Force MigrationsTable in 'public' schema

### DIFF
--- a/database/postgres/TUTORIAL.md
+++ b/database/postgres/TUTORIAL.md
@@ -7,7 +7,7 @@ Our user here is `postgres`, password `password`, and host is `localhost`.
 ```
 psql -h localhost -U postgres -w -c "create database example;"
 ```
-When using Migrate CLI we need to pass to database URL. Let's export it to a variable for convienience:
+When using Migrate CLI we need to pass to database URL. Let's export it to a variable for convenience:
 ```
 export POSTGRESQL_URL='postgres://postgres:password@localhost:5432/example?sslmode=disable'
 ```
@@ -157,7 +157,7 @@ When the migrations create the `$user` schema, the next run will store (a new) m
 To solve this you need to change the default `search_path` by removing the `$user` component, so the migrate table is always stored in the (available) `public` schema.
 This can only be done when using migrate from your own code, by creating the `driver` manually, so it can be used to configure the `search_path` before applying the migrations:
 ```golang
-	db, err := sql.Open("postgres", dbURI)
+	db, err := sql.Open("postgres", os.Getenv("POSTGRESQL_URL"))
 	if err != nil {
 		log.Fatalf("Unable to connect to the database: %s", err)
 	}

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -272,7 +272,7 @@ func (p *Postgres) SetVersion(version int, dirty bool) error {
 		return &database.Error{OrigErr: err, Err: "transaction start failed"}
 	}
 
-	query := `TRUNCATE public.` + pq.QuoteIdentifier(p.config.MigrationsTable)
+	query := `TRUNCATE ` + pq.QuoteIdentifier(p.config.MigrationsTable)
 	if _, err := tx.Exec(query); err != nil {
 		if errRollback := tx.Rollback(); errRollback != nil {
 			err = multierror.Append(err, errRollback)
@@ -284,7 +284,7 @@ func (p *Postgres) SetVersion(version int, dirty bool) error {
 	// empty schema version for failed down migration on the first migration
 	// See: https://github.com/golang-migrate/migrate/issues/330
 	if version >= 0 || (version == database.NilVersion && dirty) {
-		query = `INSERT INTO public.` + pq.QuoteIdentifier(p.config.MigrationsTable) +
+		query = `INSERT INTO ` + pq.QuoteIdentifier(p.config.MigrationsTable) +
 			` (version, dirty) VALUES ($1, $2)`
 		if _, err := tx.Exec(query, version, dirty); err != nil {
 			if errRollback := tx.Rollback(); errRollback != nil {
@@ -302,7 +302,7 @@ func (p *Postgres) SetVersion(version int, dirty bool) error {
 }
 
 func (p *Postgres) Version() (version int, dirty bool, err error) {
-	query := `SELECT version, dirty FROM public.` + pq.QuoteIdentifier(p.config.MigrationsTable) + ` LIMIT 1`
+	query := `SELECT version, dirty FROM ` + pq.QuoteIdentifier(p.config.MigrationsTable) + ` LIMIT 1`
 	err = p.conn.QueryRowContext(context.Background(), query).Scan(&version, &dirty)
 	switch {
 	case err == sql.ErrNoRows:
@@ -380,7 +380,7 @@ func (p *Postgres) ensureVersionTable() (err error) {
 		}
 	}()
 
-	query := `CREATE TABLE IF NOT EXISTS public.` + pq.QuoteIdentifier(p.config.MigrationsTable) + ` (version bigint not null primary key, dirty boolean not null)`
+	query := `CREATE TABLE IF NOT EXISTS ` + pq.QuoteIdentifier(p.config.MigrationsTable) + ` (version bigint not null primary key, dirty boolean not null)`
 	if _, err = p.conn.ExecContext(context.Background(), query); err != nil {
 		return &database.Error{OrigErr: err, Query: []byte(query)}
 	}

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -272,7 +272,7 @@ func (p *Postgres) SetVersion(version int, dirty bool) error {
 		return &database.Error{OrigErr: err, Err: "transaction start failed"}
 	}
 
-	query := `TRUNCATE ` + pq.QuoteIdentifier(p.config.MigrationsTable)
+	query := `TRUNCATE public.` + pq.QuoteIdentifier(p.config.MigrationsTable)
 	if _, err := tx.Exec(query); err != nil {
 		if errRollback := tx.Rollback(); errRollback != nil {
 			err = multierror.Append(err, errRollback)
@@ -284,7 +284,7 @@ func (p *Postgres) SetVersion(version int, dirty bool) error {
 	// empty schema version for failed down migration on the first migration
 	// See: https://github.com/golang-migrate/migrate/issues/330
 	if version >= 0 || (version == database.NilVersion && dirty) {
-		query = `INSERT INTO ` + pq.QuoteIdentifier(p.config.MigrationsTable) +
+		query = `INSERT INTO public.` + pq.QuoteIdentifier(p.config.MigrationsTable) +
 			` (version, dirty) VALUES ($1, $2)`
 		if _, err := tx.Exec(query, version, dirty); err != nil {
 			if errRollback := tx.Rollback(); errRollback != nil {
@@ -302,7 +302,7 @@ func (p *Postgres) SetVersion(version int, dirty bool) error {
 }
 
 func (p *Postgres) Version() (version int, dirty bool, err error) {
-	query := `SELECT version, dirty FROM ` + pq.QuoteIdentifier(p.config.MigrationsTable) + ` LIMIT 1`
+	query := `SELECT version, dirty FROM public.` + pq.QuoteIdentifier(p.config.MigrationsTable) + ` LIMIT 1`
 	err = p.conn.QueryRowContext(context.Background(), query).Scan(&version, &dirty)
 	switch {
 	case err == sql.ErrNoRows:
@@ -380,7 +380,7 @@ func (p *Postgres) ensureVersionTable() (err error) {
 		}
 	}()
 
-	query := `CREATE TABLE IF NOT EXISTS ` + pq.QuoteIdentifier(p.config.MigrationsTable) + ` (version bigint not null primary key, dirty boolean not null)`
+	query := `CREATE TABLE IF NOT EXISTS public.` + pq.QuoteIdentifier(p.config.MigrationsTable) + ` (version bigint not null primary key, dirty boolean not null)`
 	if _, err = p.conn.ExecContext(context.Background(), query); err != nil {
 		return &database.Error{OrigErr: err, Query: []byte(query)}
 	}


### PR DESCRIPTION
I ran into troubles when I migrated a new schema in the database:
* on first run all was ok, and `MigrationsTable` was stored in `public` schema (in empty DB this was only available schema)
* on next run, `MigrationsTable` was stored in created schema, as it was not available (obviously), the migrations were (tried to) run again, resulting in the dirty flag set in the 'new' `MigrationsTable`
I am not entirely sure how this happened, because the 'default schema' is not changed, so it should be/stay be public.

This PR forces the `MigrationsTable` in public schema.

I chose this approach (and not using `SchemaName`) to be backwards compatible, if requested I can modify the PR to use `SchemaName` instead of 'public' for the `MigrationsTable` location.