### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/database/ql/ql_test.go
+++ b/database/ql/ql_test.go
@@ -3,8 +3,6 @@ package ql
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -15,15 +13,7 @@ import (
 )
 
 func Test(t *testing.T) {
-	dir, err := ioutil.TempDir("", "ql-driver-test")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "ql.db"))
 	p := &Ql{}
 	addr := fmt.Sprintf("ql://%s", filepath.Join(dir, "ql.db"))
@@ -45,15 +35,7 @@ func Test(t *testing.T) {
 }
 
 func TestMigrate(t *testing.T) {
-	dir, err := ioutil.TempDir("", "ql-driver-test")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Error(err)
-		}
-	}()
+	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "ql.db"))
 
 	db, err := sql.Open("ql", filepath.Join(dir, "ql.db"))

--- a/database/sqlcipher/sqlcipher_test.go
+++ b/database/sqlcipher/sqlcipher_test.go
@@ -3,8 +3,6 @@ package sqlcipher
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -17,15 +15,7 @@ import (
 )
 
 func Test(t *testing.T) {
-	dir, err := ioutil.TempDir("", "sqlite3-driver-test")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Error(err)
-		}
-	}()
+	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
 	p := &Sqlite{}
 	addr := fmt.Sprintf("sqlite3://%s", filepath.Join(dir, "sqlite3.db"))
@@ -37,15 +27,7 @@ func Test(t *testing.T) {
 }
 
 func TestMigrate(t *testing.T) {
-	dir, err := ioutil.TempDir("", "sqlite3-driver-test")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Error(err)
-		}
-	}()
+	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
 
 	db, err := sql.Open("sqlite3", filepath.Join(dir, "sqlite3.db"))
@@ -72,15 +54,7 @@ func TestMigrate(t *testing.T) {
 }
 
 func TestMigrationTable(t *testing.T) {
-	dir, err := ioutil.TempDir("", "sqlite3-driver-test-migration-table")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Error(err)
-		}
-	}()
+	dir := t.TempDir()
 
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
 
@@ -120,15 +94,7 @@ func TestMigrationTable(t *testing.T) {
 }
 
 func TestNoTxWrap(t *testing.T) {
-	dir, err := ioutil.TempDir("", "sqlite3-driver-test")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Error(err)
-		}
-	}()
+	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
 	p := &Sqlite{}
 	addr := fmt.Sprintf("sqlite3://%s?x-no-tx-wrap=true", filepath.Join(dir, "sqlite3.db"))
@@ -142,19 +108,11 @@ func TestNoTxWrap(t *testing.T) {
 }
 
 func TestNoTxWrapInvalidValue(t *testing.T) {
-	dir, err := ioutil.TempDir("", "sqlite3-driver-test")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Error(err)
-		}
-	}()
+	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
 	p := &Sqlite{}
 	addr := fmt.Sprintf("sqlite3://%s?x-no-tx-wrap=yeppers", filepath.Join(dir, "sqlite3.db"))
-	_, err = p.Open(addr)
+	_, err := p.Open(addr)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "x-no-tx-wrap")
 		assert.Contains(t, err.Error(), "invalid syntax")

--- a/database/sqlite/sqlite_test.go
+++ b/database/sqlite/sqlite_test.go
@@ -3,8 +3,6 @@ package sqlite
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -17,15 +15,7 @@ import (
 )
 
 func Test(t *testing.T) {
-	dir, err := ioutil.TempDir("", "sqlite-driver-test")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Error(err)
-		}
-	}()
+	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite.db"))
 	p := &Sqlite{}
 	addr := fmt.Sprintf("sqlite://%s", filepath.Join(dir, "sqlite.db"))
@@ -37,15 +27,7 @@ func Test(t *testing.T) {
 }
 
 func TestMigrate(t *testing.T) {
-	dir, err := ioutil.TempDir("", "sqlite-driver-test")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Error(err)
-		}
-	}()
+	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite.db"))
 
 	db, err := sql.Open("sqlite", filepath.Join(dir, "sqlite.db"))
@@ -72,15 +54,7 @@ func TestMigrate(t *testing.T) {
 }
 
 func TestMigrationTable(t *testing.T) {
-	dir, err := ioutil.TempDir("", "sqlite-driver-test-migration-table")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Error(err)
-		}
-	}()
+	dir := t.TempDir()
 
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite.db"))
 
@@ -120,15 +94,7 @@ func TestMigrationTable(t *testing.T) {
 }
 
 func TestNoTxWrap(t *testing.T) {
-	dir, err := ioutil.TempDir("", "sqlite-driver-test")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Error(err)
-		}
-	}()
+	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite.db"))
 	p := &Sqlite{}
 	addr := fmt.Sprintf("sqlite://%s?x-no-tx-wrap=true", filepath.Join(dir, "sqlite.db"))
@@ -142,19 +108,11 @@ func TestNoTxWrap(t *testing.T) {
 }
 
 func TestNoTxWrapInvalidValue(t *testing.T) {
-	dir, err := ioutil.TempDir("", "sqlite-driver-test")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Error(err)
-		}
-	}()
+	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite.db"))
 	p := &Sqlite{}
 	addr := fmt.Sprintf("sqlite://%s?x-no-tx-wrap=yeppers", filepath.Join(dir, "sqlite.db"))
-	_, err = p.Open(addr)
+	_, err := p.Open(addr)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "x-no-tx-wrap")
 		assert.Contains(t, err.Error(), "invalid syntax")
