### PR TITLE
docs(spanner): clarify how to set parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Database drivers run migrations. [Add a new database?](database/driver.go)
 
 ### Database URLs
 
-Database connection strings are specified via URLs. The URL format is driver dependent but generally has the form: `dbdriver://username:password@host:port/dbname?option1=true&option2=false`
+Database connection strings are specified via URLs. The URL format is driver dependent but generally has the form: `dbdriver://username:password@host:port/dbname?param1=true&param2=false`
 
 Any [reserved URL characters](https://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_reserved_characters) need to be escaped. Note, the `%` character also [needs to be escaped](https://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_the_percent_character)
 

--- a/database/spanner/README.md
+++ b/database/spanner/README.md
@@ -2,12 +2,14 @@
 
 ## Usage
 
+See [Google Spanner Documentation](https://cloud.google.com/spanner/docs) for
+more details.
+
 The DSN must be given in the following format.
 
-`spanner://projects/{projectId}/instances/{instanceId}/databases/{databaseName}`
+`spanner://projects/{projectId}/instances/{instanceId}/databases/{databaseName}?param=true`
 
-See [Google Spanner Documentation](https://cloud.google.com/spanner/docs) for details.
-
+as described in [README.md#database-urls](../../README.md#database-urls)
 
 | Param | WithInstance Config | Description |
 | ----- | ------------------- | ----------- |
@@ -17,7 +19,6 @@ See [Google Spanner Documentation](https://cloud.google.com/spanner/docs) for de
 | `projectId` || The Google Cloud Platform project id
 | `instanceId` || The id of the instance running Spanner
 | `databaseName` || The name of the Spanner database
-
 
 > **Note:** Google Cloud Spanner migrations can take a considerable amount of 
 > time. The migrations provided as part of the example take about 6 minutes to 


### PR DESCRIPTION
- include param in DSN example                                           
- link to README docs on param (option) format                           
- switch to 'parameter' instead of 'option', in the main README, since this is preferred                    

While this is documented, I think this will make it more clear what the options are called and how to set them (context: #425)