### PR TITLE
Support environment variables in migration files using go templates

### DIFF
--- a/database/driver.go
+++ b/database/driver.go
@@ -25,22 +25,22 @@ var drivers = make(map[string]Driver)
 // Driver is the interface every database driver must implement.
 //
 // How to implement a database driver?
-//   1. Implement this interface.
-//   2. Optionally, add a function named `WithInstance`.
-//      This function should accept an existing DB instance and a Config{} struct
-//      and return a driver instance.
-//   3. Add a test that calls database/testing.go:Test()
-//   4. Add own tests for Open(), WithInstance() (when provided) and Close().
-//      All other functions are tested by tests in database/testing.
-//      Saves you some time and makes sure all database drivers behave the same way.
-//   5. Call Register in init().
-//   6. Create a internal/cli/build_<driver-name>.go file
-//   7. Add driver name in 'DATABASE' variable in Makefile
+//  1. Implement this interface.
+//  2. Optionally, add a function named `WithInstance`.
+//     This function should accept an existing DB instance and a Config{} struct
+//     and return a driver instance.
+//  3. Add a test that calls database/testing.go:Test()
+//  4. Add own tests for Open(), WithInstance() (when provided) and Close().
+//     All other functions are tested by tests in database/testing.
+//     Saves you some time and makes sure all database drivers behave the same way.
+//  5. Call Register in init().
+//  6. Create a internal/cli/build_<driver-name>.go file
+//  7. Add driver name in 'DATABASE' variable in Makefile
 //
 // Guidelines:
-//   * Don't try to correct user input. Don't assume things.
+//   - Don't try to correct user input. Don't assume things.
 //     When in doubt, return an error and explain the situation to the user.
