### PR TITLE
Fix issue when gitlab return only first 20 migrations (reopen)

### DIFF
--- a/source/gitlab/gitlab.go
+++ b/source/gitlab/gitlab.go
@@ -21,6 +21,8 @@ func init() {
 	source.Register("gitlab", &Gitlab{})
 }
 
+const DefaultMaxItemsPerPage = 100
+
 var (
 	ErrNoUserInfo       = fmt.Errorf("no username:token provided")
 	ErrNoAccessToken    = fmt.Errorf("no access token")
@@ -86,8 +88,11 @@ func (g *Gitlab) Open(url string) (source.Driver, error) {
 	}
 
 	gn.listOptions = &gitlab.ListTreeOptions{
-		Path: &gn.path,
-		Ref:  &u.Fragment,
+		Path:        &gn.path,
+		Ref:         &u.Fragment,
+		ListOptions: gitlab.ListOptions{
+			PerPage: DefaultMaxItemsPerPage,
+		},
 	}
 
 	gn.getOptions = &gitlab.GetFileOptions{
@@ -113,13 +118,22 @@ func WithInstance(client *gitlab.Client, config *Config) (source.Driver, error) 
 }
 
 func (g *Gitlab) readDirectory() error {
-	nodes, response, err := g.client.Repositories.ListTree(g.projectID, g.listOptions)
-	if err != nil {
-		return err
-	}
+	var nodes []*gitlab.TreeNode
+	for {
+		n, response, err := g.client.Repositories.ListTree(g.projectID, g.listOptions)
+		if err != nil {
+			return err
+		}
 
-	if response.StatusCode != http.StatusOK {
-		return ErrInvalidResponse
+		if response.StatusCode != http.StatusOK {
+			return ErrInvalidResponse
+		}
+
+		nodes = append(nodes, n...)
+		if response.CurrentPage >= response.TotalPages {
+			break
+		}
+		g.listOptions.ListOptions.Page = response.NextPage
 	}
 
 	for i := range nodes {

--- a/source/gitlab/gitlab.go
+++ b/source/gitlab/gitlab.go
@@ -238,3 +238,4 @@ func (g *Gitlab) ReadDown(version uint) (r io.ReadCloser, identifier string, err
 
 	return nil, "", &os.PathError{Op: fmt.Sprintf("read version %v", version), Path: g.path, Err: os.ErrNotExist}
 }
+

--- a/source/gitlab/gitlab.go
+++ b/source/gitlab/gitlab.go
@@ -88,8 +88,8 @@ func (g *Gitlab) Open(url string) (source.Driver, error) {
 	}
 
 	gn.listOptions = &gitlab.ListTreeOptions{
-		Path:        &gn.path,
-		Ref:         &u.Fragment,
+		Path: &gn.path,
+		Ref:  &u.Fragment,
 		ListOptions: gitlab.ListOptions{
 			PerPage: DefaultMaxItemsPerPage,
 		},
@@ -238,4 +238,3 @@ func (g *Gitlab) ReadDown(version uint) (r io.ReadCloser, identifier string, err
 
 	return nil, "", &os.PathError{Op: fmt.Sprintf("read version %v", version), Path: g.path, Err: os.ErrNotExist}
 }
-


### PR DESCRIPTION
It's duplicate PR #379 that looks dead.
This PR more clear and small.
Reopen for CircleCI.