### PR TITLE
Incorrect DSN example for Clickhouse

### DIFF
--- a/database/clickhouse/README.md
+++ b/database/clickhouse/README.md
@@ -1,6 +1,6 @@
 # ClickHouse
 
-`clickhouse://host:port?username=user&password=qwerty&database=clicks&x-multi-statement=true`
+`clickhouse://username:password@host:port/database=clicks?x-multi-statement=true`
 
 | URL Query  | Description |
 |------------|-------------|


### PR DESCRIPTION
The current example for the Clickhouse DSN is incorrect and will result in the client trying to use the default username, database, and password regardless of what is set in the DSN. This change fixes the DNS example to be correct for the current versions of the clickhouse-go client.

You can see the current format of the DSN here to verify: https://github.com/ClickHouse/clickhouse-go#dsn