### PR TITLE
Support multi-statement execution for PostgreSQL

### DIFF
--- a/database/postgres/README.md
+++ b/database/postgres/README.md
@@ -6,6 +6,8 @@
 |------------|---------------------|-------------|
 | `x-migrations-table` | `MigrationsTable` | Name of the migrations table |
 | `x-statement-timeout` | `StatementTimeout` | Abort any statement that takes more than the specified number of milliseconds |
+| `x-multi-statement` | `MultiStatementEnabled` | Enable multi-statement execution (default: false) |
+| `x-multi-statement-max-size` | `MultiStatementMaxSize` | Maximum size of single statement in bytes (default: 10MB) |
 | `dbname` | `DatabaseName` | The name of the database to connect to |
 | `search_path` | | This variable specifies the order in which schemas are searched when an object is referenced by a simple name with no schema specified. |
 | `user` | | The user to sign in as |
@@ -27,3 +29,10 @@
 2. Wrap your existing migrations in transactions ([BEGIN/COMMIT](https://www.postgresql.org/docs/current/static/transaction-iso.html)) if you use multiple statements within one migration.
 3. Download and install the latest migrate version.
 4. Force the current migration version with `migrate force <current_version>`.
+
+## Multi-statement mode
+
+In PostgreSQL running multiple SQL statements in one `Exec` executes them inside a transaction. Sometimes this
+behavior is not desirable because some statements can be only run outside of transaction (e.g.
+`CREATE INDEX CONCURRENTLY`). If you want to use `CREATE INDEX CONCURRENTLY` without activating multi-statement mode
+you have to put such statements in a separate migration files.

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -241,8 +241,8 @@ func (p *Postgres) runStatement(statement []byte) error {
 		ctx, cancel = context.WithTimeout(ctx, p.config.StatementTimeout)
 		defer cancel()
 	}
-	query := strings.TrimSpace(string(statement))
-	if query == "" {
+	query := string(statement)
+	if strings.TrimSpace(query) == "" {
 		return nil
 	}
 	if _, err := p.conn.ExecContext(ctx, query); err != nil {

--- a/database/postgres/postgres_test.go
+++ b/database/postgres/postgres_test.go
@@ -42,8 +42,9 @@ var (
 	}
 )
 
-func pgConnectionString(host, port string) string {
-	return fmt.Sprintf("postgres://postgres:%s@%s:%s/postgres?sslmode=disable", pgPassword, host, port)
+func pgConnectionString(host, port string, options ...string) string {
+	options = append(options, "sslmode=disable")
+	return fmt.Sprintf("postgres://postgres:%s@%s:%s/postgres?%s", pgPassword, host, port, strings.Join(options, "&"))
 }
 
 func isReady(ctx context.Context, c dktest.ContainerInfo) bool {
@@ -162,7 +163,7 @@ func TestMultipleStatementsInMultiStatementMode(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		addr := pgConnectionString(ip, port) + "&x-multi-statement=true"
+		addr := pgConnectionString(ip, port, "x-multi-statement=true")
 		p := &Postgres{}
 		d, err := p.Open(addr)
 		if err != nil {


### PR DESCRIPTION
This PR adds support for multi-statement SQL execution for PostgreSQL driver.


In PostgreSQL running multiple SQL statements in one `Exec` executes them inside a transaction. Sometimes this behavior is not desirable because some statements can be only run outside of transaction (e.g. `CREATE INDEX CONCURRENTLY`). If you want to use `CREATE INDEX CONCURRENTLY` without activating multi-statement mode you have to put such statements in a separate migration files.

* [x] Provide some tests

Resolves #284, Resolves #492