### PR TITLE
Add default GitHub API client

### DIFF
--- a/source/github/README.md
+++ b/source/github/README.md
@@ -2,12 +2,13 @@
 
 This driver is catered for those that want to source migrations from [github.com](https://github.com). The URL scheme doesn't require a hostname, as it just simply defaults to `github.com`.
 
-`github://user:personal-access-token@owner/repo/path#ref`
+Authenticated client: `github://user:personal-access-token@owner/repo/path#ref`
+Unauthenticated client: `github://owner/repo/path#ref`
 
 | URL Query  | WithInstance Config | Description |
 |------------|---------------------|-------------|
-| user | | The username of the user connecting |
-| personal-access-token | | An access token from GitHub (https://github.com/settings/tokens) |
+| user | | (optional) The username of the user connecting |
+| personal-access-token | | (optional) An access token from GitHub (https://github.com/settings/tokens) |
 | owner | | the repo owner |
 | repo | | the name of the repository |
 | path | | path in repo to migrations |

--- a/source/github/github_test.go
+++ b/source/github/github_test.go
@@ -2,10 +2,12 @@ package github
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"testing"
 
 	st "github.com/golang-migrate/migrate/v4/source/testing"
+	"github.com/stretchr/testify/assert"
 )
 
 var GithubTestSecret = "" // username:token
@@ -29,4 +31,29 @@ func Test(t *testing.T) {
 	}
 
 	st.Test(t, d)
+}
+
+func TestDefaultClient(t *testing.T) {
+	g := &Github{}
+	owner := "golang-migrate"
+	repo := "migrate"
+	path := "source/github/examples/migrations"
+
+	url := fmt.Sprintf("github://%s/%s/%s", owner, repo, path)
+	d, err := g.Open(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ver, err := d.First()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, uint(1085649617), ver)
+
+	ver, err = d.Next(ver)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, uint(1185749658), ver)
 }


### PR DESCRIPTION
I want to access the migration source from GitHub without providing personal access token.

Is it possible to add such a feature since `go-github` package [allows](https://github.com/google/go-github/blob/5cd6a0f4812a5f0fe25e9e3510aa707c7e2eaa87/github/github.go#L259) unauthenticated clients to call the API?

