### PR TITLE
add in memory source driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SOURCE ?= file go_bindata github github_ee bitbucket aws_s3 google_cloud_storage godoc_vfs gitlab
+SOURCE ?= file go_bindata github github_ee bitbucket aws_s3 google_cloud_storage godoc_vfs gitlab inmem
 DATABASE ?= postgres mysql redshift cassandra spanner cockroachdb clickhouse mongodb sqlserver firebird neo4j
 DATABASE_TEST ?= $(DATABASE) sqlite sqlcipher
 VERSION ?= $(shell git describe --tags 2>/dev/null | cut -c 2-)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Source drivers read migrations from local or remote sources. [Add a new source?]
 * [Gitlab](source/gitlab) - read from remote Gitlab repositories
 * [AWS S3](source/aws_s3) - read from Amazon Web Services S3
 * [Google Cloud Storage](source/google_cloud_storage) - read from Google Cloud Platform Storage
+* [In Memory](source/inmem) - read from defined struct to embed schema migration with program binary
 
 ## CLI usage
 

--- a/source/inmem/README.md
+++ b/source/inmem/README.md
@@ -1,0 +1,77 @@
+# inmem
+
+In memory (`inmem`) driver useful when you want to always includes your database schema migration along with your binary.
+
+
+## Usage
+
+There are 2 way to use in memory migration driver:
+
+* Using `WithInstance` so you can use it anywhere without worrying about `key` identifier conflict. Or
+* Using `RegisterMigrations` so you can migrate from anywhere in your code using `key` in URL.
+
+Whichever the method you use, you still need to implement `inmem.Migration` for all your migration schema.
+
+### Implements `inmem.Migration`
+
+Create struct and implement all method receiver for `inmam.Migration`:
+
+```go
+type DummyMigration struct {
+	Ver       uint
+	UpQuery   string
+	DownQuery string
+}
+
+func (m DummyMigration) Version() uint { return m.Ver }
+
+func (m DummyMigration) Up() string { return m.UpQuery }
+
+func (m DummyMigration) Down() string { return m.DownQuery }
+
+var _ inmem.Migration = (*DummyMigration)(nil)
+```
+
+
+### Using `WithInstance`
+```go
+import (
+  "github.com/golang-migrate/migrate/v4"
+  "github.com/golang-migrate/migrate/v4/source/inmem"
+)
+
+func main() {
+    createUserTable := &DummyMigration{
+		Ver:       1,
+		UpQuery:   "CREATE TABLE IF NOT EXISTS users(id bigint primary key, username varchar);",
+		DownQuery: "DROP TABLE IF EXISTS users;",
+	}
+
+	driver, err := inmem.WithInstance(createUserTable)
+	m, err := migrate.NewWithSourceInstance("inmem", driver, "database://foobar")
+	m.Up() // run your migrations and handle the errors above of course
+}
+```
+
+### Using `RegisterMigrations`
+
+```go
+import (
+  "github.com/golang-migrate/migrate/v4"
+  "github.com/golang-migrate/migrate/v4/source/inmem"
+)
+
+func main() {
+    createUserTable := &DummyMigration{
+		Ver:       1,
+		UpQuery:   "CREATE TABLE IF NOT EXISTS users(id bigint primary key, username varchar);",
+		DownQuery: "DROP TABLE IF EXISTS users;",
+	}
+
+	key := "myUniqueKey"
+	err := inmem.RegisterMigrations(key, createUserTable)
+	m, err := migrate.New("inmem://"+key, "database://foobar")
+	err = m.Up() // run your migrations and handle the errors above of course
+}
+```
+

--- a/source/inmem/errors.go
+++ b/source/inmem/errors.go
@@ -1,0 +1,24 @@
+package inmem
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrEmptyKey         = errors.New("key is empty")
+	ErrNilMigration     = errors.New("some migration(s) is nil")
+	ErrEmptyUrl         = errors.New("url is empty")
+	ErrInvalidUrlScheme = errors.New("url scheme must be inmem://")
+)
+
+// ErrDuplicateVersion error type when duplicate version occurred
+type ErrDuplicateVersion struct {
+	key string
+	ver uint
+}
+
+// Error implements Go error interface
+func (e ErrDuplicateVersion) Error() string {
+	return fmt.Sprintf("duplicate version %d for existing key '%s'", e.ver, e.key)
+}

