### PR TITLE
Allow to build with Go 1.17 and Go 1.16

### DIFF
--- a/source/iofs/example_test.go
+++ b/source/iofs/example_test.go
@@ -1,5 +1,5 @@
-//go:build go1.16
-// +build go1.16
+//go:build go1.16 || go1.17
+// +build go1.16 go1.17
 
 package iofs_test
 

--- a/source/iofs/iofs.go
+++ b/source/iofs/iofs.go
@@ -1,5 +1,5 @@
-//go:build go1.16
-// +build go1.16
+//go:build go1.16 || go1.17
+// +build go1.16 go1.17
 
 package iofs
 

--- a/source/iofs/iofs_test.go
+++ b/source/iofs/iofs_test.go
@@ -1,5 +1,5 @@
-//go:build go1.16
-// +build go1.16
+//go:build go1.16 || go1.17
+// +build go1.16 go1.17
 
 package iofs_test
 


### PR DESCRIPTION
Without Go 1.17 in the list of supported build tags the iofs package is
not importable in a Go 1.17 project.  A minimal example can be found in
this [playground][1].  The example will show the following build error:

    prog.go:9:5: module github.com/golang-migrate/migrate/v4@latest found
    (v4.14.1), but does not contain package
    github.com/golang-migrate/migrate/v4/source/iofs

[1]: https://play.golang.org/p/pAPzPDhjYq0