### PR TITLE
Expose configuring cassandra connect timeout through query string

### DIFF
--- a/database/cassandra/README.md
+++ b/database/cassandra/README.md
@@ -20,6 +20,7 @@ system_schema table which comes with 3.X
 | `consistency` | ALL | Migration consistency
 | `protocol` |  | Cassandra protocol version (3 or 4)
 | `timeout` | 1 minute | Migration timeout
+| `connect-timeout` | 600ms | Initial connection timeout to the cluster |
 | `username` | nil | Username to use when authenticating. |
 | `password` | nil | Password to use when authenticating. |
 | `sslcert` | | Cert file location. The file must contain PEM encoded data. |

--- a/database/cassandra/cassandra.go
+++ b/database/cassandra/cassandra.go
@@ -133,6 +133,14 @@ func (c *Cassandra) Open(url string) (database.Driver, error) {
 		}
 		cluster.Timeout = timeout
 	}
+	if len(u.Query().Get("connect-timeout")) > 0 {
+		var connectTimeout time.Duration
+		connectTimeout, err = time.ParseDuration(u.Query().Get("connect-timeout"))
+		if err != nil {
+			return nil, err
+		}
+		cluster.ConnectTimeout = connectTimeout
+	}
 
 	if len(u.Query().Get("sslmode")) > 0 {
 		if u.Query().Get("sslmode") != "disable" {


### PR DESCRIPTION
Exposes the cassandra client's ConnectTimeout parameter through
the cassandra database query string.

The Cassandra client has a fairly aggressive connect timeout of
600ms, which can cause flakiness in certain network environments
or in Cassandra-compatible clusters with a more complex process
for establishing connections (i.e. ScyllaDB).

The query timeout is already configurable and exposed, but does
not impact the connect timeout in the gocql driver. This change
allows for configurtion of both.