### PR TITLE
Use DELETE FROM instead of TRUNCATE for MySQL

### DIFF
--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -341,7 +341,7 @@ func (m *Mysql) SetVersion(version int, dirty bool) error {
 		return &database.Error{OrigErr: err, Err: "transaction start failed"}
 	}
 
-	query := "TRUNCATE `" + m.config.MigrationsTable + "`"
+	query := "DELETE FROM `" + m.config.MigrationsTable + "`"
 	if _, err := tx.ExecContext(context.Background(), query); err != nil {
 		if errRollback := tx.Rollback(); errRollback != nil {
 			err = multierror.Append(err, errRollback)

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -336,7 +336,7 @@ func (m *Mysql) Run(migration io.Reader) error {
 }
 
 func (m *Mysql) SetVersion(version int, dirty bool) error {
-	tx, err := m.conn.BeginTx(context.Background(), &sql.TxOptions{})
+	tx, err := m.conn.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
 		return &database.Error{OrigErr: err, Err: "transaction start failed"}
 	}


### PR DESCRIPTION
Resolves issue #584 

In MySQL, TRUNCATE statements cannot be rolled back, at least for 5.7:
- https://dev.mysql.com/doc/refman/5.7/en/truncate-table.html
- https://dev.mysql.com/doc/refman/5.7/en/implicit-commit.html

This is another attempt at fixing, as the previous PR #585 has stalled. The credit goes to @martinarrieta