### PR TITLE
Document drop -f in migrate -help

### DIFF
--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -54,7 +54,7 @@ Commands:
   goto V       Migrate to version V
   up [N]       Apply all or N up migrations
   down [N]     Apply all or N down migrations
-  drop         Drop everything inside database
+  drop         Drop everything inside database (use -f to bypass confirmation)
   force V      Set version V but don't run migration (ignores dirty state)
   version      Print current migration version
 

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -54,7 +54,8 @@ Commands:
   goto V       Migrate to version V
   up [N]       Apply all or N up migrations
   down [N]     Apply all or N down migrations
-  drop         Drop everything inside database (use -f to bypass confirmation)
+  drop [-f]    Drop everything inside database
+               Use -f to bypass confirmation
   force V      Set version V but don't run migration (ignores dirty state)
   version      Print current migration version
 


### PR DESCRIPTION
I started testing my migrations in CI/CD -- both up and down.

I wanted to bypass the `Are you sure you want to drop the entire database schema? [y/N]` and couldn't figure out how.

Then I found it [in the code](https://github.com/golang-migrate/migrate/blob/524edc9f0be42a2dbd47780d0d570308030c07e0/internal/cli/main.go#L231).

This `-f` feature is not documented in the `migrate -help` usage.   I added the phrase `(use -f to bypass confirmation)`.

Another option is to try to print out the Golang flag options, but that's a much bigger change and the simple usage doc is sufficient.