### PR TITLE
The example Clickhouse DSN incorrectly described how to set the usern…

### DIFF
--- a/database/clickhouse/README.md
+++ b/database/clickhouse/README.md
@@ -1,6 +1,6 @@
 # ClickHouse
 
-`clickhouse://username:password@host:port/database=clicks?x-multi-statement=true`
+`clickhouse://host:port?username=user&password=password&database=clicks&x-multi-statement=true`
 
 | URL Query  | Description |
 |------------|-------------|


### PR DESCRIPTION
…ame and password.

The example:

   `clickhouse://username:password@host:port/database=clicks?x-multi-statement=true`

did not work, but:

`clickhouse://host:port?username=user&password=password&database=clicks&x-multi-statement=true`

does.

I got the above DSN format from the tests.