--- a/source/inmem/errors_test.go
+++ b/source/inmem/errors_test.go
@@ -1,0 +1,16 @@
+package inmem
+
+import (
+	"testing"
+
+	"github.com/bmizerany/assert"
+)
+
+func TestErrDuplicateVersion_Error(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	err := ErrDuplicateVersion{}
+	assert.Equal(t, ErrDuplicateVersion{}.Error(), err.Error())
+}

--- a/source/inmem/example_test.go
+++ b/source/inmem/example_test.go
@@ -1,0 +1,70 @@
+package inmem_test
+
+import (
+	"testing"
+
+	"github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	"github.com/golang-migrate/migrate/v4/source/inmem"
+)
+
+type DummyMigration struct {
+	Ver       uint
+	UpQuery   string
+	DownQuery string
+}
+
+func (m DummyMigration) Version() uint { return m.Ver }
+
+func (m DummyMigration) Up() string { return m.UpQuery }
+
+func (m DummyMigration) Down() string { return m.DownQuery }
+
+var _ inmem.Migration = (*DummyMigration)(nil)
+
+func TestMemory_WithInstance(t *testing.T) {
+	createUserTable := &DummyMigration{
+		Ver:       1,
+		UpQuery:   "CREATE TABLE IF NOT EXISTS users(id bigint primary key, username varchar);",
+		DownQuery: "DROP TABLE IF EXISTS users;",
+	}
+
+	driver, _ := inmem.WithInstance(createUserTable)
+	m, err := migrate.NewWithSourceInstance("inmem", driver, "database://foobar")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	err = m.Up() // run your migrations and handle the errors above of course
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+}
+
+func TestMemory_RegisterMigrations(t *testing.T) {
+	createUserTable := &DummyMigration{
+		Ver:       1,
+		UpQuery:   "CREATE TABLE IF NOT EXISTS users(id bigint primary key, username varchar);",
+		DownQuery: "DROP TABLE IF EXISTS users;",
+	}
+
+	key := "myUniqueKey"
+	err := inmem.RegisterMigrations(key, createUserTable)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	m, err := migrate.New("inmem://"+key, "database://foobar")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	err = m.Up() // run your migrations and handle the errors above of course
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+}

--- a/source/inmem/local.go
+++ b/source/inmem/local.go
@@ -1,0 +1,74 @@
+package inmem
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/golang-migrate/migrate/v4/source"
+)
+
+const (
+	schemeKey = "inmem"
+	scheme    = schemeKey + "://" // construct inmem:// as scheme in Open function
+)
+
+// localMemory saves all *source.Migrations mapped by key
+type localMemory struct {
+	lock       sync.RWMutex
+	data       map[string]*source.Migrations
+	versionLog map[string]uint
+}
+
+// migrations is a local global variables to save any source.Migrations
+var migrations = &localMemory{
+	data:       make(map[string]*source.Migrations),
+	versionLog: make(map[string]uint),
+}
+
+// RegisterMigrations add new migrations for given key.
+// You can add migrations struct in go routine.
+func RegisterMigrations(key string, mig ...Migration) error {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return ErrEmptyKey
+	}
+
+	migrations.lock.Lock()
+	defer migrations.lock.Unlock()
+
+	// Create new instance on map if not exist
+	if m, exist := migrations.data[key]; !exist || m == nil {
+		migrations.data[key] = source.NewMigrations()
+	}
+
+	for _, m := range mig {
+		if m == nil {
+			return ErrNilMigration
+		}
+
+		if v, exist := migrations.versionLog[key]; exist && v == m.Version() {
+			return ErrDuplicateVersion{
+				key: key,
+				ver: m.Version(),
+			}
+		}
+
+		migrations.versionLog[key] = m.Version()
+		migrations.data[key].Append(&source.Migration{
+			Version:    m.Version(),
+			Identifier: m.Up(),
+			Direction:  source.Up,
+			Raw:        fmt.Sprintf("%d.memory.up", m.Version()),
+		})
+
+		migrations.data[key].Append(&source.Migration{
+			Version:    m.Version(),
+			Identifier: m.Down(),
+			Direction:  source.Down,
+			Raw:        fmt.Sprintf("%d.memory.down", m.Version()),
+		})
+	}
+
+	return nil
+}

