### PR TITLE
Added a method to create a mysql database from a connection object

### DIFF
--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -24,6 +24,8 @@ import (
 	"github.com/golang-migrate/migrate/v4/database"
 )
 
+var _ database.Driver = (*Mysql)(nil) // explicit compile time type check
+
 func init() {
 	database.Register("mysql", &Mysql{})
 }


### PR DESCRIPTION
This PR implements #578  by adding the `WithConnection` method to the MySQL driver.

I could test and verify that it works. However, I don't have the environment or time to provide and test the same change on all other drivers, so it creates a small inconsistency. How do you want to proceed?