### PR TITLE
Include URL in bad URL error message, wrap error describing problem

### DIFF
--- a/internal/url/url.go
+++ b/internal/url/url.go
@@ -2,6 +2,7 @@ package url
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 )
 
@@ -11,15 +12,20 @@ var errEmptyURL = errors.New("URL cannot be empty")
 // schemeFromURL returns the scheme from a URL string
 func SchemeFromURL(url string) (string, error) {
 	if url == "" {
-		return "", errEmptyURL
+		return "", errorWithURL(url, errEmptyURL)
 	}
 
 	i := strings.Index(url, ":")
 
 	// No : or : is the first character.
 	if i < 1 {
-		return "", errNoScheme
+		return "", errorWithURL(url, errNoScheme)
 	}
 
 	return url[0:i], nil
+}
+
+// errorWithURL creates a new error including the provided url and wrapping the error it caused
+func errorWithURL(url string, err error) error {
+	return fmt.Errorf("invalid URL '%s': %w", url, err)
 }

--- a/internal/url/url_test.go
+++ b/internal/url/url_test.go
@@ -1,6 +1,7 @@
 package url
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -37,7 +38,7 @@ func TestSchemeFromUrl(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			s, err := SchemeFromURL(tc.urlStr)
-			if err != tc.expectErr {
+			if !errors.Is(err, tc.expectErr) {
 				t.Fatalf("expected %q, but received %q", tc.expectErr, err)
 			}
 			if s != tc.expected {


### PR DESCRIPTION
When failing to extract a scheme from a URL, include the URL in the error message. This would make it easier to disambiguate between faulty database URLs and faulty source URLs.