@@ -162,15 +120,7 @@ func TestNoTxWrapInvalidValue(t *testing.T) {
 }
 
 func TestMigrateWithDirectoryNameContainsWhitespaces(t *testing.T) {
-	dir, err := ioutil.TempDir("", "directory name contains whitespaces")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Error(err)
-		}
-	}()
+	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "sqlite.db")
 	t.Logf("DB path : %s\n", dbPath)
 	p := &Sqlite{}

--- a/database/sqlite3/sqlite3_test.go
+++ b/database/sqlite3/sqlite3_test.go
@@ -3,8 +3,6 @@ package sqlite3
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -17,15 +15,7 @@ import (
 )
 
 func Test(t *testing.T) {
-	dir, err := ioutil.TempDir("", "sqlite3-driver-test")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Error(err)
-		}
-	}()
+	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
 	p := &Sqlite{}
 	addr := fmt.Sprintf("sqlite3://%s", filepath.Join(dir, "sqlite3.db"))
@@ -37,15 +27,7 @@ func Test(t *testing.T) {
 }
 
 func TestMigrate(t *testing.T) {
-	dir, err := ioutil.TempDir("", "sqlite3-driver-test")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Error(err)
-		}
-	}()
+	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
 
 	db, err := sql.Open("sqlite3", filepath.Join(dir, "sqlite3.db"))
@@ -72,15 +54,7 @@ func TestMigrate(t *testing.T) {
 }
 
 func TestMigrationTable(t *testing.T) {
-	dir, err := ioutil.TempDir("", "sqlite3-driver-test-migration-table")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Error(err)
-		}
-	}()
+	dir := t.TempDir()
 
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
 
@@ -120,15 +94,7 @@ func TestMigrationTable(t *testing.T) {
 }
 
 func TestNoTxWrap(t *testing.T) {
-	dir, err := ioutil.TempDir("", "sqlite3-driver-test")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Error(err)
-		}
-	}()
+	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
 	p := &Sqlite{}
 	addr := fmt.Sprintf("sqlite3://%s?x-no-tx-wrap=true", filepath.Join(dir, "sqlite3.db"))
@@ -142,19 +108,11 @@ func TestNoTxWrap(t *testing.T) {
 }
 
 func TestNoTxWrapInvalidValue(t *testing.T) {
-	dir, err := ioutil.TempDir("", "sqlite3-driver-test")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Error(err)
-		}
-	}()
+	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
 	p := &Sqlite{}
 	addr := fmt.Sprintf("sqlite3://%s?x-no-tx-wrap=yeppers", filepath.Join(dir, "sqlite3.db"))
-	_, err = p.Open(addr)
+	_, err := p.Open(addr)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "x-no-tx-wrap")
 		assert.Contains(t, err.Error(), "invalid syntax")
@@ -162,15 +120,7 @@ func TestNoTxWrapInvalidValue(t *testing.T) {
 }
 
 func TestMigrateWithDirectoryNameContainsWhitespaces(t *testing.T) {
-	dir, err := ioutil.TempDir("", "directory name contains whitespaces")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Error(err)
-		}
-	}()
+	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "sqlite3.db")
 	t.Logf("DB path : %s\n", dbPath)
 	p := &Sqlite{}

--- a/source/file/file_test.go
+++ b/source/file/file_test.go
@@ -13,15 +13,7 @@ import (
 )
 
 func Test(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			t.Error(err)
-		}
-	}()
+	tmpDir := t.TempDir()
 
 	// write files that meet driver test requirements
 	mustWriteFile(t, tmpDir, "1_foobar.up.sql", "1 up")
@@ -47,15 +39,7 @@ func Test(t *testing.T) {
 }
 
 func TestOpen(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "TestOpen")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			t.Error(err)
-		}
-	}()
+	tmpDir := t.TempDir()
 
 	mustWriteFile(t, tmpDir, "1_foobar.up.sql", "")
 	mustWriteFile(t, tmpDir, "1_foobar.down.sql", "")
@@ -65,22 +49,14 @@ func TestOpen(t *testing.T) {
 	}
 
 	f := &File{}
-	_, err = f.Open("file://" + tmpDir) // absolute path
+	_, err := f.Open("file://" + tmpDir) // absolute path
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestOpenWithRelativePath(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "TestOpen")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			t.Error(err)
-		}
-	}()
+	tmpDir := t.TempDir()
 
 	wd, err := os.Getwd()
 	if err != nil {
@@ -144,36 +120,20 @@ func TestOpenDefaultsToCurrentDirectory(t *testing.T) {
 }
 
 func TestOpenWithDuplicateVersion(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "TestOpenWithDuplicateVersion")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			t.Error(err)
-		}
-	}()
+	tmpDir := t.TempDir()
 
 	mustWriteFile(t, tmpDir, "1_foo.up.sql", "") // 1 up
 	mustWriteFile(t, tmpDir, "1_bar.up.sql", "") // 1 up
 
 	f := &File{}
-	_, err = f.Open("file://" + tmpDir)
+	_, err := f.Open("file://" + tmpDir)
 	if err == nil {
 		t.Fatal("expected err")
 	}
 }
 
 func TestClose(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "TestOpen")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			t.Error(err)
-		}
-	}()
+	tmpDir := t.TempDir()
 
 	f := &File{}
 	d, err := f.Open("file://" + tmpDir)
@@ -193,10 +153,7 @@ func mustWriteFile(t testing.TB, dir, file string, body string) {
 }
 
 func mustCreateBenchmarkDir(t *testing.B) (dir string) {
-	tmpDir, err := ioutil.TempDir("", "Benchmark")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tmpDir := t.TempDir()
 
 	for i := 0; i < 1000; i++ {
 		mustWriteFile(t, tmpDir, fmt.Sprintf("%v_foobar.up.sql", i), "")


### PR DESCRIPTION
We can write less code by using the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir