### PR TITLE
Pass context to database drivers

### DIFF
--- a/database/cassandra/cassandra_test.go
+++ b/database/cassandra/cassandra_test.go
@@ -79,6 +79,22 @@ func Test(t *testing.T) {
 	})
 }
 
+func TestContextCancellation(t *testing.T) {
+	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ip, port, err := c.Port(9042)
+		if err != nil {
+			t.Fatal("Unable to get mapped port:", err)
+		}
+		addr := fmt.Sprintf("cassandra://%v:%v/testks", ip, port)
+		p := &Cassandra{}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err = p.OpenWithContext(ctx, addr)
+		if err == nil {
+			t.Fatal("Should fail when opened with a canceled context")
+		}
+	})
+}
 func TestMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.Port(9042)

--- a/database/firebird/firebird_test.go
+++ b/database/firebird/firebird_test.go
@@ -98,7 +98,22 @@ func Test(t *testing.T) {
 		dt.Test(t, d, []byte("SELECT Count(*) FROM rdb$relations"))
 	})
 }
-
+func TestContextCancellation(t *testing.T) {
+	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ip, port, err := c.FirstPort()
+		if err != nil {
+			t.Fatal(err)
+		}
+		addr := fbConnectionString(ip, port)
+		p := &Firebird{}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err = p.OpenWithContext(ctx, addr)
+		if err == nil {
+			t.Fatal("Should fail when opened with a canceled context")
+		}
+	})
+}
 func TestMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()

