### PR TITLE
sqlite3: Add test case with database path contains whitespace

### DIFF
--- a/database/sqlite3/sqlite3_test.go
+++ b/database/sqlite3/sqlite3_test.go
@@ -160,3 +160,23 @@ func TestNoTxWrapInvalidValue(t *testing.T) {
 		assert.Contains(t, err.Error(), "invalid syntax")
 	}
 }
+
+func TestMigrateWithDirectoryNameContainsWhitespaces(t *testing.T) {
+	dir, err := ioutil.TempDir("", "directory name contains whitespaces")
+	if err != nil {
+		return
+	}
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Error(err)
+		}
+	}()
+	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
+	p := &Sqlite{}
+	addr := fmt.Sprintf("sqlite3://%s%s", "file:", filepath.Join(dir, "sqlite3.db"))
+	d, err := p.Open(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dt.Test(t, d, []byte("CREATE TABLE t (Qty int, Name string);"))
+}


### PR DESCRIPTION
Fix https://github.com/golang-migrate/migrate/issues/499



Since URL will be encoded using percent-encoding in
https://github.com/golang-migrate/migrate/blob/550193e3e0b3d8f4858a625ed9b468751cdeb620/database/sqlite3/sqlite3.go#L95

`url` like `/path/to database/` (it contains whitespace) will be encoded to `/path/to%20database/`, which causes

https://github.com/golang-migrate/migrate/blob/550193e3e0b3d8f4858a625ed9b468751cdeb620/database/sqlite3/sqlite3.go#L47

to return an error.