### PR TITLE
Clickhouse DSN docs described username and password incorrectly.

### DIFF
--- a/database/clickhouse/README.md
+++ b/database/clickhouse/README.md
@@ -1,6 +1,6 @@
 # ClickHouse
 
-`clickhouse://username:password@host:port/database=clicks?x-multi-statement=true`
+`clickhouse://host:port?username=user&password=password&database=clicks&x-multi-statement=true`
 
 | URL Query  | Description |
 |------------|-------------|


### PR DESCRIPTION
Clickhouse DSN docs described username and password incorrectly.

The example:

   `clickhouse://username:password@host:port/database=clicks?x-multi-statement=true`

did not work, but:

`clickhouse://host:port?username=user&password=password&database=clicks&x-multi-statement=true`

does.

I got the above DSN format from the tests.