--- a/database/mongodb/mongodb.go
+++ b/database/mongodb/mongodb.go
@@ -75,6 +75,9 @@ type findFilter struct {
 }
 
 func WithInstance(instance *mongo.Client, config *Config) (database.Driver, error) {
+	return WithInstanceContext(context.TODO(), instance, config)
+}
+func WithInstanceContext(ctx context.Context, instance *mongo.Client, config *Config) (database.Driver, error) {
 	if config == nil {
 		return nil, ErrNilConfig
 	}
@@ -101,11 +104,11 @@ func WithInstance(instance *mongo.Client, config *Config) (database.Driver, erro
 	}
 
 	if mc.config.Locking.Enabled {
-		if err := mc.ensureLockTable(); err != nil {
+		if err := mc.ensureLockTable(ctx); err != nil {
 			return nil, err
 		}
 	}
-	if err := mc.ensureVersionTable(); err != nil {
+	if err := mc.ensureVersionTable(ctx); err != nil {
 		return nil, err
 	}
 
@@ -113,6 +116,9 @@ func WithInstance(instance *mongo.Client, config *Config) (database.Driver, erro
 }
 
 func (m *Mongo) Open(dsn string) (database.Driver, error) {
+	return m.OpenWithContext(context.TODO(), dsn)
+}
+func (m *Mongo) OpenWithContext(ctx context.Context, dsn string) (database.Driver, error) {
 	//connstring is experimental package, but it used for parse connection string in mongo.Connect function
 	uri, err := connstring.Parse(dsn)
 	if err != nil {
@@ -146,10 +152,10 @@ func (m *Mongo) Open(dsn string) (database.Driver, error) {
 		return nil, err
 	}
 
-	if err = client.Ping(context.TODO(), nil); err != nil {
+	if err = client.Ping(ctx, nil); err != nil {
 		return nil, err
 	}
-	mc, err := WithInstance(client, &Config{
+	mc, err := WithInstanceContext(ctx, client, &Config{
 		DatabaseName:         uri.Database,
 		MigrationsCollection: migrationsCollection,
 		TransactionMode:      transactionMode,
@@ -212,8 +218,11 @@ func (m *Mongo) SetVersion(version int, dirty bool) error {
 }
 
 func (m *Mongo) Version() (version int, dirty bool, err error) {
+	return m.versionWithContext(context.TODO())
+}
+func (m *Mongo) versionWithContext(ctx context.Context) (version int, dirty bool, err error) {
 	var versionInfo versionInfo
-	err = m.db.Collection(m.config.MigrationsCollection).FindOne(context.TODO(), bson.M{}).Decode(&versionInfo)
+	err = m.db.Collection(m.config.MigrationsCollection).FindOne(ctx, bson.M{}).Decode(&versionInfo)
 	switch {
 	case err == mongo.ErrNoDocuments:
 		return database.NilVersion, false, nil
@@ -285,11 +294,11 @@ func (m *Mongo) Drop() error {
 	return m.db.Drop(context.TODO())
 }
 
-func (m *Mongo) ensureLockTable() error {
+func (m *Mongo) ensureLockTable(ctx context.Context) error {
 	indexes := m.db.Collection(m.config.Locking.CollectionName).Indexes()
 
 	indexOptions := options.Index().SetUnique(true).SetName(LockIndexName)
-	_, err := indexes.CreateOne(context.TODO(), mongo.IndexModel{
+	_, err := indexes.CreateOne(ctx, mongo.IndexModel{
 		Options: indexOptions,
 		Keys:    findFilter{Key: -1},
 	})
@@ -302,7 +311,7 @@ func (m *Mongo) ensureLockTable() error {
 // ensureVersionTable checks if versions table exists and, if not, creates it.
 // Note that this function locks the database, which deviates from the usual
 // convention of "caller locks" in the MongoDb type.
-func (m *Mongo) ensureVersionTable() (err error) {
+func (m *Mongo) ensureVersionTable(ctx context.Context) (err error) {
 	if err = m.Lock(); err != nil {
 		return err
 	}
@@ -320,7 +329,7 @@ func (m *Mongo) ensureVersionTable() (err error) {
 	if err != nil {
 		return err
 	}
-	if _, _, err = m.Version(); err != nil {
+	if _, _, err = m.versionWithContext(ctx); err != nil {
 		return err
 	}
 	return nil

--- a/database/mongodb/mongodb_test.go
+++ b/database/mongodb/mongodb_test.go
@@ -98,7 +98,22 @@ func Test(t *testing.T) {
 		dt.TestDrop(t, d)
 	})
 }
-
+func TestContextCancellation(t *testing.T) {
+	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ip, port, err := c.FirstPort()
+		if err != nil {
+			t.Fatal(err)
+		}
+		addr := mongoConnectionString(ip, port)
+		p := &Mongo{}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err = p.OpenWithContext(ctx, addr)
+		if err == nil {
+			t.Fatal("Should fail when opened with a canceled context")
+		}
+	})
+}
 func TestMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()

--- a/database/mysql/mysql_test.go
+++ b/database/mysql/mysql_test.go
@@ -110,16 +110,32 @@ func Test(t *testing.T) {
 		dt.Test(t, d, []byte("SELECT 1"))
 
 		// check ensureVersionTable
-		if err := d.(*Mysql).ensureVersionTable(); err != nil {
+		if err := d.(*Mysql).ensureVersionTable(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 		// check again
-		if err := d.(*Mysql).ensureVersionTable(); err != nil {
+		if err := d.(*Mysql).ensureVersionTable(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	})
 }
 
+func TestContextCancellation(t *testing.T) {
+	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ip, port, err := c.FirstPort()
+		if err != nil {
+			t.Fatal(err)
+		}
+		addr := fmt.Sprintf("mysql://root:root@tcp(%v:%v)/public", ip, port)
+		p := &Mysql{}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err = p.OpenWithContext(ctx, addr)
+		if err == nil {
+			t.Fatal("Should fail when opened with a canceled context")
+		}
+	})
+}
 func TestMigrate(t *testing.T) {
 	// mysql.SetLogger(mysql.Logger(log.New(ioutil.Discard, "", log.Ltime)))
 
@@ -148,11 +164,11 @@ func TestMigrate(t *testing.T) {
 		dt.TestMigrate(t, m)
 
 		// check ensureVersionTable
-		if err := d.(*Mysql).ensureVersionTable(); err != nil {
+		if err := d.(*Mysql).ensureVersionTable(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 		// check again
-		if err := d.(*Mysql).ensureVersionTable(); err != nil {
+		if err := d.(*Mysql).ensureVersionTable(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -186,11 +202,11 @@ func TestMigrateAnsiQuotes(t *testing.T) {
 		dt.TestMigrate(t, m)
 
 		// check ensureVersionTable
-		if err := d.(*Mysql).ensureVersionTable(); err != nil {
+		if err := d.(*Mysql).ensureVersionTable(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 		// check again
-		if err := d.(*Mysql).ensureVersionTable(); err != nil {
+		if err := d.(*Mysql).ensureVersionTable(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/database/pgx/pgx_test.go
+++ b/database/pgx/pgx_test.go
@@ -107,6 +107,22 @@ func Test(t *testing.T) {
 	})
 }
 
+func TestContextCancellation(t *testing.T) {
+	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ip, port, err := c.FirstPort()
+		if err != nil {
+			t.Fatal(err)
+		}
+		addr := pgConnectionString(ip, port)
+		p := &Postgres{}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err = p.OpenWithContext(ctx, addr)
+		if err == nil {
+			t.Fatal("Should fail when opened with a canceled context")
+		}
+	})
+}
 func TestMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -66,18 +66,21 @@ type Postgres struct {
 }
 
 func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
+	return WithInstanceContext(context.Background(), instance, config)
+}
+func WithInstanceContext(ctx context.Context, instance *sql.DB, config *Config) (database.Driver, error) {
 	if config == nil {
 		return nil, ErrNilConfig
 	}
 
-	if err := instance.Ping(); err != nil {
+	if err := instance.PingContext(ctx); err != nil {
 		return nil, err
 	}
 
 	if config.DatabaseName == "" {
 		query := `SELECT CURRENT_DATABASE()`
 		var databaseName string
-		if err := instance.QueryRow(query).Scan(&databaseName); err != nil {
+		if err := instance.QueryRowContext(ctx, query).Scan(&databaseName); err != nil {
 			return nil, &database.Error{OrigErr: err, Query: []byte(query)}
 		}
 
@@ -91,7 +94,7 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 	if config.SchemaName == "" {
 		query := `SELECT CURRENT_SCHEMA()`
 		var schemaName string
-		if err := instance.QueryRow(query).Scan(&schemaName); err != nil {
+		if err := instance.QueryRowContext(ctx, query).Scan(&schemaName); err != nil {
 			return nil, &database.Error{OrigErr: err, Query: []byte(query)}
 		}
 
@@ -131,14 +134,18 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 		config: config,
 	}
 
-	if err := px.ensureVersionTable(); err != nil {
+	if err := px.ensureVersionTable(ctx); err != nil {
 		return nil, err
 	}
 
 	return px, nil
 }
-
 func (p *Postgres) Open(url string) (database.Driver, error) {
+	return p.OpenWithContext(context.Background(), url)
+}
+
+func (p *Postgres) OpenWithContext(ctx context.Context, url string) (database.Driver, error) {
+
 	purl, err := nurl.Parse(url)
 	if err != nil {
 		return nil, err
@@ -189,7 +196,7 @@ func (p *Postgres) Open(url string) (database.Driver, error) {
 		}
 	}
 
-	px, err := WithInstance(db, &Config{
+	px, err := WithInstanceContext(ctx, db, &Config{
 		DatabaseName:          purl.Path,
 		MigrationsTable:       migrationsTable,
 		MigrationsTableQuoted: migrationsTableQuoted,
@@ -435,7 +442,7 @@ func (p *Postgres) Drop() (err error) {
 // ensureVersionTable checks if versions table exists and, if not, creates it.
 // Note that this function locks the database, which deviates from the usual
 // convention of "caller locks" in the Postgres type.
-func (p *Postgres) ensureVersionTable() (err error) {
+func (p *Postgres) ensureVersionTable(ctx context.Context) (err error) {
 	if err = p.Lock(); err != nil {
 		return err
 	}
@@ -455,7 +462,7 @@ func (p *Postgres) ensureVersionTable() (err error) {
 	// `CREATE TABLE IF NOT EXISTS...` query would fail because the user does not have the CREATE permission.
 	// Taken from https://github.com/mattes/migrate/blob/master/database/postgres/postgres.go#L258
 	query := `SELECT COUNT(1) FROM information_schema.tables WHERE table_schema = $1 AND table_name = $2 LIMIT 1`
-	row := p.conn.QueryRowContext(context.Background(), query, p.config.migrationsSchemaName, p.config.migrationsTableName)
+	row := p.conn.QueryRowContext(ctx, query, p.config.migrationsSchemaName, p.config.migrationsTableName)
 
 	var count int
 	err = row.Scan(&count)
@@ -468,7 +475,7 @@ func (p *Postgres) ensureVersionTable() (err error) {
 	}
 
 	query = `CREATE TABLE IF NOT EXISTS ` + pq.QuoteIdentifier(p.config.migrationsSchemaName) + `.` + pq.QuoteIdentifier(p.config.migrationsTableName) + ` (version bigint not null primary key, dirty boolean not null)`
-	if _, err = p.conn.ExecContext(context.Background(), query); err != nil {
+	if _, err = p.conn.ExecContext(ctx, query); err != nil {
 		return &database.Error{OrigErr: err, Query: []byte(query)}
 	}
 

--- a/database/postgres/postgres_test.go
+++ b/database/postgres/postgres_test.go
@@ -105,7 +105,22 @@ func Test(t *testing.T) {
 		dt.Test(t, d, []byte("SELECT 1"))
 	})
 }
-
+func TestContextCancellation(t *testing.T) {
+	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ip, port, err := c.FirstPort()
+		if err != nil {
+			t.Fatal(err)
+		}
+		addr := pgConnectionString(ip, port)
+		p := &Postgres{}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err = p.OpenWithContext(ctx, addr)
+		if err == nil {
+			t.Fatal("Should fail when opened with a canceled context")
+		}
+	})
+}
 func TestMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()

--- a/database/ql/ql_test.go
+++ b/database/ql/ql_test.go
@@ -1,6 +1,7 @@
 package ql
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io/ioutil"
@@ -42,6 +43,27 @@ func Test(t *testing.T) {
 		}
 	}()
 	dt.Test(t, d, []byte("CREATE TABLE t (Qty int, Name string);"))
+}
+
+func TestContextCancellation(t *testing.T) {
+	dir, err := ioutil.TempDir("", "ql-driver-test")
+	if err != nil {
+		return
+	}
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	t.Logf("DB path : %s\n", filepath.Join(dir, "ql.db"))
+	p := &Ql{}
+	addr := fmt.Sprintf("ql://%s", filepath.Join(dir, "ql.db"))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = p.OpenWithContext(ctx, addr)
+	if err == nil {
+		t.Fatal("Should fail when opened with a canceled context")
+	}
 }
 
 func TestMigrate(t *testing.T) {

--- a/database/redshift/redshift_test.go
+++ b/database/redshift/redshift_test.go
@@ -96,7 +96,22 @@ func Test(t *testing.T) {
 		dt.Test(t, d, []byte("SELECT 1"))
 	})
 }
-
+func TestContextCancellation(t *testing.T) {
+	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ip, port, err := c.FirstPort()
+		if err != nil {
+			t.Fatal(err)
+		}
+		addr := redshiftConnectionString(ip, port)
+		p := &Redshift{}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err = p.OpenWithContext(ctx, addr)
+		if err == nil {
+			t.Fatal("Should fail when opened with a canceled context")
+		}
+	})
+}
 func TestMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()

--- a/database/snowflake/snowflake.go
+++ b/database/snowflake/snowflake.go
@@ -47,18 +47,21 @@ type Snowflake struct {
 }
 
 func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
+	return WithInstanceContext(context.Background(), instance, config)
+}
+func WithInstanceContext(ctx context.Context, instance *sql.DB, config *Config) (database.Driver, error) {
 	if config == nil {
 		return nil, ErrNilConfig
 	}
 
-	if err := instance.Ping(); err != nil {
+	if err := instance.PingContext(ctx); err != nil {
 		return nil, err
 	}
 
 	if config.DatabaseName == "" {
 		query := `SELECT CURRENT_DATABASE()`
 		var databaseName string
-		if err := instance.QueryRow(query).Scan(&databaseName); err != nil {
+		if err := instance.QueryRowContext(ctx, query).Scan(&databaseName); err != nil {
 			return nil, &database.Error{OrigErr: err, Query: []byte(query)}
 		}
 
@@ -85,7 +88,7 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 		config: config,
 	}
 
-	if err := px.ensureVersionTable(); err != nil {
+	if err := px.ensureVersionTable(ctx); err != nil {
 		return nil, err
 	}
 
@@ -93,6 +96,9 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 }
 
 func (p *Snowflake) Open(url string) (database.Driver, error) {
+	return p.OpenWithContext(context.Background(), url)
+}
+func (p *Snowflake) OpenWithContext(ctx context.Context, url string) (database.Driver, error) {
 	purl, err := nurl.Parse(url)
 	if err != nil {
 		return nil, err
@@ -138,7 +144,7 @@ func (p *Snowflake) Open(url string) (database.Driver, error) {
 
 	migrationsTable := purl.Query().Get("x-migrations-table")
 
-	px, err := WithInstance(db, &Config{
+	px, err := WithInstanceContext(ctx, db, &Config{
 		DatabaseName:    database,
 		MigrationsTable: migrationsTable,
 	})
@@ -340,7 +346,7 @@ func (p *Snowflake) Drop() (err error) {
 // ensureVersionTable checks if versions table exists and, if not, creates it.
 // Note that this function locks the database, which deviates from the usual
 // convention of "caller locks" in the Snowflake type.
-func (p *Snowflake) ensureVersionTable() (err error) {
+func (p *Snowflake) ensureVersionTable(ctx context.Context) (err error) {
 	if err = p.Lock(); err != nil {
 		return err
 	}
@@ -358,7 +364,7 @@ func (p *Snowflake) ensureVersionTable() (err error) {
 	// check if migration table exists
 	var count int
 	query := `SELECT COUNT(1) FROM information_schema.tables WHERE table_name = $1 AND table_schema = (SELECT current_schema()) LIMIT 1`
-	if err := p.conn.QueryRowContext(context.Background(), query, p.config.MigrationsTable).Scan(&count); err != nil {
+	if err := p.conn.QueryRowContext(ctx, query, p.config.MigrationsTable).Scan(&count); err != nil {
 		return &database.Error{OrigErr: err, Query: []byte(query)}
 	}
 	if count == 1 {
@@ -368,7 +374,7 @@ func (p *Snowflake) ensureVersionTable() (err error) {
 	// if not, create the empty migration table
 	query = `CREATE TABLE if not exists "` + p.config.MigrationsTable + `" (
 			version bigint not null primary key, dirty boolean not null)`
-	if _, err := p.conn.ExecContext(context.Background(), query); err != nil {
+	if _, err := p.conn.ExecContext(ctx, query); err != nil {
 		return &database.Error{OrigErr: err, Query: []byte(query)}
 	}
 

--- a/database/spanner/spanner_test.go
+++ b/database/spanner/spanner_test.go
@@ -1,6 +1,7 @@
 package spanner
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -42,6 +43,19 @@ func Test(t *testing.T) {
 			t.Fatal(err)
 		}
 		dt.Test(t, d, []byte("CREATE TABLE test (id BOOL) PRIMARY KEY (id)"))
+	})
+}
+
+func TestContextCancellation(t *testing.T) {
+	withSpannerEmulator(t, func(t *testing.T) {
+		s := &Spanner{}
+		uri := fmt.Sprintf("spanner://%s", db)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := s.OpenWithContext(ctx, uri)
+		if err == nil {
+			t.Fatal("Should fail when opened with a canceled context")
+		}
 	})
 }
 

--- a/database/sqlcipher/sqlcipher.go
+++ b/database/sqlcipher/sqlcipher.go
@@ -1,6 +1,7 @@
 package sqlcipher
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"go.uber.org/atomic"
@@ -41,11 +42,14 @@ type Sqlite struct {
 }
 
 func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
+	return WithInstanceContext(context.Background(), instance, config)
+}
+func WithInstanceContext(ctx context.Context, instance *sql.DB, config *Config) (database.Driver, error) {
 	if config == nil {
 		return nil, ErrNilConfig
 	}
 
-	if err := instance.Ping(); err != nil {
+	if err := instance.PingContext(ctx); err != nil {
 		return nil, err
 	}
 
@@ -57,7 +61,7 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 		db:     instance,
 		config: config,
 	}
-	if err := mx.ensureVersionTable(); err != nil {
+	if err := mx.ensureVersionTable(ctx); err != nil {
 		return nil, err
 	}
 	return mx, nil
@@ -66,7 +70,7 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 // ensureVersionTable checks if versions table exists and, if not, creates it.
 // Note that this function locks the database, which deviates from the usual
 // convention of "caller locks" in the Sqlite type.
-func (m *Sqlite) ensureVersionTable() (err error) {
+func (m *Sqlite) ensureVersionTable(ctx context.Context) (err error) {
 	if err = m.Lock(); err != nil {
 		return err
 	}
@@ -86,13 +90,16 @@ func (m *Sqlite) ensureVersionTable() (err error) {
   CREATE UNIQUE INDEX IF NOT EXISTS version_unique ON %s (version);
   `, m.config.MigrationsTable, m.config.MigrationsTable)
 
-	if _, err := m.db.Exec(query); err != nil {
+	if _, err := m.db.ExecContext(ctx, query); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (m *Sqlite) Open(url string) (database.Driver, error) {
+	return m.OpenWithContext(context.Background(), url)
+}
+func (m *Sqlite) OpenWithContext(ctx context.Context, url string) (database.Driver, error) {
 	purl, err := nurl.Parse(url)
 	if err != nil {
 		return nil, err
@@ -118,7 +125,7 @@ func (m *Sqlite) Open(url string) (database.Driver, error) {
 		}
 	}
 
-	mx, err := WithInstance(db, &Config{
+	mx, err := WithInstanceContext(ctx, db, &Config{
 		DatabaseName:    purl.Path,
 		MigrationsTable: migrationsTable,
 		NoTxWrap:        noTxWrap,

--- a/database/sqlcipher/sqlcipher_test.go
+++ b/database/sqlcipher/sqlcipher_test.go
@@ -1,6 +1,7 @@
 package sqlcipher
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io/ioutil"
@@ -35,7 +36,26 @@ func Test(t *testing.T) {
 	}
 	dt.Test(t, d, []byte("CREATE TABLE t (Qty int, Name string);"))
 }
-
+func TestContextCancellation(t *testing.T) {
+	dir, err := ioutil.TempDir("", "sqlite3-driver-test")
+	if err != nil {
+		return
+	}
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Error(err)
+		}
+	}()
+	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
+	p := &Sqlite{}
+	addr := fmt.Sprintf("sqlite3://%s", filepath.Join(dir, "sqlite3.db"))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = p.OpenWithContext(ctx, addr)
+	if err == nil {
+		t.Fatal("Should fail when opened with a canceled context")
+	}
+}
 func TestMigrate(t *testing.T) {
 	dir, err := ioutil.TempDir("", "sqlite3-driver-test")
 	if err != nil {

--- a/database/sqlite/sqlite.go
+++ b/database/sqlite/sqlite.go
@@ -1,6 +1,7 @@
 package sqlite
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"go.uber.org/atomic"
@@ -41,11 +42,14 @@ type Sqlite struct {
 }
 
 func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
+	return WithInstanceContext(context.Background(), instance, config)
+}
+func WithInstanceContext(ctx context.Context, instance *sql.DB, config *Config) (database.Driver, error) {
 	if config == nil {
 		return nil, ErrNilConfig
 	}
 
-	if err := instance.Ping(); err != nil {
+	if err := instance.PingContext(ctx); err != nil {
 		return nil, err
 	}
 
@@ -57,7 +61,7 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 		db:     instance,
 		config: config,
 	}
-	if err := mx.ensureVersionTable(); err != nil {
+	if err := mx.ensureVersionTable(ctx); err != nil {
 		return nil, err
 	}
 	return mx, nil
@@ -66,7 +70,7 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 // ensureVersionTable checks if versions table exists and, if not, creates it.
 // Note that this function locks the database, which deviates from the usual
 // convention of "caller locks" in the Sqlite type.
-func (m *Sqlite) ensureVersionTable() (err error) {
+func (m *Sqlite) ensureVersionTable(ctx context.Context) (err error) {
 	if err = m.Lock(); err != nil {
 		return err
 	}
@@ -86,13 +90,16 @@ func (m *Sqlite) ensureVersionTable() (err error) {
   CREATE UNIQUE INDEX IF NOT EXISTS version_unique ON %s (version);
   `, m.config.MigrationsTable, m.config.MigrationsTable)
 
-	if _, err := m.db.Exec(query); err != nil {
+	if _, err := m.db.ExecContext(ctx, query); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (m *Sqlite) Open(url string) (database.Driver, error) {
+	return m.OpenWithContext(context.Background(), url)
+}
+func (m *Sqlite) OpenWithContext(ctx context.Context, url string) (database.Driver, error) {
 	purl, err := nurl.Parse(url)
 	if err != nil {
 		return nil, err
@@ -118,7 +125,7 @@ func (m *Sqlite) Open(url string) (database.Driver, error) {
 		}
 	}
 
-	mx, err := WithInstance(db, &Config{
+	mx, err := WithInstanceContext(ctx, db, &Config{
 		DatabaseName:    purl.Path,
 		MigrationsTable: migrationsTable,
 		NoTxWrap:        noTxWrap,

--- a/database/sqlite/sqlite_test.go
+++ b/database/sqlite/sqlite_test.go
@@ -1,6 +1,7 @@
 package sqlite
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io/ioutil"
@@ -35,7 +36,26 @@ func Test(t *testing.T) {
 	}
 	dt.Test(t, d, []byte("CREATE TABLE t (Qty int, Name string);"))
 }
-
+func TestContextCancellation(t *testing.T) {
+	dir, err := ioutil.TempDir("", "sqlite-driver-test")
+	if err != nil {
+		return
+	}
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Error(err)
+		}
+	}()
+	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite.db"))
+	p := &Sqlite{}
+	addr := fmt.Sprintf("sqlite://%s", filepath.Join(dir, "sqlite.db"))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = p.OpenWithContext(ctx, addr)
+	if err == nil {
+		t.Fatal("Should fail when opened with a canceled context")
+	}
+}
 func TestMigrate(t *testing.T) {
 	dir, err := ioutil.TempDir("", "sqlite-driver-test")
 	if err != nil {

--- a/database/sqlite3/sqlite3_test.go
+++ b/database/sqlite3/sqlite3_test.go
@@ -1,6 +1,7 @@
 package sqlite3
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io/ioutil"
@@ -35,7 +36,26 @@ func Test(t *testing.T) {
 	}
 	dt.Test(t, d, []byte("CREATE TABLE t (Qty int, Name string);"))
 }
-
+func TestContextCancellation(t *testing.T) {
+	dir, err := ioutil.TempDir("", "sqlite3-driver-test")
+	if err != nil {
+		return
+	}
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Error(err)
+		}
+	}()
+	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
+	p := &Sqlite{}
+	addr := fmt.Sprintf("sqlite3://%s", filepath.Join(dir, "sqlite3.db"))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = p.OpenWithContext(ctx, addr)
+	if err == nil {
+		t.Fatal("Should fail when opened with a canceled context")
+	}
+}
 func TestMigrate(t *testing.T) {
 	dir, err := ioutil.TempDir("", "sqlite3-driver-test")
 	if err != nil {

--- a/database/sqlserver/sqlserver_test.go
+++ b/database/sqlserver/sqlserver_test.go
@@ -98,6 +98,24 @@ func Test(t *testing.T) {
 	})
 }
 
+func TestContextCancellation(t *testing.T) {
+	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ip, port, err := c.Port(defaultPort)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		addr := msConnectionString(ip, port)
+		ctx, cancel := context.WithCancel(context.Background())
+		p := &SQLServer{}
+		cancel()
+		_, err = p.OpenWithContext(ctx, addr)
+		if err == nil {
+			t.Fatal("Should fail when opened with a canceled context")
+		}
+	})
+}
+
 func TestMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.Port(defaultPort)

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -2,6 +2,7 @@ package migrate
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"errors"
 	"io/ioutil"
@@ -73,6 +74,15 @@ func ExampleNew() {
 	// Migrate all the way up ...
 	if err := m.Up(); err != nil && err != ErrNoChange {
 		log.Fatal(err)
+	}
+}
+
+func TestNewWithContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := NewWithContext(ctx, "stub://", "stub://")
+	if err == nil {
+		t.Fatal("expected context canceled error")
 	}
 }
 
@@ -182,6 +192,21 @@ func ExampleNewWithSourceInstance() {
 	// Migrate all the way up ...
 	if err := m.Up(); err != nil {
 		log.Fatal(err)
+	}
+}
+
+func TestNewWithSourceInstanceContext(t *testing.T) {
+	dummySource := &DummyInstance{"source"}
+	sInst, err := sStub.WithInstance(dummySource, &sStub.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = NewWithSourceInstanceContext(ctx, srcDrvNameStub, sInst, "stub://")
+	if err == nil {
+		t.Fatal("expected context canceled error")
 	}
 }
 


### PR DESCRIPTION
This PR adds support for passing a context to database drivers. I've added `migrate.NewWithContext()` and `migrate.NewWithSourceContext()` which accept a context. For each driver, I've added `OpenWithContext` and `WithInstanceContext` which will pass the context to the database during any initial connection. This handles https://github.com/golang-migrate/migrate/issues/571. 