### PR TITLE
Replace deprecated ioutil pkg with os & io

### DIFF
--- a/database/cassandra/cassandra.go
+++ b/database/cassandra/cassandra.go
@@ -3,13 +3,13 @@ package cassandra
 import (
 	"errors"
 	"fmt"
-	"go.uber.org/atomic"
 	"io"
-	"io/ioutil"
 	nurl "net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	"go.uber.org/atomic"
 
 	"github.com/gocql/gocql"
 	"github.com/golang-migrate/migrate/v4/database"
@@ -231,7 +231,7 @@ func (c *Cassandra) Run(migration io.Reader) error {
 		return err
 	}
 
-	migr, err := ioutil.ReadAll(migration)
+	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
 	}

--- a/database/clickhouse/clickhouse.go
+++ b/database/clickhouse/clickhouse.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"strconv"
 	"strings"
@@ -153,7 +152,7 @@ func (ch *ClickHouse) Run(r io.Reader) error {
 		return err
 	}
 
-	migration, err := ioutil.ReadAll(r)
+	migration, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/database/cockroachdb/cockroachdb.go
+++ b/database/cockroachdb/cockroachdb.go
@@ -4,23 +4,17 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"go.uber.org/atomic"
 	"io"
-	"io/ioutil"
 	nurl "net/url"
 	"regexp"
 	"strconv"
-)
 
