### PR TITLE
`NoLock` config option for mysql driver

### DIFF
--- a/database/mysql/README.md
+++ b/database/mysql/README.md
@@ -5,6 +5,7 @@
 | URL Query  | WithInstance Config | Description |
 |------------|---------------------|-------------|
 | `x-migrations-table` | `MigrationsTable` | Name of the migrations table |
+| `x-no-lock` | `NoLock` | Set to `true` to skip `GET_LOCK`/`RELEASE_LOCK` statements. Useful for [multi-master MySQL flavors](https://www.percona.com/doc/percona-xtradb-cluster/LATEST/features/pxc-strict-mode.html#explicit-table-locking). Only run migrations from one host when this is enabled. |
 | `dbname` | `DatabaseName` | The name of the database to connect to |
 | `user` | | The user to sign in as |
 | `password` | | The user's password | 

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -200,6 +200,14 @@ func (m *Mysql) Open(url string) (database.Driver, error) {
 		return nil, err
 	}
 
+	noLockParam, noLock := customParams["x-no-lock"], false
+	if noLockParam != "" {
+		noLock, err = strconv.ParseBool(noLockParam)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse x-no-lock as bool: %w", err)
+		}
+	}
+
 	db, err := sql.Open("mysql", config.FormatDSN())
 	if err != nil {
 		return nil, err
@@ -208,7 +216,7 @@ func (m *Mysql) Open(url string) (database.Driver, error) {
 	mx, err := WithInstance(db, &Config{
 		DatabaseName:    config.DBName,
 		MigrationsTable: customParams["x-migrations-table"],
-		NoLock:          customParams["x-no-lock"] == "true",
+		NoLock:          noLock,
 	})
 	if err != nil {
 		return nil, err

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -41,6 +41,7 @@ var (
 type Config struct {
 	MigrationsTable string
 	DatabaseName    string
+	NoLock          bool
 }
 
 type Mysql struct {
@@ -207,6 +208,7 @@ func (m *Mysql) Open(url string) (database.Driver, error) {
 	mx, err := WithInstance(db, &Config{
 		DatabaseName:    config.DBName,
 		MigrationsTable: customParams["x-migrations-table"],
+		NoLock:          customParams["x-no-lock"] == "true",
 	})
 	if err != nil {
 		return nil, err
@@ -227,6 +229,11 @@ func (m *Mysql) Close() error {
 func (m *Mysql) Lock() error {
 	if m.isLocked {
 		return database.ErrLocked
+	}
+
+	if m.config.NoLock {
+		m.isLocked = true
+		return nil
 	}
 
 	aid, err := database.GenerateAdvisoryLockId(
@@ -251,6 +258,11 @@ func (m *Mysql) Lock() error {
 
 func (m *Mysql) Unlock() error {
 	if !m.isLocked {
+		return nil
+	}
+
+	if m.config.NoLock {
+		m.isLocked = false
 		return nil
 	}
 

--- a/database/mysql/mysql_test.go
+++ b/database/mysql/mysql_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"database/sql"
 	sqldriver "database/sql/driver"
+	"errors"
 	"fmt"
 	"log"
+	"strconv"
 	"testing"
 )
 
@@ -173,6 +175,17 @@ func TestLockWorks(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+}
+
+func TestNoLockParamValidation(t *testing.T) {
+	ip := "127.0.0.1"
+	port := 3306
+	addr := fmt.Sprintf("mysql://root:root@tcp(%v:%v)/public", ip, port)
+	p := &Mysql{}
+	_, err := p.Open(addr + "?x-no-lock=not-a-bool")
+	if !errors.Is(err, strconv.ErrSyntax) {
+		t.Fatal("Expected syntax error when passing a non-bool as x-no-lock parameter")
+	}
 }
 
 func TestNoLockWorks(t *testing.T) {


### PR DESCRIPTION
Skipping `GET_LOCK`/`RELEASE_LOCK` is useful when running MySQL as
multi-master. This change simply disables the locking.

The internal client lock is left in place as a sanity check.

Fixes #215 