### PR TITLE
clickhouse: make table engine for schema versions  table configurable

### DIFF
--- a/database/clickhouse/README.md
+++ b/database/clickhouse/README.md
@@ -1,13 +1,14 @@
 # ClickHouse
 
-`clickhouse://host:port?username=user&password=qwerty&database=clicks&x-multi-statement=true`
+`clickhouse://host:port?username=user&password=qwerty&database=clicks&x-multi-statement=true&x-table-engine=MergeTree`
 
 | URL Query  | Description |
 |------------|-------------|
 | `x-migrations-table`| Name of the migrations table |
+| `x-table-engine`| Table engine to use for the migrations table, defaults to TinyLog |
 | `database` | The name of the database to connect to |
 | `username` | The user to sign in as |
-| `password` | The user's password | 
+| `password` | The user's password |
 | `host` | The host to connect to. |
 | `port` | The port to bind to. |
 | `x-multi-statement` | false | Enable multiple statements to be ran in a single migration (See note below) |

--- a/database/clickhouse/README.md
+++ b/database/clickhouse/README.md
@@ -1,11 +1,11 @@
 # ClickHouse
 
-`clickhouse://host:port?username=user&password=qwerty&database=clicks&x-multi-statement=true&x-table-engine=MergeTree`
+`clickhouse://host:port?username=user&password=qwerty&database=clicks&x-multi-statement=true`
 
 | URL Query  | Description |
 |------------|-------------|
 | `x-migrations-table`| Name of the migrations table |
-| `x-table-engine`| Table engine to use for the migrations table, defaults to TinyLog |
+| `x-migrations-table-engine`| Engine to use for the migrations table, defaults to TinyLog |
 | `database` | The name of the database to connect to |
 | `username` | The user to sign in as |
 | `password` | The user's password |
@@ -18,3 +18,4 @@
 * The Clickhouse driver does not natively support executing multipe statements in a single query. To allow for multiple statements in a single migration, you can use the `x-multi-statement` param. There are two important caveats:
   * This mode splits the migration text into separately-executed statements by a semi-colon `;`. Thus `x-multi-statement` cannot be used when a statement in the migration contains a string with a semi-colon.
   * The queries are not executed in any sort of transaction/batch, meaning you are responsible for fixing partial migrations.
