### PR TITLE
pgx: Make it actually use pgx

### DIFF
--- a/database/pgx/pgx.go
+++ b/database/pgx/pgx.go
@@ -160,7 +160,7 @@ func (p *Postgres) Open(url string) (database.Driver, error) {
 	// i.e. pgx://user:password@host:port/db => postgres://user:password@host:port/db
 	purl.Scheme = "postgres"
 
-	db, err := sql.Open("pgx", migrate.FilterCustomQuery(purl).String())
+	conn, err := pgx.Connect(context.Background(), migrate.FilterCustomQuery(purl).String())
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +205,7 @@ func (p *Postgres) Open(url string) (database.Driver, error) {
 		}
 	}
 
-	px, err := WithInstance(db, &Config{
+	px, err := WithConnection(context.Background(), conn, &Config{
 		DatabaseName:          purl.Path,
 		MigrationsTable:       migrationsTable,
 		MigrationsTableQuoted: migrationsTableQuoted,

--- a/database/pgx/pgx.go
+++ b/database/pgx/pgx.go
@@ -395,7 +395,7 @@ func (p *Postgres) Version() (version int, dirty bool, err error) {
 	query := `SELECT version, dirty FROM ` + quoteIdentifier(p.config.migrationsSchemaName) + `.` + quoteIdentifier(p.config.migrationsTableName) + ` LIMIT 1`
 	err = p.db.QueryRow(context.Background(), query).Scan(&version, &dirty)
 	switch {
-	case err == sql.ErrNoRows:
+	case err == pgx.ErrNoRows:
 		return database.NilVersion, false, nil
 
 	case err != nil:

--- a/database/pgx/pgx_test.go
+++ b/database/pgx/pgx_test.go
@@ -157,7 +157,7 @@ func TestMultipleStatements(t *testing.T) {
 
 		// make sure second table exists
 		var exists bool
-		if err := d.(*Postgres).conn.QueryRowContext(context.Background(), "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'bar' AND table_schema = (SELECT current_schema()))").Scan(&exists); err != nil {
+		if err := d.(*Postgres).db.QueryRow(context.Background(), "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'bar' AND table_schema = (SELECT current_schema()))").Scan(&exists); err != nil {
 			t.Fatal(err)
 		}
 		if !exists {
@@ -190,7 +190,7 @@ func TestMultipleStatementsInMultiStatementMode(t *testing.T) {
 
 		// make sure created index exists
 		var exists bool
-		if err := d.(*Postgres).conn.QueryRowContext(context.Background(), "SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = (SELECT current_schema()) AND indexname = 'idx_foo')").Scan(&exists); err != nil {
+		if err := d.(*Postgres).db.QueryRow(context.Background(), "SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = (SELECT current_schema()) AND indexname = 'idx_foo')").Scan(&exists); err != nil {
 			t.Fatal(err)
 		}
 		if !exists {
@@ -364,7 +364,7 @@ func TestMigrationTableOption(t *testing.T) {
 
 		// make sure migrate.schema_migrations table exists
 		var exists bool
-		if err := d.(*Postgres).conn.QueryRowContext(context.Background(), "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'schema_migrations' AND table_schema = 'migrate')").Scan(&exists); err != nil {
+		if err := d.(*Postgres).db.QueryRow(context.Background(), "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'schema_migrations' AND table_schema = 'migrate')").Scan(&exists); err != nil {
 			t.Fatal(err)
 		}
 		if !exists {
@@ -376,7 +376,7 @@ func TestMigrationTableOption(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := d.(*Postgres).conn.QueryRowContext(context.Background(), "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'migrate.schema_migrations' AND table_schema = (SELECT current_schema()))").Scan(&exists); err != nil {
+		if err := d.(*Postgres).db.QueryRow(context.Background(), "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'migrate.schema_migrations' AND table_schema = (SELECT current_schema()))").Scan(&exists); err != nil {
 			t.Fatal(err)
 		}
 		if !exists {

--- a/database/pgx/pgx_test.go
+++ b/database/pgx/pgx_test.go
@@ -157,7 +157,7 @@ func TestMultipleStatements(t *testing.T) {
 
 		// make sure second table exists
 		var exists bool
-		if err := d.(*Postgres).db.QueryRow(context.Background(), "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'bar' AND table_schema = (SELECT current_schema()))").Scan(&exists); err != nil {
+		if err := d.(*Postgres).conn.QueryRow(context.Background(), "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'bar' AND table_schema = (SELECT current_schema()))").Scan(&exists); err != nil {
 			t.Fatal(err)
 		}
 		if !exists {
@@ -190,7 +190,7 @@ func TestMultipleStatementsInMultiStatementMode(t *testing.T) {
 
 		// make sure created index exists
 		var exists bool
-		if err := d.(*Postgres).db.QueryRow(context.Background(), "SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = (SELECT current_schema()) AND indexname = 'idx_foo')").Scan(&exists); err != nil {
+		if err := d.(*Postgres).conn.QueryRow(context.Background(), "SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = (SELECT current_schema()) AND indexname = 'idx_foo')").Scan(&exists); err != nil {
 			t.Fatal(err)
 		}
 		if !exists {
@@ -364,7 +364,7 @@ func TestMigrationTableOption(t *testing.T) {
 
 		// make sure migrate.schema_migrations table exists
 		var exists bool
-		if err := d.(*Postgres).db.QueryRow(context.Background(), "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'schema_migrations' AND table_schema = 'migrate')").Scan(&exists); err != nil {
+		if err := d.(*Postgres).conn.QueryRow(context.Background(), "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'schema_migrations' AND table_schema = 'migrate')").Scan(&exists); err != nil {
 			t.Fatal(err)
 		}
 		if !exists {
@@ -376,7 +376,7 @@ func TestMigrationTableOption(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := d.(*Postgres).db.QueryRow(context.Background(), "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'migrate.schema_migrations' AND table_schema = (SELECT current_schema()))").Scan(&exists); err != nil {
+		if err := d.(*Postgres).conn.QueryRow(context.Background(), "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'migrate.schema_migrations' AND table_schema = (SELECT current_schema()))").Scan(&exists); err != nil {
 			t.Fatal(err)
 		}
 		if !exists {


### PR DESCRIPTION
This modifies the pgx driver to actually use pgx directly, and adds a `WithPgxInstance` function, which will let people who are using the pgx driver directly run migrations using the package as a library.