### PR TITLE
clickhouse: honor `DefaultMigrationsTableEngine` when created `WithInstance()`

### DIFF
--- a/database/clickhouse/clickhouse.go
+++ b/database/clickhouse/clickhouse.go
@@ -127,6 +127,10 @@ func (ch *ClickHouse) init() error {
 		ch.config.MultiStatementMaxSize = DefaultMultiStatementMaxSize
 	}
 
+	if len(ch.config.MigrationsTableEngine) == 0 {
+		ch.config.MigrationsTableEngine = DefaultMigrationsTableEngine
+	}
+
 	return ch.ensureVersionTable()
 }
 


### PR DESCRIPTION
Before this patch, `clickhouse.WithInstance()` would not select `DefaultMigrationsTableEngine` when no `MigrationsTableEngine` was provided through the `clickhouse.Config` argument. This behaviour forces the caller to always provide explicitely the config's `MigrationsTableEngine`.

This patch make it so `DefaultMigrationsTableEngine` is used when `MigrationsTableEngine` is not provided through `clickhouse.Config`.