### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ __[CLI Documentation](cmd/migrate)__
 ### Basic usage
 
 ```bash
-$ migrate -source file://path/to/migrations -database postgres://localhost:5432/database up 2
+$ migrate -source file://path/to/migrations -database "postgres://localhost:5432/database" up 2
 ```
 
 ### Docker usage


### PR DESCRIPTION
It makes sense to just add the quotes to the basic usage because the vast majority of people are going to be running migrations locally, and a large chunk of people will need to use query params, which completely break since they need to be escaped. The vast majority of people trying this are going to miss the giant paragraph about url schemes 3 sections up. 

https://github.com/golang-migrate/migrate/issues/9 
https://github.com/golang-migrate/migrate/issues/255#issuecomment-588993062