### PR TITLE
Run SQL server tests on Azure SQL Edge

### DIFF
--- a/database/sqlserver/sqlserver_test.go
+++ b/database/sqlserver/sqlserver_test.go
@@ -6,11 +6,13 @@ import (
 	sqldriver "database/sql/driver"
 	"fmt"
 	"log"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/dhui/dktest"
+	"github.com/docker/go-connections/nat"
 	"github.com/golang-migrate/migrate/v4"
 
 	dt "github.com/golang-migrate/migrate/v4/database/testing"
@@ -23,14 +25,27 @@ const defaultPort = 1433
 const saPassword = "Root1234"
 
 var (
-	opts = dktest.Options{
-		Env:          map[string]string{"ACCEPT_EULA": "Y", "SA_PASSWORD": saPassword, "MSSQL_PID": "Express"},
+	sqlEdgeOpts = dktest.Options{
+		Env: map[string]string{"ACCEPT_EULA": "Y", "MSSQL_SA_PASSWORD": saPassword},
+		PortBindings: map[nat.Port][]nat.PortBinding{
+			nat.Port(fmt.Sprintf("%d/tcp", defaultPort)): {
+				nat.PortBinding{
+					HostIP:   "0.0.0.0",
+					HostPort: "0/tcp",
+				},
+			},
+		},
+		PortRequired: true, ReadyFunc: isReady, PullTimeout: 2 * time.Minute,
+	}
+	sqlServerOpts = dktest.Options{
+		Env:          map[string]string{"ACCEPT_EULA": "Y", "MSSQL_SA_PASSWORD": saPassword, "MSSQL_PID": "Express"},
 		PortRequired: true, ReadyFunc: isReady, PullTimeout: 2 * time.Minute,
 	}
 	// Container versions: https://mcr.microsoft.com/v2/mssql/server/tags/list
 	specs = []dktesting.ContainerSpec{
-		{ImageName: "mcr.microsoft.com/mssql/server:2017-latest", Options: opts},
-		{ImageName: "mcr.microsoft.com/mssql/server:2019-latest", Options: opts},
+		{ImageName: "mcr.microsoft.com/azure-sql-edge:latest", Options: sqlEdgeOpts},
+		{ImageName: "mcr.microsoft.com/mssql/server:2017-latest", Options: sqlServerOpts},
+		{ImageName: "mcr.microsoft.com/mssql/server:2019-latest", Options: sqlServerOpts},
 	}
 )
 
@@ -74,8 +89,15 @@ func isReady(ctx context.Context, c dktest.ContainerInfo) bool {
 	return true
 }
 
+func SkipIfUnsupportedArch(t *testing.T, c dktest.ContainerInfo) {
+	if strings.Contains(c.ImageName, "mssql") && !strings.HasPrefix(runtime.GOARCH, "amd") {
+		t.Skip(fmt.Sprintf("Image %s is not supported on arch %s", c.ImageName, runtime.GOARCH))
+	}
+}
+
 func Test(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		SkipIfUnsupportedArch(t, c)
 		ip, port, err := c.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
@@ -100,6 +122,7 @@ func Test(t *testing.T) {
 
 func TestMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		SkipIfUnsupportedArch(t, c)
 		ip, port, err := c.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
@@ -128,7 +151,8 @@ func TestMigrate(t *testing.T) {
 
 func TestMultiStatement(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
-		ip, port, err := c.FirstPort()
+		SkipIfUnsupportedArch(t, c)
+		ip, port, err := c.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -161,12 +185,14 @@ func TestMultiStatement(t *testing.T) {
 
 func TestErrorParsing(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
-		ip, port, err := c.FirstPort()
+		SkipIfUnsupportedArch(t, c)
+		ip, port, err := c.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		addr := msConnectionString(ip, port)
+
 		p := &SQLServer{}
 		d, err := p.Open(addr)
 		if err != nil {
@@ -191,6 +217,7 @@ func TestErrorParsing(t *testing.T) {
 
 func TestLockWorks(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		SkipIfUnsupportedArch(t, c)
 		ip, port, err := c.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
@@ -229,6 +256,7 @@ func TestLockWorks(t *testing.T) {
 
 func TestMsiTrue(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		SkipIfUnsupportedArch(t, c)
 		ip, port, err := c.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
@@ -245,6 +273,7 @@ func TestMsiTrue(t *testing.T) {
 
 func TestOpenWithPasswordAndMSI(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		SkipIfUnsupportedArch(t, c)
 		ip, port, err := c.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
@@ -276,6 +305,7 @@ func TestOpenWithPasswordAndMSI(t *testing.T) {
 
 func TestMsiFalse(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		SkipIfUnsupportedArch(t, c)
 		ip, port, err := c.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/denisenkom/go-mssqldb v0.10.0
 	github.com/dhui/dktest v0.3.9
 	github.com/docker/docker v20.10.12+incompatible
+	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712 // indirect
 	github.com/envoyproxy/go-control-plane v0.10.1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.6.2 // indirect


### PR DESCRIPTION
While taking a look at floating #666 on an internal fork, I learned that the mssql images are x86 only. This means that if you run the tests on an m1 mac today, a bunch of them will fail.

Microsoft is a long way from releasing an arm build of SQL Server, so we can't really wait on it. However, they've released an IOT flavor of SQL Server called [Azure SQL Edge](https://hub.docker.com/_/microsoft-azure-sql-edge) which *does* have arm builds (fun fact, it can run on a raspberry pi) and which is in many cases a drop-in replacement.

tl;dr: This PR adds this image to the tested specs in `sqlserver_test.go` and only adds the existing `mssql` images if the runtime architecture is x64-compatible.

Note, I did some slightly funky things with setting up the edge container spec and the port lookup. The current logic assumes that there's only one exposed port on any given image and grabs "the first one" in multiple cases. Unlike the mssql images, the edge image exposes a handful of other ports that coincidentally get listed prior to the port we actually want - hence, manually setting the port to the one we expect and manually passing a port map to the edge options.

I have mssql tests *with edge* passing locally, and I have the full mssql test suite passing in our org's fork. However, the CI tests aren't passing here. I believe these failures are due to other databases and I consider fixing those out-of-scope for this change, so I haven't attempted to fix these non-mssql tests.