+* Using the default TinyLog table engine for the schema_versions table prevents backing up the table if using the [clickhouse-backup](https://github.com/AlexAkulov/clickhouse-backup) tool. If backing up the database with make sure the migrations are run with `x-migrations-table-engine=MergeTree`.

--- a/database/clickhouse/clickhouse.go
+++ b/database/clickhouse/clickhouse.go
@@ -22,7 +22,7 @@ var (
 	multiStmtDelimiter = []byte(";")
 
 	DefaultMigrationsTable       = "schema_migrations"
-	DefaultTableEngine           = "TinyLog"
+	DefaultMigrationsTableEngine = "TinyLog"
 	DefaultMultiStatementMaxSize = 10 * 1 << 20 // 10 MB
 
 	ErrNilConfig = fmt.Errorf("no config")
@@ -31,7 +31,7 @@ var (
 type Config struct {
 	DatabaseName          string
 	MigrationsTable       string
-	TableEngine           string
+	MigrationsTableEngine string
 	MultiStatementEnabled bool
 	MultiStatementMaxSize int
 }
@@ -87,16 +87,16 @@ func (ch *ClickHouse) Open(dsn string) (database.Driver, error) {
 		}
 	}
 
-	tableEngine := DefaultTableEngine
-	if s := purl.Query().Get("x-table-engine"); len(s) > 0 {
-		tableEngine = s
+	migrationsTableEngine := DefaultMigrationsTableEngine
+	if s := purl.Query().Get("x-migrations-table-engine"); len(s) > 0 {
+		migrationsTableEngine = s
 	}
 
 	ch = &ClickHouse{
 		conn: conn,
 		config: &Config{
 			MigrationsTable:       purl.Query().Get("x-migrations-table"),
-			TableEngine:           tableEngine,
+			MigrationsTableEngine: migrationsTableEngine,
 			DatabaseName:          purl.Query().Get("database"),
 			MultiStatementEnabled: purl.Query().Get("x-multi-statement") == "true",
 			MultiStatementMaxSize: multiStatementMaxSize,
@@ -232,9 +232,9 @@ func (ch *ClickHouse) ensureVersionTable() (err error) {
 			version    Int64,
 			dirty      UInt8,
 			sequence   UInt64
-		) Engine=%s`, ch.config.MigrationsTable, ch.config.TableEngine)
+		) Engine=%s`, ch.config.MigrationsTable, ch.config.MigrationsTableEngine)
 
-	if strings.HasSuffix(ch.config.TableEngine, "Tree") {
+	if strings.HasSuffix(ch.config.MigrationsTableEngine, "Tree") {
 		query = fmt.Sprintf(`%s ORDER BY sequence`, query)
 	}
 

--- a/database/clickhouse/clickhouse.go
+++ b/database/clickhouse/clickhouse.go
@@ -3,13 +3,14 @@ package clickhouse
 import (
 	"database/sql"
 	"fmt"
-	"go.uber.org/atomic"
 	"io"
 	"io/ioutil"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	"go.uber.org/atomic"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database"
@@ -21,6 +22,7 @@ var (
 	multiStmtDelimiter = []byte(";")
 
 	DefaultMigrationsTable       = "schema_migrations"
+	DefaultTableEngine           = "TinyLog"
 	DefaultMultiStatementMaxSize = 10 * 1 << 20 // 10 MB
 
 	ErrNilConfig = fmt.Errorf("no config")
@@ -29,6 +31,7 @@ var (
 type Config struct {
 	DatabaseName          string
 	MigrationsTable       string
+	TableEngine           string
 	MultiStatementEnabled bool
 	MultiStatementMaxSize int
 }
@@ -84,10 +87,16 @@ func (ch *ClickHouse) Open(dsn string) (database.Driver, error) {
 		}
 	}
 
+	tableEngine := DefaultTableEngine
+	if s := purl.Query().Get("x-table-engine"); len(s) > 0 {
+		tableEngine = s
+	}
+
 	ch = &ClickHouse{
 		conn: conn,
 		config: &Config{
 			MigrationsTable:       purl.Query().Get("x-migrations-table"),
+			TableEngine:           tableEngine,
 			DatabaseName:          purl.Query().Get("database"),
 			MultiStatementEnabled: purl.Query().Get("x-multi-statement") == "true",
 			MultiStatementMaxSize: multiStatementMaxSize,
@@ -216,14 +225,19 @@ func (ch *ClickHouse) ensureVersionTable() (err error) {
 	} else {
 		return nil
 	}
+
 	// if not, create the empty migration table
-	query = `
-		CREATE TABLE ` + ch.config.MigrationsTable + ` (
-			version    Int64, 
+	query = fmt.Sprintf(`
+		CREATE TABLE %s (
+			version    Int64,
 			dirty      UInt8,
 			sequence   UInt64
-		) Engine=TinyLog
-	`
+		) Engine=%s`, ch.config.MigrationsTable, ch.config.TableEngine)
+
+	if strings.HasSuffix(ch.config.TableEngine, "Tree") {
+		query = fmt.Sprintf(`%s ORDER BY sequence`, query)
+	}
+
 	if _, err := ch.conn.Exec(query); err != nil {
 		return &database.Error{OrigErr: err, Query: []byte(query)}
 	}

--- a/database/clickhouse/clickhouse_test.go
+++ b/database/clickhouse/clickhouse_test.go
@@ -5,6 +5,9 @@ import (
 	"database/sql"
 	sqldriver "database/sql/driver"
 	"fmt"
+	"log"
+	"testing"
+
 	_ "github.com/ClickHouse/clickhouse-go"
 	"github.com/dhui/dktest"
 	"github.com/golang-migrate/migrate/v4"
@@ -12,8 +15,6 @@ import (
 	dt "github.com/golang-migrate/migrate/v4/database/testing"
 	"github.com/golang-migrate/migrate/v4/dktesting"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
-	"log"
-	"testing"
 )
 
 const defaultPort = 9000
@@ -29,7 +30,7 @@ var (
 )
 
 func clickhouseConnectionString(host, port string) string {
-	return fmt.Sprintf("clickhouse://%v:%v?username=user&password=password&database=db&x-multi-statement=true&debug=false", host, port)
+	return fmt.Sprintf("clickhouse://%v:%v?username=user&password=password&database=db&x-multi-statement=true&x-table-engine=MergeTree&debug=false", host, port)
 }
 
 func isReady(ctx context.Context, c dktest.ContainerInfo) bool {


### PR DESCRIPTION
This change adds the x-table-engine parameter to choose the default table engine for the schema versions table. Defaults to the current one "TinyLog".

Fixes https://github.com/golang-migrate/migrate/issues/505