### PR TITLE
Fix Paths with Whitespace Errors

### DIFF
--- a/database/sqlite3/sqlite3.go
+++ b/database/sqlite3/sqlite3.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	nurl "net/url"
 	"strconv"
-	"strings"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database"
@@ -96,7 +95,7 @@ func (m *Sqlite) Open(url string) (database.Driver, error) {
 	if err != nil {
 		return nil, err
 	}
-	dbfile := strings.Replace(migrate.FilterCustomQuery(purl).String(), "sqlite3://", "", 1)
+	dbfile := dbPathFromURL(purl)
 	db, err := sql.Open("sqlite3", dbfile)
 	if err != nil {
 		return nil, err
@@ -267,4 +266,15 @@ func (m *Sqlite) Version() (version int, dirty bool, err error) {
 		return database.NilVersion, false, nil
 	}
 	return version, dirty, nil
+}
+
+func dbPathFromURL(url *nurl.URL) string {
+	dbPath := url.Path
+	encodedQuery := migrate.FilterCustomQuery(url).Query().Encode()
+
+	if len(encodedQuery) > 0 {
+		dbPath = dbPath + "?" + encodedQuery
+	}
+
+	return dbPath
 }

--- a/database/sqlite3/sqlite3_test.go
+++ b/database/sqlite3/sqlite3_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"io/ioutil"
+	nurl "net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -180,4 +181,46 @@ func TestMigrateWithDirectoryNameContainsWhitespaces(t *testing.T) {
 		t.Fatal(err)
 	}
 	dt.Test(t, d, []byte("CREATE TABLE t (Qty int, Name string);"))
+}
+
+func TestDbPathFromURLWithSimpleURL(t *testing.T) {
+
+	expected := "/Path/To/A/DB/file.db"
+
+	inputStr := "sqlite3:///Path/To/A/DB/file.db"
+	inputURL, _ := nurl.Parse(inputStr)
+
+	output := dbPathFromURL(inputURL)
+
+	if output != expected {
+		t.Fatalf("Expected:  %v == %v", output, expected)
+	}
+}
+
+func TestDbPathFromURLWithSimpleURLWithWhitespaces(t *testing.T) {
+
+	expected := "/Path To/A DB/file name.db"
+
+	inputStr := "sqlite3:///Path To/A DB/file name.db"
+	inputURL, _ := nurl.Parse(inputStr)
+
+	output := dbPathFromURL(inputURL)
+
+	if output != expected {
+		t.Fatalf("Expected:  %v == %v", output, expected)
+	}
+}
+
+func TestDbPathFromURLWithURLWithQuery(t *testing.T) {
+
+	expected := "/Path To/A DB/file name.db?aQuery=something&bQuery=else&c=d"
+
+	inputStr := "sqlite3:///Path To/A DB/file name.db?aQuery=something&bQuery=else&c=d&x-custom-query-param=scrubbed"
+	inputURL, _ := nurl.Parse(inputStr)
+
+	output := dbPathFromURL(inputURL)
+
+	if output != expected {
+		t.Fatalf("Expected:  %v == %v", output, expected)
+	}
 }


### PR DESCRIPTION
This changes how the `dbfile` string is created. Rather than using `{URL}.String()` in `net/url` (in which, paths get escaped so whitespaces are replaced with %20), this adds a function that reconstructs the path from` URL.Path` and appending the encoded query parameters on the end if any query parameters are present.

This is my attempt at a fix for issue #499 (which seems prematurely closed, as its still an issue).  

Also includes some test cases to ensure the new function produces a the expected results based on a few different inputs(including paths with spaces, as well as paths with and without query arguments).

PS.  I had created a pull request for this previously, but in an attempt to rebase my fork on top of the most recent changes to the master, things got out of sync, so I just deleted and recreated the fork so it wouldn't create any conflicts.