### PR TITLE
Added schemaname support for sqlserver driver

### DIFF
--- a/database/sqlserver/sqlserver.go
+++ b/database/sqlserver/sqlserver.go
@@ -231,7 +231,7 @@ func (ss *SQLServer) SetVersion(version int, dirty bool) error {
 		return &database.Error{OrigErr: err, Err: "transaction start failed"}
 	}
 
-	query := `TRUNCATE TABLE "` + ss.config.MigrationsTable + `"`
+	query := `TRUNCATE TABLE [`+ ss.config.SchemaName +`].[` + ss.config.MigrationsTable + `]`
 	if _, err := tx.Exec(query); err != nil {
 		if errRollback := tx.Rollback(); errRollback != nil {
 			err = multierror.Append(err, errRollback)
@@ -247,7 +247,7 @@ func (ss *SQLServer) SetVersion(version int, dirty bool) error {
 		if dirty {
 			dirtyBit = 1
 		}
-		query = `INSERT INTO "` + ss.config.MigrationsTable + `" (version, dirty) VALUES (@p1, @p2)`
+		query = `INSERT INTO [`+ ss.config.SchemaName +`].[` + ss.config.MigrationsTable + `] (version, dirty) VALUES (@p1, @p2)`
 		if _, err := tx.Exec(query, version, dirtyBit); err != nil {
 			if errRollback := tx.Rollback(); errRollback != nil {
 				err = multierror.Append(err, errRollback)
@@ -265,7 +265,7 @@ func (ss *SQLServer) SetVersion(version int, dirty bool) error {
 
 // Version of the current database state
 func (ss *SQLServer) Version() (version int, dirty bool, err error) {
-	query := `SELECT TOP 1 version, dirty FROM "` + ss.config.MigrationsTable + `"`
+	query := `SELECT TOP 1 version, dirty FROM [`+ ss.config.SchemaName +`].[` + ss.config.MigrationsTable + `]`
 	err = ss.conn.QueryRowContext(context.Background(), query).Scan(&version, &dirty)
 	switch {
 	case err == sql.ErrNoRows:
@@ -329,14 +329,14 @@ func (ss *SQLServer) ensureVersionTable() (err error) {
 			}
 		}
 	}()
-
+	
 	query := `IF NOT EXISTS
 	(SELECT *
 		 FROM sysobjects
-		WHERE id = object_id(N'[dbo].[` + ss.config.MigrationsTable + `]')
+		WHERE id = object_id(N'[`+ ss.config.SchemaName +`].[` + ss.config.MigrationsTable + `]')
 			AND OBJECTPROPERTY(id, N'IsUserTable') = 1
 	)
-	CREATE TABLE ` + ss.config.MigrationsTable + ` ( version BIGINT PRIMARY KEY NOT NULL, dirty BIT NOT NULL );`
+	CREATE TABLE [`+ ss.config.SchemaName +`].[` + ss.config.MigrationsTable + `] ( version BIGINT PRIMARY KEY NOT NULL, dirty BIT NOT NULL );`
 
 	if _, err = ss.conn.ExecContext(context.Background(), query); err != nil {
 		return &database.Error{OrigErr: err, Query: []byte(query)}


### PR DESCRIPTION
I've added support for the `SchemaName` config parameter for the SQL Server driver.
This creates the opportunity to place the migrations table in a different schema. The same as the postgres driver.