### PR TITLE
Resolves #647 - Fixes typos in Mongo advisory locking parameters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,6 @@
   1. Write awesome code ...
   1. `make test` to run all tests against all database versions
   1. Push code and open Pull Request
- :wq
 Some more helpful commands:
 
   * You can specify which database/ source tests to run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@
   1. Write awesome code ...
   1. `make test` to run all tests against all database versions
   1. Push code and open Pull Request
- 
+ :wq
 Some more helpful commands:
 
   * You can specify which database/ source tests to run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@
   1. Write awesome code ...
   1. `make test` to run all tests against all database versions
   1. Push code and open Pull Request
-
+ 
 Some more helpful commands:
 
   * You can specify which database/ source tests to run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@
   1. Write awesome code ...
   1. `make test` to run all tests against all database versions
   1. Push code and open Pull Request
+
 Some more helpful commands:
 
   * You can specify which database/ source tests to run:

--- a/database/mongodb/README.md
+++ b/database/mongodb/README.md
@@ -15,8 +15,8 @@
 | `x-transaction-mode` | `TransactionMode` | If set to `true` wrap commands in [transaction](https://docs.mongodb.com/manual/core/transactions). Available only for replica set. Driver is using [strconv.ParseBool](https://golang.org/pkg/strconv/#ParseBool) for parsing|
 | `x-advisory-locking` | `true` | Feature flag for advisory locking, if set to false, disable advisory locking |
 | `x-advisory-lock-collection` | `migrate_advisory_lock` | The name of the collection to use for advisory locking.|
-| `x-advisory-lock-timout` | `15` | The max time in seconds that the advisory lock will wait if the db is already locked. |
-| `x-advisory-lock-timout-interval` | `10` | The max timeout in seconds interval that the advisory lock will wait if the db is already locked. |
+| `x-advisory-lock-timeout` | `15` | The max time in seconds that migrate will wait to acquire a lock before failing. |
+| `x-advisory-lock-timeout-interval` | `10` | The max time in seconds between attempts to acquire the advisory lock, the lock is attempted to be acquired using an exponential backoff algorithm. |
 | `dbname` | `DatabaseName` | The name of the database to connect to |
 | `user` | | The user to sign in as. Can be omitted |
 | `password` | | The user's password. Can be omitted | 

--- a/database/mongodb/mongodb.go
+++ b/database/mongodb/mongodb.go
@@ -36,7 +36,7 @@ const LockIndexName = "lock_unique_key"                  // the name of the inde
 const contextWaitTimeout = 5 * time.Second               // how long to wait for the request to mongo to block/wait for.
 
 var (
-	ErrNoDatabaseName = fmt.Errorf("no database name")
+	ErrNoDatabaseName        = fmt.Errorf("no database name")
 	ErrNilConfig             = fmt.Errorf("no config")
 	ErrTypoAndNotNonTypoUsed = fmt.Errorf("both x-advisory-lock-timeout-interval and x-advisory-lock-timout-interval were specified")
 )
@@ -146,9 +146,9 @@ func (m *Mongo) Open(dsn string) (database.Driver, error) {
 
 	lockTimeout := lockTimeoutIntervalValue
 
-	if (lockTimeoutIntervalValue != "" && lockTimeoutIntervalValueFromTypo != "") {
+	if lockTimeoutIntervalValue != "" && lockTimeoutIntervalValueFromTypo != "" {
 		return nil, ErrTypoAndNotNonTypoUsed
-	} else if (lockTimeoutIntervalValueFromTypo != "") {
+	} else if lockTimeoutIntervalValueFromTypo != "" {
 		lockTimeout = lockTimeoutIntervalValueFromTypo
 	}
 

--- a/database/mongodb/mongodb.go
+++ b/database/mongodb/mongodb.go
@@ -36,7 +36,7 @@ const LockIndexName = "lock_unique_key"                  // the name of the inde
 const contextWaitTimeout = 5 * time.Second               // how long to wait for the request to mongo to block/wait for.
 
 var (
-	ErrNoDatabaseName        = fmt.Errorf("no database name")
+	ErrNoDatabaseName            = fmt.Errorf("no database name")
 	ErrNilConfig                 = fmt.Errorf("no config")
 	ErrLockTimeoutConfigConflict = fmt.Errorf("both x-advisory-lock-timeout-interval and x-advisory-lock-timout-interval were specified")
 )

--- a/database/mongodb/mongodb.go
+++ b/database/mongodb/mongodb.go
@@ -37,8 +37,8 @@ const contextWaitTimeout = 5 * time.Second               // how long to wait for
 
 var (
 	ErrNoDatabaseName        = fmt.Errorf("no database name")
-	ErrNilConfig             = fmt.Errorf("no config")
-	ErrTypoAndNotNonTypoUsed = fmt.Errorf("both x-advisory-lock-timeout-interval and x-advisory-lock-timout-interval were specified")
+	ErrNilConfig                 = fmt.Errorf("no config")
+	ErrLockTimeoutConfigConflict = fmt.Errorf("both x-advisory-lock-timeout-interval and x-advisory-lock-timout-interval were specified")
 )
 
 type Mongo struct {
@@ -147,7 +147,7 @@ func (m *Mongo) Open(dsn string) (database.Driver, error) {
 	lockTimeout := lockTimeoutIntervalValue
 
 	if lockTimeoutIntervalValue != "" && lockTimeoutIntervalValueFromTypo != "" {
-		return nil, ErrTypoAndNotNonTypoUsed
+		return nil, ErrLockTimeoutConfigConflict
 	} else if lockTimeoutIntervalValueFromTypo != "" {
 		lockTimeout = lockTimeoutIntervalValueFromTypo
 	}


### PR DESCRIPTION
`make-test` was failing a bunch for me on neo4j, and mssql, not sure if it's just my environment however. I can investigate if you think it's a risk.

This is for #647 