### PR TITLE
Revert "fix: incorrect clickhouse dns example"

### DIFF
--- a/database/clickhouse/README.md
+++ b/database/clickhouse/README.md
@@ -1,6 +1,6 @@
 # ClickHouse
 
-`clickhouse://username:password@host:port/database=clicks?x-multi-statement=true`
+`clickhouse://host:port?username=user&password=qwerty&database=clicks&x-multi-statement=true`
 
 | URL Query  | Description |
 |------------|-------------|


### PR DESCRIPTION
This reverts commit 81cbc9c0582a35289c8caed45d676bf6497c9618.

The current clickhouse-go driver's version is 1.4.3, this version's
driver doesn't support reading username/password using the following
DSN:
`clickhouse://username:password@host:port`

This is the origin spec on the DSN format from the upstream:
`tcp://host1:9000?username=user&password=qwerty  ....`

please refer to https://github.com/ClickHouse/clickhouse-go/tree/v1.4.3

This doc needs to be updated once the driver is updated to v2.