### PR TITLE
fix test on windows

### DIFF
--- a/source/testing/testing.go
+++ b/source/testing/testing.go
@@ -131,7 +131,7 @@ func TestReadUp(t *testing.T, d source.Driver) {
 		}
 		if up != nil {
 			if err := up.Close(); err != nil {
-				t.Log(err)
+				t.Error(err)
 			}
 		}
 	}
@@ -173,7 +173,7 @@ func TestReadDown(t *testing.T, d source.Driver) {
 		}
 		if down != nil {
 			if err := down.Close(); err != nil {
-				t.Log(err)
+				t.Error(err)
 			}
 		}
 	}

--- a/source/testing/testing.go
+++ b/source/testing/testing.go
@@ -129,6 +129,11 @@ func TestReadUp(t *testing.T, d source.Driver) {
 				t.Errorf("expected up to be nil, got %v, in %v", up, i)
 			}
 		}
+		if up != nil {
+			if err := up.Close(); err != nil {
+				t.Log(err)
+			}
+		}
 	}
 }
 
@@ -164,6 +169,11 @@ func TestReadDown(t *testing.T, d source.Driver) {
 				t.Errorf("expected down not to be nil, in %v", i)
 			} else if !v.expectDown && down != nil {
 				t.Errorf("expected down to be nil, got %v, in %v", down, i)
+			}
+		}
+		if down != nil {
+			if err := down.Close(); err != nil {
+				t.Log(err)
 			}
 		}
 	}


### PR DESCRIPTION
On Windows, the test fails because os.Remove cannot remove unclosed and still-handled files.