--- a/source/inmem/local_test.go
+++ b/source/inmem/local_test.go
@@ -1,0 +1,52 @@
+package inmem
+
+import (
+	"testing"
+
+	"github.com/bmizerany/assert"
+)
+
+func TestRegisterMigrations_ErrEmptyKey(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	err := RegisterMigrations("")
+	assert.Equal(t, ErrEmptyKey, err)
+}
+
+func TestRegisterMigrations_EmptyMap(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	err := RegisterMigrations(testKey)
+	assert.Equal(t, nil, err)
+}
+
+func TestRegisterMigrations_ErrNilMigration(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	err := RegisterMigrations(testKey, nil)
+	assert.Equal(t, ErrNilMigration, err)
+}
+
+func TestRegisterMigrations_ErrDuplicateVersion(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	err := RegisterMigrations(testKey, firstMigration, firstMigration)
+	assert.NotEqual(t, nil, err)
+}
+
+func TestRegisterMigration(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	err := RegisterMigrations(testKey, firstMigration, secondMigration)
+	assert.Equal(t, nil, err)
+}

--- a/source/inmem/memory.go
+++ b/source/inmem/memory.go
@@ -1,0 +1,189 @@
+package inmem
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/golang-migrate/migrate/v4/source"
+)
+
+// init register to the source.Driver so it can be used easily
+func init() {
+	source.Register(schemeKey, &Memory{})
+}
+
+// Migration is an interface that holds migration info
+type Migration interface {
+	Version() uint
+	Up() string
+	Down() string
+}
+
+// Memory implements source.Driver interface and hold in memory migration
+type Memory struct {
+	lock           sync.RWMutex
+	currKey        string
+	migrationsData *source.Migrations
+}
+
+// Ensures that Memory implements source.Driver
+var _ source.Driver = (*Memory)(nil)
+
+// WithInstance creates new instance using Memory driver.
+func WithInstance(mig ...Migration) (source.Driver, error) {
+	mem := &Memory{
+		currKey:        "WithInstance",
+		migrationsData: source.NewMigrations(),
+	}
+
+	mem.lock.Lock()
+	defer mem.lock.Unlock()
+
+	for _, m := range mig {
+		if m == nil {
+			return nil, ErrNilMigration
+		}
+
+		mem.migrationsData.Append(&source.Migration{
+			Version:    m.Version(),
+			Identifier: m.Up(),
+			Direction:  source.Up,
+			Raw:        fmt.Sprintf("%d.instance_memory.up", m.Version()),
+		})
+
+		mem.migrationsData.Append(&source.Migration{
+			Version:    m.Version(),
+			Identifier: m.Down(),
+			Direction:  source.Down,
+			Raw:        fmt.Sprintf("%d.instance_memory.down", m.Version()),
+		})
+	}
+
+	return mem, nil
+}
+
+// Open create new source.Driver using Memory based on url string.
+// url string should contain format: `inmem://{key}`
+// where `{key}` is a unique identifier registered using RegisterMigrations method.
+// ErrEmptyKey returned when key is not found, or other error will be thrown if unexpected things happen.
+// This is part of source.Driver interface implementation.
+func (m *Memory) Open(url string) (source.Driver, error) {
+	url = strings.TrimSpace(url)
+	if url == "" {
+		return nil, ErrEmptyUrl
+	}
+
+	if !strings.HasPrefix(url, scheme) {
+		return nil, ErrInvalidUrlScheme
+	}
+
+	key := strings.TrimPrefix(url, scheme)
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return nil, ErrEmptyKey
+	}
+
+	migrations.lock.Lock()
+	defer migrations.lock.Unlock()
+	srcMigration, exist := migrations.data[key]
+	if !exist {
+		return nil, ErrNilMigration
+	}
+
+	return &Memory{
+		currKey:        key,
+		migrationsData: srcMigration,
+	}, nil
+}
+
+// Close always return nil since there is nothing to close.
+// This is part of source.Driver interface implementation.
+func (m *Memory) Close() error {
+	return nil
+}
+
+// First returns first migration data after sorted by version in ascending order.
+// This is part of source.Driver interface implementation.
+func (m *Memory) First() (version uint, err error) {
+	if v, ok := m.migrationsData.First(); ok {
+		return v, nil
+	}
+
+	err = &os.PathError{
+		Op:   "first",
+		Path: fmt.Sprintf("%s%s", scheme, m.currKey),
+		Err:  os.ErrNotExist,
+	}
+	return
+}
+
+// Prev return previous version of current version value.
+// This is part of source.Driver interface implementation.
+func (m *Memory) Prev(version uint) (prevVersion uint, err error) {
+	if v, ok := m.migrationsData.Prev(version); ok {
+		return v, nil
+	}
+
+	err = &os.PathError{
+		Op:   fmt.Sprintf("prev for version %v", version),
+		Path: fmt.Sprintf("%s%s", scheme, m.currKey),
+		Err:  os.ErrNotExist,
+	}
+	return
+}
+
+// Next return next version of current version value.
+// This is part of source.Driver interface implementation.
+func (m *Memory) Next(version uint) (nextVersion uint, err error) {
+	if v, ok := m.migrationsData.Next(version); ok {
+		return v, nil
+	}
+
+	err = &os.PathError{
+		Op:   fmt.Sprintf("next for version %v", version),
+		Path: fmt.Sprintf("%s%s", scheme, m.currKey),
+		Err:  os.ErrNotExist,
+	}
+	return
+}
+
+// ReadUp return the query that needs to be executed on source.Up command.
+// This is part of source.Driver interface implementation.
+func (m *Memory) ReadUp(version uint) (r io.ReadCloser, identifier string, err error) {
+	migration, ok := m.migrationsData.Up(version)
+	if !ok {
+		err = &os.PathError{
+			Op:   fmt.Sprintf("read up version %v", version),
+			Path: fmt.Sprintf("%s%s", scheme, m.currKey),
+			Err:  os.ErrNotExist,
+		}
+		return
+	}
+
+	r = ioutil.NopCloser(bytes.NewBufferString(migration.Identifier))
+	identifier = fmt.Sprintf("%d.memory.up", version)
+	return
+}
+
+// ReadDown return the query that needs to be executed on source.Down command.
+// This is part of source.Driver interface implementation.
+func (m *Memory) ReadDown(version uint) (r io.ReadCloser, identifier string, err error) {
+	migration, ok := m.migrationsData.Down(version)
+	if !ok {
+		err = &os.PathError{
+			Op:   fmt.Sprintf("read down version %v", version),
+			Path: fmt.Sprintf("%s%s", scheme, m.currKey),
+			Err:  os.ErrNotExist,
+		}
+		return
+	}
+
+	r = ioutil.NopCloser(bytes.NewBufferString(migration.Identifier))
+	identifier = fmt.Sprintf("%d.memory.down", version)
+	return
+}

