### PR TITLE
Changing TRUNCATE for a DELETE in the SetVersion Method

### DIFF
--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -13,15 +13,10 @@ import (
 	nurl "net/url"
 	"strconv"
 	"strings"
-)
 
-import (
 	"github.com/go-sql-driver/mysql"
-	"github.com/hashicorp/go-multierror"
-)
-
-import (
 	"github.com/golang-migrate/migrate/v4/database"
+	"github.com/hashicorp/go-multierror"
 )
 
 func init() {
@@ -329,7 +324,7 @@ func (m *Mysql) SetVersion(version int, dirty bool) error {
 		return &database.Error{OrigErr: err, Err: "transaction start failed"}
 	}
 
-	query := "TRUNCATE `" + m.config.MigrationsTable + "`"
+	query := "DELETE FROM `" + m.config.MigrationsTable + "`"
 	if _, err := tx.ExecContext(context.Background(), query); err != nil {
 		if errRollback := tx.Rollback(); errRollback != nil {
 			err = multierror.Append(err, errRollback)


### PR DESCRIPTION
Since MySQL does not support transactions for DDLs, I have changed the TRUNCATE statement for a DELETE FROM, which is transactional.

The details are explained in issue #584 