### PR TITLE
revert binary file location change in docker image

### DIFF
--- a/Dockerfile.github-actions
+++ b/Dockerfile.github-actions
@@ -2,8 +2,10 @@ FROM alpine:3.13
 
 RUN apk add --no-cache ca-certificates
 
-COPY migrate /usr/bin/migrate
-RUN ln -s /usr/bin/migrate /migrate
+COPY migrate /usr/local/bin/migrate
+
+RUN ln -s /usr/local/bin/migrate /usr/bin/migrate
+RUN ln -s /usr/local/bin/migrate /migrate
 
 ENTRYPOINT ["migrate"]
 CMD ["--help"]


### PR DESCRIPTION
fixes #625 

Reverting the binary file location change by copying the executable to the original `/usr/local/bin/migrate` and creating a symlink on `/usr/bin/migrate`.