### PR TITLE
Add -only-up create command option to skip down migration creation

### DIFF
--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -72,7 +72,7 @@ func timeVersion(startTime time.Time, format string) (version string, err error)
 }
 
 // createCmd (meant to be called via a CLI command) creates a new migration
-func createCmd(dir string, startTime time.Time, format string, name string, ext string, seq bool, seqDigits int, print bool) error {
+func createCmd(dir string, startTime time.Time, format string, name string, ext string, seq bool, seqDigits int, onlyUp bool, print bool) error {
 	if seq && format != defaultTimeFormat {
 		return errIncompatibleSeqAndFormat
 	}
@@ -119,6 +119,10 @@ func createCmd(dir string, startTime time.Time, format string, name string, ext 
 	}
 
 	for _, direction := range []string{"up", "down"} {
+		if direction == "down" && onlyUp {
+			continue
+		}
+
 		basename := fmt.Sprintf("%s_%s.%s%s", version, name, direction, ext)
 		filename := filepath.Join(dir, basename)
 

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -159,6 +159,7 @@ Database drivers: `+strings.Join(database.List(), ", ")+"\n", createUsage, gotoU
 
 		seq := false
 		seqDigits := 6
+		onlyUp := false
 
 		createFlagSet, help := newFlagSetWithHelp("create")
 		extPtr := createFlagSet.String("ext", "", "File extension")
@@ -167,6 +168,7 @@ Database drivers: `+strings.Join(database.List(), ", ")+"\n", createUsage, gotoU
 		timezoneName := createFlagSet.String("tz", defaultTimezone, `The timezone that will be used for generating timestamps (default: utc)`)
 		createFlagSet.BoolVar(&seq, "seq", seq, "Use sequential numbers instead of timestamps (default: false)")
 		createFlagSet.IntVar(&seqDigits, "digits", seqDigits, "The number of digits to use in sequences (default: 6)")
+		createFlagSet.BoolVar(&onlyUp, "only-up", onlyUp, "Skip down migration (default: false)")
 
 		if err := createFlagSet.Parse(args); err != nil {
 			log.fatalErr(err)
@@ -188,7 +190,7 @@ Database drivers: `+strings.Join(database.List(), ", ")+"\n", createUsage, gotoU
 			log.fatal(err)
 		}
 
-		if err := createCmd(*dirPtr, startTime.In(timezone), *formatPtr, name, *extPtr, seq, seqDigits, true); err != nil {
+		if err := createCmd(*dirPtr, startTime.In(timezone), *formatPtr, name, *extPtr, seq, seqDigits, onlyUp, true); err != nil {
 			log.fatalErr(err)
 		}
 


### PR DESCRIPTION
`migrate create -only-up …` would help those who use only `up` migrations instead of `up/down` pairs.