--- a/source/inmem/memory_test.go
+++ b/source/inmem/memory_test.go
@@ -1,0 +1,293 @@
+package inmem
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/bmizerany/assert"
+	"github.com/golang-migrate/migrate/v4/source"
+)
+
+const (
+	testKey = "key"
+)
+
+type testCaseKeyEmptiness struct {
+	key string
+	err error
+}
+
+var testCasesKey = []testCaseKeyEmptiness{
+	{
+		key: "",
+		err: ErrEmptyKey,
+	},
+	{
+		key: " ",
+		err: ErrEmptyKey,
+	},
+	{
+		key: "   ", // more spaces
+		err: ErrEmptyKey,
+	},
+	{
+		key: "	", // tabs
+		err: ErrEmptyKey,
+	},
+}
+
+type mockMigration struct {
+	Ver       uint
+	UpQuery   string
+	DownQuery string
+}
+
+func (m mockMigration) Version() uint { return m.Ver }
+
+func (m mockMigration) Up() string { return m.UpQuery }
+
+func (m mockMigration) Down() string { return m.DownQuery }
+
+var _ Migration = (*mockMigration)(nil)
+
+var firstMigration = &mockMigration{
+	Ver:       1,
+	UpQuery:   "1.up",
+	DownQuery: "1.down",
+}
+
+var secondMigration = mockMigration{
+	Ver:       2,
+	UpQuery:   "2.up",
+	DownQuery: "2.down",
+}
+
+// testMigrations only contains 2 migration versions
+// this is a mock data
+var testMigrations = []Migration{firstMigration, secondMigration}
+
+var clear = func() {
+	migrations = &localMemory{
+		data:       make(map[string]*source.Migrations),
+		versionLog: make(map[string]uint),
+	}
+}
+
+func TestWithInstance_ErrNilMigration(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	driver, err := WithInstance(nil)
+	assert.Equal(t, nil, driver)
+	assert.Equal(t, ErrNilMigration, err)
+}
+
+func TestWithInstance(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	driver, err := WithInstance(testMigrations...)
+	assert.NotEqual(t, nil, driver)
+	assert.Equal(t, nil, err)
+}
+
+func TestMemory_Open_ErrEmptyUrl(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	m := new(Memory)
+	driver, err := m.Open("")
+	assert.Equal(t, nil, driver)
+	assert.Equal(t, ErrEmptyUrl, err)
+}
+
+func TestMemory_Open_ErrInvalidUrlScheme(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	m := new(Memory)
+	driver, err := m.Open("invalidScheme://key")
+	assert.Equal(t, nil, driver)
+	assert.Equal(t, ErrInvalidUrlScheme, err)
+}
+
+func TestMemory_Open_ErrEmptyKey(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	m := new(Memory)
+	for _, caseData := range testCasesKey {
+		driver, err := m.Open(scheme + caseData.key)
+		assert.Equal(t, nil, driver)
+		assert.Equal(t, caseData.err, err)
+	}
+
+}
+
+func TestMemory_Open_ErrNilMigration(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	m := new(Memory)
+	driver, err := m.Open(scheme + "notExist")
+	assert.Equal(t, nil, driver)
+	assert.Equal(t, ErrNilMigration, err)
+}
+
+func TestMemory_Close(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	m := new(Memory)
+	err := m.Close()
+	assert.Equal(t, nil, err)
+}
+
+func TestMemory_First(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	m, err := WithInstance(testMigrations...)
+	assert.Equal(t, nil, err)
+
+	v, err := m.First()
+	assert.Equal(t, firstMigration.Version(), v)
+	assert.Equal(t, nil, err)
+}
+
+func TestMemory_First_Error(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	m, err := WithInstance()
+	assert.Equal(t, nil, err)
+
+	v, err := m.First()
+	assert.Equal(t, uint(0), v)
+	assert.NotEqual(t, nil, err)
+}
+
+func TestMemory_Prev(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	m, err := WithInstance(testMigrations...)
+	assert.Equal(t, nil, err)
+
+	v, err := m.Prev(secondMigration.Version())
+	assert.Equal(t, firstMigration.Version(), v)
+	assert.Equal(t, nil, err)
+}
+
+func TestMemory_Prev_Error(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	m, err := WithInstance()
+	assert.Equal(t, nil, err)
+
+	v, err := m.Prev(secondMigration.Version())
+	assert.Equal(t, uint(0), v)
+	assert.NotEqual(t, nil, err)
+}
+
+func TestMemory_Next(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	m, err := WithInstance(testMigrations...)
+	assert.Equal(t, nil, err)
+
+	v, err := m.Next(firstMigration.Version())
+	assert.Equal(t, secondMigration.Version(), v)
+	assert.Equal(t, nil, err)
+}
+
+func TestMemory_Next_Error(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	m, err := WithInstance()
+	assert.Equal(t, nil, err)
+
+	v, err := m.Next(firstMigration.Version())
+	assert.Equal(t, uint(0), v)
+	assert.NotEqual(t, nil, err)
+}
+
+func TestMemory_ReadUp(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	m, err := WithInstance(testMigrations...)
+	assert.Equal(t, nil, err)
+
+	reader, identifier, err := m.ReadUp(firstMigration.Version())
+	assert.NotEqual(t, "", identifier)
+	assert.Equal(t, nil, err)
+
+	exp, err := ioutil.ReadAll(reader)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, string(exp), firstMigration.Up())
+
+}
+
+func TestMemory_ReadUp_Error(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	m, err := WithInstance()
+	assert.Equal(t, nil, err)
+
+	reader, identifier, err := m.ReadUp(firstMigration.Version())
+	assert.Equal(t, nil, reader)
+	assert.Equal(t, "", identifier)
+	assert.NotEqual(t, nil, err)
+}
+
+func TestMemory_ReadDown(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	m, err := WithInstance(testMigrations...)
+	assert.Equal(t, nil, err)
+
+	reader, identifier, err := m.ReadDown(firstMigration.Version())
+	assert.NotEqual(t, "", identifier)
+	assert.Equal(t, nil, err)
+
+	exp, err := ioutil.ReadAll(reader)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, string(exp), firstMigration.Down())
+
+}
+
+func TestMemory_ReadDown_Error(t *testing.T) {
+	t.Cleanup(func() {
+		clear()
+	})
+
+	m, err := WithInstance()
+	assert.Equal(t, nil, err)
+
+	reader, identifier, err := m.ReadDown(firstMigration.Version())
+	assert.Equal(t, nil, reader)
+	assert.Equal(t, "", identifier)
+	assert.NotEqual(t, nil, err)
+}


### PR DESCRIPTION
In my previous company, we develop a program that can be installed in our client system as an on-premise installation. We usually using go-bindata and currently is not maintained by anyone. 

I think having some native "in-memory" or "local" database schema migration by implement defined interface in this `golang-migrate/migrate/source/inmem` package will give user more control about their code rather than generate text file into Go code. This is because in the end, after writing `.down` and `.up` files, user needs to convert it using tool like go-bindata or pkger.