### PR TITLE
fix missing /migrate link in docker image

### DIFF
--- a/Dockerfile.github-actions
+++ b/Dockerfile.github-actions
@@ -2,7 +2,8 @@ FROM alpine:3.13
 
 RUN apk add --no-cache ca-certificates
 
-ENTRYPOINT ["/usr/bin/migrate"]
-CMD ["--help"]
-
 COPY migrate /usr/bin/migrate
+RUN ln -s /usr/bin/migrate /migrate
+
+ENTRYPOINT ["migrate"]
+CMD ["--help"]


### PR DESCRIPTION
Closes #607 

The previously used Dockerfile had a `/migrate` link that was used as entrypoint, this PR fixes that.