### PR TITLE
Allow multi-statement mode to be enabled per-migration in Postgres

### DIFF
--- a/database/multistmt/constants.go
+++ b/database/multistmt/constants.go
@@ -1,0 +1,5 @@
+package multistmt
+
+const (
+	MultiStatementCommentFlag = "migrate:x-multi-statement"
+)

--- a/database/postgres/README.md
+++ b/database/postgres/README.md
@@ -12,14 +12,14 @@
 | `dbname` | `DatabaseName` | The name of the database to connect to |
 | `search_path` | | This variable specifies the order in which schemas are searched when an object is referenced by a simple name with no schema specified. |
 | `user` | | The user to sign in as |
-| `password` | | The user's password | 
+| `password` | | The user's password |
 | `host` | | The host to connect to. Values that start with / are for unix domain sockets. (default is localhost) |
 | `port` | | The port to bind to. (default is 5432) |
 | `fallback_application_name` | | An application_name to fall back to if one isn't provided. |
 | `connect_timeout` | | Maximum wait for connection, in seconds. Zero or not specified means wait indefinitely. |
 | `sslcert` | | Cert file location. The file must contain PEM encoded data. |
 | `sslkey` | | Key file location. The file must contain PEM encoded data. |
-| `sslrootcert` | | The location of the root certificate file. The file must contain PEM encoded data. | 
+| `sslrootcert` | | The location of the root certificate file. The file must contain PEM encoded data. |
 | `sslmode` | | Whether or not to use SSL (disable\|require\|verify-ca\|verify-full) |
 
 
@@ -37,3 +37,6 @@ In PostgreSQL running multiple SQL statements in one `Exec` executes them inside
 behavior is not desirable because some statements can be only run outside of transaction (e.g.
 `CREATE INDEX CONCURRENTLY`). If you want to use `CREATE INDEX CONCURRENTLY` without activating multi-statement mode
 you have to put such statements in a separate migration files.
+
+To activate multi-statement mode for a specific migration, before the migration SQL include the string `migrate:x-multi-statement` anywhere in a comment (single line or multi-line).
+To activate multi-statement mode for every migration, append the url query param above to your db dsn or use the WithInstance config option.


### PR DESCRIPTION
### overview.
The multi-statement mode work for Postgres is fantastic and addresses a long-standing issue we've had with this. By design, the multi-statement mode parser is meant to be pretty basic. It works well in the base case, but unfortunately it does break when doing things like function and stored procedures CREATE/UPDATES, as lines in these are expected to terminate with semicolons

An example of a problematic migration:
```sql
-- create function
CREATE OR REPLACE FUNCTION update_modified()
RETURNS TRIGGER AS $$
BEGIN
    NEW.modified = now();
    RETURN NEW;
END;
$$ language 'plpgsql';
```

The goal of this PR is to allow per-migration enablement of multi-statement mode (while still allowing global enablement if necessary) via a flag within the migration itself.
This is admittedly still a relatively naive approach, as it is for the full file

Inspiration for this was gleaned from sql-migrate, which we can see attempts to address the problem in a similar manner
https://github.com/rubenv/sql-migrate/blob/f842348935589e4563be545226d465178bd439cf/sqlparse/sqlparse.go#L106