### PR TITLE
Postgres - Add schema name support in x-migrations-table value (#95)

### DIFF
--- a/database/postgres/README.md
+++ b/database/postgres/README.md
@@ -2,22 +2,23 @@
 
 `postgres://user:password@host:port/dbname?query` (`postgresql://` works, too)
 
-| URL Query  | WithInstance Config | Description |
-|------------|---------------------|-------------|
-| `x-migrations-table` | `MigrationsTable` | Name of the migrations table |
-| `x-statement-timeout` | `StatementTimeout` | Abort any statement that takes more than the specified number of milliseconds |
-| `dbname` | `DatabaseName` | The name of the database to connect to |
-| `search_path` | | This variable specifies the order in which schemas are searched when an object is referenced by a simple name with no schema specified. |
-| `user` | | The user to sign in as |
-| `password` | | The user's password | 
-| `host` | | The host to connect to. Values that start with / are for unix domain sockets. (default is localhost) |
-| `port` | | The port to bind to. (default is 5432) |
-| `fallback_application_name` | | An application_name to fall back to if one isn't provided. |
-| `connect_timeout` | | Maximum wait for connection, in seconds. Zero or not specified means wait indefinitely. |
-| `sslcert` | | Cert file location. The file must contain PEM encoded data. |
-| `sslkey` | | Key file location. The file must contain PEM encoded data. |
-| `sslrootcert` | | The location of the root certificate file. The file must contain PEM encoded data. | 
-| `sslmode` | | Whether or not to use SSL (disable\|require\|verify-ca\|verify-full) |
+| URL Query  | WithInstance Config | Description | Default value |
+|------------|---------------------|-------------|---------------|
+| `x-migrations-table-has-schema` | `MigrationsTableHasSchema` | Enable schema name support in `x-migrations-table` parameter | `false` |
+| `x-migrations-table` | `MigrationsTable` | Name of the migrations table, if `x-migrations-table-has-schema` is enabled then the first dot is treated as the schema and table name separator, for instance `gomigrate.schema_migrations` | `schema_migrations` |
+| `x-statement-timeout` | `StatementTimeout` | Abort any statement that takes more than the specified number of milliseconds | `0` |
+| `dbname` | `DatabaseName` | The name of the database to connect to | `SELECT CURRENT_DATABASE()` result |
+| `search_path` | | This variable specifies the order in which schemas are searched when an object is referenced by a simple name with no schema specified. | `SHOW search_path` result |
+| `user` | | The user to sign in as | |
+| `password` | | The user's password | |
+| `host` | | The host to connect to. Values that start with / are for unix domain sockets | `localhost` |
+| `port` | | The port to bind to| `5432` |
+| `fallback_application_name` | | An application_name to fall back to if one isn't provided. | |
+| `connect_timeout` | | Maximum wait for connection, in seconds. Zero or not specified means wait indefinitely. | |
+| `sslcert` | | Cert file location. The file must contain PEM encoded data. | |
+| `sslkey` | | Key file location. The file must contain PEM encoded data. | |
+| `sslrootcert` | | The location of the root certificate file. The file must contain PEM encoded data. | |
+| `sslmode` | | Whether or not to use SSL (disable\|require\|verify-ca\|verify-full) | |
 
 
 ## Upgrading from v1

--- a/database/postgres/postgres_test.go
+++ b/database/postgres/postgres_test.go
@@ -508,5 +508,46 @@ func Test_computeLineFromPos(t *testing.T) {
 			run(true, true)
 		})
 	}
+}
 
+func Test_quoteIdentifier(t *testing.T) {
+	testcases := []struct {
+		migrationsTableHasSchema bool
+		name                     string
+		want                     string
+	}{
+		{
+			true,
+			"schema_name.table_name",
+			"\"schema_name\".\"table_name\"",
+		},
+		{
+			true,
+			"schema_name.table.name",
+			"\"schema_name\".\"table.name\"",
+		},
+		{
+			false,
+			"table_name",
+			"\"table_name\"",
+		},
+		{
+			false,
+			"table.name",
+			"\"table.name\"",
+		},
+	}
+	p := &Postgres{
+		config: &Config{
+			MigrationsTableHasSchema: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		p.config.MigrationsTableHasSchema = tc.migrationsTableHasSchema
+		got := p.quoteIdentifier(tc.name)
+		if tc.want != got {
+			t.Fatalf("expected %s but got %s", tc.want, got)
+	}
+	}
 }


### PR DESCRIPTION
@dhui what do you think about this commit which add `x-schema-name` URL Query support as suggest by this [comment](https://github.com/golang-migrate/migrate/issues/95#issuecomment-499596690)?

Is anything missing to approve this Pull Request? Some documention, unit test or other?

Best regards,<br />
Stéphane


---

Edit:

The second version of this patch add schema name support in  `x-migrations-table` value.

Now, you can use:

```
migrate ... -database ...?x-migrations-table=gomigrate.schema_migrations
```

---

Edit: alternative implementation: https://github.com/golang-migrate/migrate/pull/533