### PR TITLE
Update driver.go

### DIFF
--- a/source/driver.go
+++ b/source/driver.go
@@ -87,7 +87,7 @@ func Open(url string) (Driver, error) {
 	d, ok := drivers[u.Scheme]
 	driversMu.RUnlock()
 	if !ok {
-		return nil, fmt.Errorf("source driver: unknown driver %v (forgotten import?)", u.Scheme)
+		return nil, fmt.Errorf("source driver: unknown driver '%v' (forgotten import?)", u.Scheme)
 	}
 
 	return d.Open(url)

--- a/source/driver.go
+++ b/source/driver.go
@@ -87,7 +87,7 @@ func Open(url string) (Driver, error) {
 	d, ok := drivers[u.Scheme]
 	driversMu.RUnlock()
 	if !ok {
-		return nil, fmt.Errorf("source driver: unknown driver '%v' (forgotten import?)", u.Scheme)
+		return nil, fmt.Errorf("source driver: unknown driver '%s' (forgotten import?)", u.Scheme)
 	}
 
 	return d.Open(url)


### PR DESCRIPTION
I've stumbled upon the `source driver: unknown driver file (forgotten import?)` error which has been reported as an issue multiple times. 

This is a tiny proposal that might make the error message more readable:
instead of `source driver: unknown driver file (forgotten import?)`, the message can be `source driver: unknown driver 'file' (forgotten import?)` to indicate that 'file' is the type of the driver