-//   * All configuration input must come from the URL string in func Open()
+//   - All configuration input must come from the URL string in func Open()
 //     or the Config{} struct in WithInstance. Don't os.Getenv().
 type Driver interface {
 	// Open returns a new driver instance configured with parameters

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -17,8 +17,9 @@ import (
 
 // sourceStubMigrations hold the following migrations:
 // u = up migration, d = down migration, n = version
-//  |  1  |  -  |  3  |  4  |  5  |  -  |  7  |
-//  | u d |  -  | u   | u d |   d |  -  | u d |
+//
+//	|  1  |  -  |  3  |  4  |  5  |  -  |  7  |
+//	| u d |  -  | u   | u d |   d |  -  | u d |
 var sourceStubMigrations *source.Migrations
 
 const (

--- a/source/driver.go
+++ b/source/driver.go
@@ -17,21 +17,21 @@ var drivers = make(map[string]Driver)
 // Driver is the interface every source driver must implement.
 //
 // How to implement a source driver?
-//   1. Implement this interface.
-//   2. Optionally, add a function named `WithInstance`.
-//      This function should accept an existing source instance and a Config{} struct
-//      and return a driver instance.
-//   3. Add a test that calls source/testing.go:Test()
-//   4. Add own tests for Open(), WithInstance() (when provided) and Close().
-//      All other functions are tested by tests in source/testing.
-//      Saves you some time and makes sure all source drivers behave the same way.
-//   5. Call Register in init().
+//  1. Implement this interface.
+//  2. Optionally, add a function named `WithInstance`.
+//     This function should accept an existing source instance and a Config{} struct
+//     and return a driver instance.
+//  3. Add a test that calls source/testing.go:Test()
+//  4. Add own tests for Open(), WithInstance() (when provided) and Close().
+//     All other functions are tested by tests in source/testing.
+//     Saves you some time and makes sure all source drivers behave the same way.
+//  5. Call Register in init().
 //
 // Guidelines:
-//   * All configuration input must come from the URL string in func Open()
+//   - All configuration input must come from the URL string in func Open()
 //     or the Config{} struct in WithInstance. Don't os.Getenv().
-//   * Drivers are supposed to be read only.
-//   * Ideally don't load any contents (into memory) in Open or WithInstance.
+//   - Drivers are supposed to be read only.
+//   - Ideally don't load any contents (into memory) in Open or WithInstance.
 type Driver interface {
 	// Open returns a new driver instance configured with parameters
 	// coming from the URL string. Migrate will call this function

--- a/source/parse.go
+++ b/source/parse.go
@@ -16,8 +16,9 @@ var (
 )
 
 // Regex matches the following pattern:
-//  123_name.up.ext
-//  123_name.down.ext
+//
+//	123_name.up.ext
+//	123_name.down.ext
 var Regex = regexp.MustCompile(`^([0-9]+)_(.*)\.(` + string(Down) + `|` + string(Up) + `)\.(.*)$`)
 
 // Parse returns Migration for matching Regex pattern.

--- a/source/testing/testing.go
+++ b/source/testing/testing.go
@@ -15,8 +15,9 @@ import (
 // It assumes that the driver tests has access to the following migrations:
 //
 // u = up migration, d = down migration, n = version
-//  |  1  |  -  |  3  |  4  |  5  |  -  |  7  |
-//  | u d |  -  | u   | u d |   d |  -  | u d |
+//
+//	|  1  |  -  |  3  |  4  |  5  |  -  |  7  |
+//	| u d |  -  | u   | u d |   d |  -  | u d |
 //
 // See source/stub/stub_test.go or source/file/file_test.go for an example.
 func Test(t *testing.T, d source.Driver) {

--- a/template.go
+++ b/template.go
@@ -1,0 +1,47 @@
+package migrate
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/template"
+)
+
+var envMapCache map[string]string
+
+func envMap() map[string]string {
+	if envMapCache != nil {
+		return envMapCache
+	}
+	envMapCache = make(map[string]string)
+	for _, kvp := range os.Environ() {
+		kvParts := strings.SplitN(kvp, "=", 2)
+		envMapCache[kvParts[0]] = kvParts[1]
+	}
+	return envMapCache
+}
+
+func applyEnvironmentTemplate(body io.ReadCloser) (io.ReadCloser, error) {
+	bodyBytes, err := io.ReadAll(body)
+	if err != nil {
+		return nil, fmt.Errorf("reading body: %w", err)
+	}
+	defer func() {
+		_ = body.Close()
+	}()
+
+	tmpl, err := template.New("migration").Parse(string(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("parsing template: %w", err)
+	}
+
+	r, w := io.Pipe()
+
+	go func() {
+		_ = tmpl.Execute(w, envMap())
+		_ = w.Close()
+	}()
+
+	return r, nil
+}

--- a/template_test.go
+++ b/template_test.go
@@ -1,0 +1,30 @@
+package migrate
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+)
+
+func Test_applyEnvironmentTemplate(t *testing.T) {
+	envMapCache = nil
+	_ = os.Setenv("WAREHOUSE_DB", "WH_STAGING")
+
+	migration := io.NopCloser(bytes.NewBuffer([]byte(`SELECT * FROM {{.WAREHOUSE_DB}}.STD.INVOICES`)))
+
+	gotReader, err := applyEnvironmentTemplate(migration)
+	if err != nil {
+		t.Fatalf("expected no error applying template")
+	}
+
+	gotBytes, err := io.ReadAll(gotReader)
+	if err != nil {
+		t.Fatalf("expected no error reading")
+	}
+	got := string(gotBytes)
+	want := `SELECT * FROM WH_STAGING.STD.INVOICES`
+	if got != want {
+		t.Fatalf("expected [%s] but got [%s]", want, got)
+	}
+}

--- a/util.go
+++ b/util.go
@@ -16,7 +16,6 @@ type MultiError struct {
 // NewMultiError returns an error type holding multiple errors.
 //
 // Deprecated: Use github.com/hashicorp/go-multierror instead
-//
 func NewMultiError(errs ...error) MultiError {
 	compactErrs := make([]error, 0)
 	for _, e := range errs {


### PR DESCRIPTION
This PR adds a `-template` command line option that, when enabled, allows you to substitute any environment variables into your migration file with go templating.  i.e. If you set the `LOCAL_WAREHOUSE` environment variable to `MY_DB` and have a migration file with the following contents:
```sql
                       INSERT INTO {{.LOCAL_WAREHOUSE}}.INVENTORY.RECORDS ('foo') VALUES ('bar');
```
it will be transformed into the following before being executed:
```sql
                       INSERT INTO MY_DB.INVENTORY.RECORDS ('foo') VALUES ('bar');
```
See https://pkg.go.dev/text/template for more information on supported template formats.

As mentioned in #747, this functionality could be done with envsubt, but that requires you to build custom scripts to do so.  It ended up being just as much effort to add the functionality with go template and kept our pipelines and local development workflow more simple.