-import (
 	"github.com/cockroachdb/cockroach-go/v2/crdb"
-	"github.com/hashicorp/go-multierror"
-	"github.com/lib/pq"
-)
-
-import (
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database"
+	"github.com/hashicorp/go-multierror"
+	"github.com/lib/pq"
+	"go.uber.org/atomic"
 )
 
 func init() {
@@ -217,7 +211,7 @@ func (c *CockroachDb) Unlock() error {
 }
 
 func (c *CockroachDb) Run(migration io.Reader) error {
-	migr, err := ioutil.ReadAll(migration)
+	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
 	}

--- a/database/firebird/firebird.go
+++ b/database/firebird/firebird.go
@@ -7,14 +7,14 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"io"
+	nurl "net/url"
+
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database"
 	"github.com/hashicorp/go-multierror"
 	_ "github.com/nakagami/firebirdsql"
 	"go.uber.org/atomic"
-	"io"
-	"io/ioutil"
-	nurl "net/url"
 )
 
 func init() {
@@ -122,7 +122,7 @@ func (f *Firebird) Unlock() error {
 }
 
 func (f *Firebird) Run(migration io.Reader) error {
-	migr, err := ioutil.ReadAll(migration)
+	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
 	}

--- a/database/mongodb/mongodb.go
+++ b/database/mongodb/mongodb.go
@@ -3,6 +3,12 @@ package mongodb
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+
 	"github.com/cenkalti/backoff/v4"
 	"github.com/golang-migrate/migrate/v4/database"
 	"github.com/hashicorp/go-multierror"
@@ -11,12 +17,6 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
 	"go.uber.org/atomic"
-	"io"
-	"io/ioutil"
-	"net/url"
-	os "os"
-	"strconv"
-	"time"
 )
 
 func init() {
@@ -114,7 +114,7 @@ func WithInstance(instance *mongo.Client, config *Config) (database.Driver, erro
 }
 
 func (m *Mongo) Open(dsn string) (database.Driver, error) {
-	//connstring is experimental package, but it used for parse connection string in mongo.Connect function
+	// connstring is experimental package, but it used for parse connection string in mongo.Connect function
 	uri, err := connstring.Parse(dsn)
 	if err != nil {
 		return nil, err
@@ -182,7 +182,7 @@ func (m *Mongo) Open(dsn string) (database.Driver, error) {
 	return mc, nil
 }
 
-//Parse the url param, convert it to boolean
+// Parse the url param, convert it to boolean
 // returns error if param invalid. returns defaultValue if param not present
 func parseBoolean(urlParam string, defaultValue bool) (bool, error) {
 
@@ -199,7 +199,7 @@ func parseBoolean(urlParam string, defaultValue bool) (bool, error) {
 	return defaultValue, nil
 }
 
-//Parse the url param, convert it to int
+// Parse the url param, convert it to int
 // returns error if param invalid. returns defaultValue if param not present
 func parseInt(urlParam string, defaultValue int) (int, error) {
 
@@ -241,7 +241,7 @@ func (m *Mongo) Version() (version int, dirty bool, err error) {
 }
 
 func (m *Mongo) Run(migration io.Reader) error {
-	migr, err := ioutil.ReadAll(migration)
+	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
 	}
@@ -268,8 +268,8 @@ func (m *Mongo) executeCommandsWithTransaction(ctx context.Context, cmds []bson.
 			return &database.Error{OrigErr: err, Err: "failed to start transaction"}
 		}
 		if err := m.executeCommands(sessionContext, cmds); err != nil {
-			//When command execution is failed, it's aborting transaction
-			//If you tried to call abortTransaction, it`s return error that transaction already aborted
+			// When command execution is failed, it's aborting transaction
+			// If you tried to call abortTransaction, it`s return error that transaction already aborted
 			return err
 		}
 		if err := sessionContext.CommitTransaction(sessionContext); err != nil {

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -9,12 +9,13 @@ import (
 	"crypto/x509"
 	"database/sql"
 	"fmt"
-	"go.uber.org/atomic"
 	"io"
-	"io/ioutil"
 	nurl "net/url"
+	"os"
 	"strconv"
 	"strings"
+
+	"go.uber.org/atomic"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/golang-migrate/migrate/v4/database"
@@ -154,7 +155,7 @@ func urlToMySQLConfig(url string) (*mysql.Config, error) {
 		if len(ctls) > 0 {
 			if _, isBool := readBool(ctls); !isBool && strings.ToLower(ctls) != "skip-verify" {
 				rootCertPool := x509.NewCertPool()
-				pem, err := ioutil.ReadFile(parsedParams.Get("x-tls-ca"))
+				pem, err := os.ReadFile(parsedParams.Get("x-tls-ca"))
 				if err != nil {
 					return nil, err
 				}
@@ -322,7 +323,7 @@ func (m *Mysql) Unlock() error {
 }
 
 func (m *Mysql) Run(migration io.Reader) error {
-	migr, err := ioutil.ReadAll(migration)
+	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
 	}

--- a/database/mysql/mysql_test.go
+++ b/database/mysql/mysql_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/big"
 	"math/rand"
@@ -17,19 +16,14 @@ import (
 	"os"
 	"strconv"
 	"testing"
-)
 
-import (
 	"github.com/dhui/dktest"
 	"github.com/go-sql-driver/mysql"
-	"github.com/stretchr/testify/assert"
-)
-
-import (
 	"github.com/golang-migrate/migrate/v4"
 	dt "github.com/golang-migrate/migrate/v4/database/testing"
 	"github.com/golang-migrate/migrate/v4/dktesting"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/stretchr/testify/assert"
 )
 
 const defaultPort = 3306
@@ -88,7 +82,7 @@ func isReady(ctx context.Context, c dktest.ContainerInfo) bool {
 }
 
 func Test(t *testing.T) {
-	// mysql.SetLogger(mysql.Logger(log.New(ioutil.Discard, "", log.Ltime)))
+	// mysql.SetLogger(mysql.Logger(log.New(io.Discard, "", log.Ltime)))
 
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.Port(defaultPort)
@@ -121,7 +115,7 @@ func Test(t *testing.T) {
 }
 
 func TestMigrate(t *testing.T) {
-	// mysql.SetLogger(mysql.Logger(log.New(ioutil.Discard, "", log.Ltime)))
+	// mysql.SetLogger(mysql.Logger(log.New(io.Discard, "", log.Ltime)))
 
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.Port(defaultPort)
@@ -159,7 +153,7 @@ func TestMigrate(t *testing.T) {
 }
 
 func TestMigrateAnsiQuotes(t *testing.T) {
-	// mysql.SetLogger(mysql.Logger(log.New(ioutil.Discard, "", log.Ltime)))
+	// mysql.SetLogger(mysql.Logger(log.New(io.Discard, "", log.Ltime)))
 
 	dktesting.ParallelTest(t, specsAnsiQuotes, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.Port(defaultPort)
@@ -342,7 +336,7 @@ func TestExtractCustomQueryParams(t *testing.T) {
 }
 
 func createTmpCert(t *testing.T) string {
-	tmpCertFile, err := ioutil.TempFile("", "migrate_test_cert")
+	tmpCertFile, err := os.CreateTemp("", "migrate_test_cert")
 	if err != nil {
 		t.Fatal("Failed to create temp cert file:", err)
 	}

--- a/database/neo4j/neo4j.go
+++ b/database/neo4j/neo4j.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	neturl "net/url"
 	"strconv"
 	"sync/atomic"
@@ -173,7 +172,7 @@ func (n *Neo4j) Run(migration io.Reader) (err error) {
 		return err
 	}
 
-	body, err := ioutil.ReadAll(migration)
+	body, err := io.ReadAll(migration)
 	if err != nil {
 		return err
 	}

--- a/database/pgx/pgx.go
+++ b/database/pgx/pgx.go
@@ -7,19 +7,19 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"go.uber.org/atomic"
 	"io"
-	"io/ioutil"
 	nurl "net/url"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
+	"go.uber.org/atomic"
+
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database"
 	"github.com/golang-migrate/migrate/v4/database/multistmt"
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
 	_ "github.com/jackc/pgx/v4/stdlib"
@@ -265,7 +265,7 @@ func (p *Postgres) Run(migration io.Reader) error {
 		}
 		return err
 	}
-	migr, err := ioutil.ReadAll(migration)
+	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
 	}

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -8,7 +8,6 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
-	"io/ioutil"
 	nurl "net/url"
 	"regexp"
 	"strconv"
@@ -278,7 +277,7 @@ func (p *Postgres) Run(migration io.Reader) error {
 		}
 		return err
 	}
-	migr, err := ioutil.ReadAll(migration)
+	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
 	}

--- a/database/ql/ql.go
+++ b/database/ql/ql.go
@@ -3,13 +3,12 @@ package ql
 import (
 	"database/sql"
 	"fmt"
-	"github.com/hashicorp/go-multierror"
-	"go.uber.org/atomic"
 	"io"
-	"io/ioutil"
+	nurl "net/url"
 	"strings"
 
-	nurl "net/url"
+	"github.com/hashicorp/go-multierror"
+	"go.uber.org/atomic"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database"
@@ -179,7 +178,7 @@ func (m *Ql) Unlock() error {
 	return nil
 }
 func (m *Ql) Run(migration io.Reader) error {
-	migr, err := ioutil.ReadAll(migration)
+	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
 	}

--- a/database/redshift/redshift.go
+++ b/database/redshift/redshift.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"go.uber.org/atomic"
 	"io"
-	"io/ioutil"
 	nurl "net/url"
 	"strconv"
 	"strings"
+
+	"go.uber.org/atomic"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database"
@@ -142,7 +142,7 @@ func (p *Redshift) Unlock() error {
 }
 
 func (p *Redshift) Run(migration io.Reader) error {
-	migr, err := ioutil.ReadAll(migration)
+	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
 	}

--- a/database/snowflake/snowflake.go
+++ b/database/snowflake/snowflake.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"go.uber.org/atomic"
 	"io"
-	"io/ioutil"
 	nurl "net/url"
 	"strconv"
 	"strings"
+
+	"go.uber.org/atomic"
 
 	"github.com/golang-migrate/migrate/v4/database"
 	"github.com/hashicorp/go-multierror"
@@ -173,7 +173,7 @@ func (p *Snowflake) Unlock() error {
 }
 
 func (p *Snowflake) Run(migration io.Reader) error {
-	migr, err := ioutil.ReadAll(migration)
+	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
 	}

--- a/database/spanner/spanner.go
+++ b/database/spanner/spanner.go
@@ -1,17 +1,15 @@
 package spanner
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	nurl "net/url"
 	"regexp"
 	"strconv"
 	"strings"
-
-	"context"
 
 	"cloud.google.com/go/spanner"
 	sdb "cloud.google.com/go/spanner/admin/database/apiv1"
@@ -171,7 +169,7 @@ func (s *Spanner) Unlock() error {
 
 // Run implements database.Driver
 func (s *Spanner) Run(migration io.Reader) error {
-	migr, err := ioutil.ReadAll(migration)
+	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
 	}

--- a/database/sqlcipher/sqlcipher.go
+++ b/database/sqlcipher/sqlcipher.go
@@ -3,12 +3,12 @@ package sqlcipher
 import (
 	"database/sql"
 	"fmt"
-	"go.uber.org/atomic"
 	"io"
-	"io/ioutil"
 	nurl "net/url"
 	"strconv"
 	"strings"
+
+	"go.uber.org/atomic"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database"
@@ -192,7 +192,7 @@ func (m *Sqlite) Unlock() error {
 }
 
 func (m *Sqlite) Run(migration io.Reader) error {
-	migr, err := ioutil.ReadAll(migration)
+	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
 	}

--- a/database/sqlite/sqlite.go
+++ b/database/sqlite/sqlite.go
@@ -3,12 +3,12 @@ package sqlite
 import (
 	"database/sql"
 	"fmt"
-	"go.uber.org/atomic"
 	"io"
-	"io/ioutil"
 	nurl "net/url"
 	"strconv"
 	"strings"
+
+	"go.uber.org/atomic"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database"
@@ -192,7 +192,7 @@ func (m *Sqlite) Unlock() error {
 }
 
 func (m *Sqlite) Run(migration io.Reader) error {
-	migr, err := ioutil.ReadAll(migration)
+	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
 	}

--- a/database/sqlite3/sqlite3.go
+++ b/database/sqlite3/sqlite3.go
@@ -3,12 +3,12 @@ package sqlite3
 import (
 	"database/sql"
 	"fmt"
-	"go.uber.org/atomic"
 	"io"
-	"io/ioutil"
 	nurl "net/url"
 	"strconv"
 	"strings"
+
+	"go.uber.org/atomic"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database"
@@ -192,7 +192,7 @@ func (m *Sqlite) Unlock() error {
 }
 
 func (m *Sqlite) Run(migration io.Reader) error {
-	migr, err := ioutil.ReadAll(migration)
+	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
 	}

--- a/database/sqlserver/sqlserver.go
+++ b/database/sqlserver/sqlserver.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
-	"io/ioutil"
 	nurl "net/url"
 	"strconv"
 	"strings"
@@ -235,7 +234,7 @@ func (ss *SQLServer) Unlock() error {
 
 // Run the migrations for the database
 func (ss *SQLServer) Run(migration io.Reader) error {
-	migr, err := ioutil.ReadAll(migration)
+	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
 	}

--- a/database/stub/stub.go
+++ b/database/stub/stub.go
@@ -1,10 +1,10 @@
 package stub
 
 import (
-	"go.uber.org/atomic"
 	"io"
-	"io/ioutil"
 	"reflect"
+
+	"go.uber.org/atomic"
 
 	"github.com/golang-migrate/migrate/v4/database"
 )
@@ -64,7 +64,7 @@ func (s *Stub) Unlock() error {
 }
 
 func (s *Stub) Run(migration io.Reader) error {
-	m, err := ioutil.ReadAll(migration)
+	m, err := io.ReadAll(migration)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -22,7 +21,7 @@ func TestCreateCmdSuite(t *testing.T) {
 }
 
 func (s *CreateCmdSuite) mustCreateTempDir() string {
-	tmpDir, err := ioutil.TempDir("", "migrate_")
+	tmpDir, err := os.MkdirTemp("", "migrate_")
 
 	if err != nil {
 		s.FailNow(err.Error())
@@ -44,7 +43,7 @@ func (s *CreateCmdSuite) mustRemoveDir(dir string) {
 }
 
 func (s *CreateCmdSuite) mustWriteFile(dir, file, body string) {
-	if err := ioutil.WriteFile(filepath.Join(dir, file), []byte(body), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, file), []byte(body), 0644); err != nil {
 		s.FailNow(err.Error())
 	}
 }
@@ -66,7 +65,7 @@ func (s *CreateCmdSuite) mustChdir(dir string) {
 }
 
 func (s *CreateCmdSuite) assertEmptyDir(dir string) bool {
-	fis, err := ioutil.ReadDir(dir)
+	fis, err := os.ReadDir(dir)
 
 	if err != nil {
 		return s.Fail(err.Error())

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -4,14 +4,12 @@ import (
 	"bytes"
 	"database/sql"
 	"errors"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"strings"
 	"testing"
-)
 
-import (
 	dStub "github.com/golang-migrate/migrate/v4/database/stub"
 	"github.com/golang-migrate/migrate/v4/source"
 	sStub "github.com/golang-migrate/migrate/v4/source/stub"
@@ -1349,14 +1347,14 @@ func (m *migrationSequence) bodySequence() []string {
 	r := make([]string, 0)
 	for _, v := range *m {
 		if v.Body != nil {
-			body, err := ioutil.ReadAll(v.Body)
+			body, err := io.ReadAll(v.Body)
 			if err != nil {
 				panic(err) // that should never happen
 			}
 
 			// reset body reader
 			// TODO: is there a better/nicer way?
-			v.Body = ioutil.NopCloser(bytes.NewReader(body))
+			v.Body = io.NopCloser(bytes.NewReader(body))
 
 			r = append(r, string(body[:]))
 		} else {
@@ -1388,7 +1386,7 @@ func M(version uint, targetVersion ...int) *Migration {
 // mr is a convenience func to create a new *Migration from the raw database query
 func mr(value string) *Migration {
 	return &Migration{
-		Body: ioutil.NopCloser(strings.NewReader(value)),
+		Body: io.NopCloser(strings.NewReader(value)),
 	}
 }
 

--- a/migration_test.go
+++ b/migration_test.go
@@ -2,14 +2,14 @@ package migrate
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"strings"
 )
 
 func ExampleNewMigration() {
 	// Create a dummy migration body, this is coming from the source usually.
-	body := ioutil.NopCloser(strings.NewReader("dumy migration that creates users table"))
+	body := io.NopCloser(strings.NewReader("dumy migration that creates users table"))
 
 	// Create a new Migration that represents version 1486686016.
 	// Once this migration has been applied to the database, the new
@@ -40,7 +40,7 @@ func ExampleNewMigration_nilMigration() {
 
 func ExampleNewMigration_nilVersion() {
 	// Create a dummy migration body, this is coming from the source usually.
-	body := ioutil.NopCloser(strings.NewReader("dumy migration that deletes users table"))
+	body := io.NopCloser(strings.NewReader("dumy migration that deletes users table"))
 
 	// Create a new Migration that represents version 1486686016.
 	// This is the last available down migration, so the migration version

--- a/source/aws_s3/s3_test.go
+++ b/source/aws_s3/s3_test.go
@@ -2,7 +2,7 @@ package awss3
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -120,7 +120,7 @@ func (s *fakeS3) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error
 		return nil, errors.New("bucket not found")
 	}
 	if data, ok := s.objects[aws.StringValue(input.Key)]; ok {
-		body := ioutil.NopCloser(strings.NewReader(data))
+		body := io.NopCloser(strings.NewReader(data))
 		return &s3.GetObjectOutput{Body: body}, nil
 	}
 	return nil, errors.New("object not found")

--- a/source/bitbucket/bitbucket.go
+++ b/source/bitbucket/bitbucket.go
@@ -3,7 +3,6 @@ package bitbucket
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	nurl "net/url"
 	"os"
 	"path"
@@ -177,7 +176,7 @@ func (b *Bitbucket) ReadUp(version uint) (r io.ReadCloser, identifier string, er
 		}
 		if file != nil {
 			r := file.Content
-			return ioutil.NopCloser(strings.NewReader(string(r))), m.Identifier, nil
+			return io.NopCloser(strings.NewReader(string(r))), m.Identifier, nil
 		}
 	}
 	return nil, "", &os.PathError{Op: fmt.Sprintf("read version %v", version), Path: b.config.Path, Err: os.ErrNotExist}
@@ -201,7 +200,7 @@ func (b *Bitbucket) ReadDown(version uint) (r io.ReadCloser, identifier string, 
 		if file != nil {
 			r := file.Content
 
-			return ioutil.NopCloser(strings.NewReader(string(r))), m.Identifier, nil
+			return io.NopCloser(strings.NewReader(string(r))), m.Identifier, nil
 		}
 	}
 	return nil, "", &os.PathError{Op: fmt.Sprintf("read version %v", version), Path: b.config.Path, Err: os.ErrNotExist}

--- a/source/bitbucket/bitbucket_test.go
+++ b/source/bitbucket/bitbucket_test.go
@@ -2,7 +2,7 @@ package bitbucket
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	st "github.com/golang-migrate/migrate/v4/source/testing"
@@ -11,7 +11,7 @@ import (
 var BitbucketTestSecret = "" // username:password
 
 func init() {
-	secrets, err := ioutil.ReadFile(".bitbucket_test_secrets")
+	secrets, err := os.ReadFile(".bitbucket_test_secrets")
 	if err == nil {
 		BitbucketTestSecret = string(bytes.TrimSpace(secrets)[:])
 	}

--- a/source/file/file_test.go
+++ b/source/file/file_test.go
@@ -3,7 +3,6 @@ package file
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -147,7 +146,7 @@ func TestClose(t *testing.T) {
 }
 
 func mustWriteFile(t testing.TB, dir, file string, body string) {
-	if err := ioutil.WriteFile(path.Join(dir, file), []byte(body), 06444); err != nil {
+	if err := os.WriteFile(path.Join(dir, file), []byte(body), 06444); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/source/github/github.go
+++ b/source/github/github.go
@@ -3,14 +3,14 @@ package github
 import (
 	"context"
 	"fmt"
-	"golang.org/x/oauth2"
 	"io"
-	"io/ioutil"
 	"net/http"
 	nurl "net/url"
 	"os"
 	"path"
 	"strings"
+
+	"golang.org/x/oauth2"
 
 	"github.com/golang-migrate/migrate/v4/source"
 	"github.com/google/go-github/v39/github"
@@ -194,7 +194,7 @@ func (g *Github) ReadUp(version uint) (r io.ReadCloser, identifier string, err e
 			if err != nil {
 				return nil, "", err
 			}
-			return ioutil.NopCloser(strings.NewReader(r)), m.Identifier, nil
+			return io.NopCloser(strings.NewReader(r)), m.Identifier, nil
 		}
 	}
 	return nil, "", &os.PathError{Op: fmt.Sprintf("read version %v", version), Path: g.config.Path, Err: os.ErrNotExist}
@@ -220,7 +220,7 @@ func (g *Github) ReadDown(version uint) (r io.ReadCloser, identifier string, err
 			if err != nil {
 				return nil, "", err
 			}
-			return ioutil.NopCloser(strings.NewReader(r)), m.Identifier, nil
+			return io.NopCloser(strings.NewReader(r)), m.Identifier, nil
 		}
 	}
 	return nil, "", &os.PathError{Op: fmt.Sprintf("read version %v", version), Path: g.config.Path, Err: os.ErrNotExist}

--- a/source/github/github_test.go
+++ b/source/github/github_test.go
@@ -3,7 +3,7 @@ package github
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	st "github.com/golang-migrate/migrate/v4/source/testing"
@@ -13,7 +13,7 @@ import (
 var GithubTestSecret = "" // username:token
 
 func init() {
-	secrets, err := ioutil.ReadFile(".github_test_secrets")
+	secrets, err := os.ReadFile(".github_test_secrets")
 	if err == nil {
 		GithubTestSecret = string(bytes.TrimSpace(secrets)[:])
 	}

--- a/source/gitlab/gitlab.go
+++ b/source/gitlab/gitlab.go
@@ -4,15 +4,12 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	nurl "net/url"
 	"os"
 	"strconv"
 	"strings"
-)
 
-import (
 	"github.com/golang-migrate/migrate/v4/source"
 	"github.com/xanzy/go-gitlab"
 )
@@ -211,7 +208,7 @@ func (g *Gitlab) ReadUp(version uint) (r io.ReadCloser, identifier string, err e
 			return nil, "", err
 		}
 
-		return ioutil.NopCloser(strings.NewReader(string(content))), m.Identifier, nil
+		return io.NopCloser(strings.NewReader(string(content))), m.Identifier, nil
 	}
 
 	return nil, "", &os.PathError{Op: fmt.Sprintf("read version %v", version), Path: g.path, Err: os.ErrNotExist}
@@ -233,7 +230,7 @@ func (g *Gitlab) ReadDown(version uint) (r io.ReadCloser, identifier string, err
 			return nil, "", err
 		}
 
-		return ioutil.NopCloser(strings.NewReader(string(content))), m.Identifier, nil
+		return io.NopCloser(strings.NewReader(string(content))), m.Identifier, nil
 	}
 
 	return nil, "", &os.PathError{Op: fmt.Sprintf("read version %v", version), Path: g.path, Err: os.ErrNotExist}

--- a/source/gitlab/gitlab_test.go
+++ b/source/gitlab/gitlab_test.go
@@ -2,7 +2,7 @@ package gitlab
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	st "github.com/golang-migrate/migrate/v4/source/testing"
@@ -11,7 +11,7 @@ import (
 var GitlabTestSecret = "" // username:token
 
 func init() {
-	secrets, err := ioutil.ReadFile(".gitlab_test_secrets")
+	secrets, err := os.ReadFile(".gitlab_test_secrets")
 	if err == nil {
 		GitlabTestSecret = string(bytes.TrimSpace(secrets)[:])
 	}

--- a/source/go_bindata/examples/migrations/bindata.go
+++ b/source/go_bindata/examples/migrations/bindata.go
@@ -13,7 +13,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -270,7 +269,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}

--- a/source/go_bindata/go-bindata.go
+++ b/source/go_bindata/go-bindata.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/golang-migrate/migrate/v4/source"
@@ -102,7 +101,7 @@ func (b *Bindata) ReadUp(version uint) (r io.ReadCloser, identifier string, err 
 		if err != nil {
 			return nil, "", err
 		}
-		return ioutil.NopCloser(bytes.NewReader(body)), m.Identifier, nil
+		return io.NopCloser(bytes.NewReader(body)), m.Identifier, nil
 	}
 	return nil, "", &os.PathError{Op: fmt.Sprintf("read version %v", version), Path: b.path, Err: os.ErrNotExist}
 }
@@ -113,7 +112,7 @@ func (b *Bindata) ReadDown(version uint) (r io.ReadCloser, identifier string, er
 		if err != nil {
 			return nil, "", err
 		}
-		return ioutil.NopCloser(bytes.NewReader(body)), m.Identifier, nil
+		return io.NopCloser(bytes.NewReader(body)), m.Identifier, nil
 	}
 	return nil, "", &os.PathError{Op: fmt.Sprintf("read version %v", version), Path: b.path, Err: os.ErrNotExist}
 }

--- a/source/go_bindata/testdata/bindata.go
+++ b/source/go_bindata/testdata/bindata.go
@@ -17,7 +17,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -288,13 +287,13 @@ func AssetNames() []string {
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
 	"1_test.down.sql": _1_testDownSql,
-	"1_test.up.sql": _1_testUpSql,
-	"3_test.up.sql": _3_testUpSql,
+	"1_test.up.sql":   _1_testUpSql,
+	"3_test.up.sql":   _3_testUpSql,
 	"4_test.down.sql": _4_testDownSql,
-	"4_test.up.sql": _4_testUpSql,
+	"4_test.up.sql":   _4_testUpSql,
 	"5_test.down.sql": _5_testDownSql,
 	"7_test.down.sql": _7_testDownSql,
-	"7_test.up.sql": _7_testUpSql,
+	"7_test.up.sql":   _7_testUpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -336,15 +335,16 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
 	"1_test.down.sql": &bintree{_1_testDownSql, map[string]*bintree{}},
-	"1_test.up.sql": &bintree{_1_testUpSql, map[string]*bintree{}},
-	"3_test.up.sql": &bintree{_3_testUpSql, map[string]*bintree{}},
+	"1_test.up.sql":   &bintree{_1_testUpSql, map[string]*bintree{}},
+	"3_test.up.sql":   &bintree{_3_testUpSql, map[string]*bintree{}},
 	"4_test.down.sql": &bintree{_4_testDownSql, map[string]*bintree{}},
-	"4_test.up.sql": &bintree{_4_testUpSql, map[string]*bintree{}},
+	"4_test.up.sql":   &bintree{_4_testUpSql, map[string]*bintree{}},
 	"5_test.down.sql": &bintree{_5_testDownSql, map[string]*bintree{}},
 	"7_test.down.sql": &bintree{_7_testDownSql, map[string]*bintree{}},
-	"7_test.up.sql": &bintree{_7_testUpSql, map[string]*bintree{}},
+	"7_test.up.sql":   &bintree{_7_testUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory
@@ -361,7 +361,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}
@@ -393,4 +393,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/source/stub/stub.go
+++ b/source/stub/stub.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/golang-migrate/migrate/v4/source"
@@ -72,14 +71,14 @@ func (s *Stub) Next(version uint) (nextVersion uint, err error) {
 
 func (s *Stub) ReadUp(version uint) (r io.ReadCloser, identifier string, err error) {
 	if m, ok := s.Migrations.Up(version); ok {
-		return ioutil.NopCloser(bytes.NewBufferString(m.Identifier)), fmt.Sprintf("%v.up.stub", version), nil
+		return io.NopCloser(bytes.NewBufferString(m.Identifier)), fmt.Sprintf("%v.up.stub", version), nil
 	}
 	return nil, "", &os.PathError{Op: fmt.Sprintf("read up version %v", version), Path: s.Url, Err: os.ErrNotExist}
 }
 
 func (s *Stub) ReadDown(version uint) (r io.ReadCloser, identifier string, err error) {
 	if m, ok := s.Migrations.Down(version); ok {
-		return ioutil.NopCloser(bytes.NewBufferString(m.Identifier)), fmt.Sprintf("%v.down.stub", version), nil
+		return io.NopCloser(bytes.NewBufferString(m.Identifier)), fmt.Sprintf("%v.down.stub", version), nil
 	}
 	return nil, "", &os.PathError{Op: fmt.Sprintf("read down version %v", version), Path: s.Url, Err: os.ErrNotExist}
 }

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -1,7 +1,7 @@
 package testing
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"strconv"
 	"testing"
@@ -86,7 +86,7 @@ func containerLogs(t *testing.T, c *DockerContainer) []byte {
 			t.Error(err)
 		}
 	}()
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		t.Error(err)
 		return nil


### PR DESCRIPTION
As of Go 1.16, the same functionality is now provided by package io or
package os, and those implementations should be preferred in new code.

So replacing all usage of `ioutil` pkg with `io` & `os`.

Do note that the switch from `ioutil.TempFile` to `os.CreateTemp` in the go doc itself (i.e. the former just calls the later) was only done in Go 1.17, but the functionality of os.CreateTemp was already available in 1.16 and thus is safe for use with Go 1.16 as well.