### PR TITLE
bump up CI version & fix CI failed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,12 +6,17 @@ on:
 
 jobs:
   lint:
+    name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
 
   test:
     runs-on: ubuntu-latest
@@ -19,9 +24,9 @@ jobs:
       matrix:
         go: ["1.17.x", "1.18.x"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
 
@@ -55,13 +60,13 @@ jobs:
     # 3. When the workflow is triggered by a tag with `v` prefix
     if: ${{ success() && github.repository == 'golang-migrate/migrate' && startsWith(github.ref, 'refs/tags/v') }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: "1.18.x"
 

--- a/source/go_bindata/examples/migrations/bindata.go
+++ b/source/go_bindata/examples/migrations/bindata.go
@@ -212,11 +212,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error


### PR DESCRIPTION
I found many pull requests CI failed. to fix it.
- bump `actions/checkout@v2` to `actions/checkout@v3`
- bump `golangci/golangci-lint-action@v2` to `golangci/golangci-lint-action@v3`
- bump `actions/setup-go@v2` to `actions/setup-go@v3`
- use go1.19 to fix go fmt
  - why
    - golangci-lint is using go v1.19 for gofmt linter inspite. [reference](https://github.com/golangci/golangci-lint/issues/3069)
  - what I did
    - `go1.19 fmt ./...`
  