### PR TITLE
docs: use v4 godocs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ $ docker run -v {{ migration dir }}:/migrations --network host migrate/migrate
 * Uses `io.Reader` streams internally for low memory overhead.
 * Thread-safe and no goroutine leaks.
 
-__[Go Documentation](https://godoc.org/github.com/golang-migrate/migrate)__
+__[Go Documentation](https://pkg.go.dev/github.com/golang-migrate/migrate/v4)__
 
 ```go
 import (


### PR DESCRIPTION
at the moment this points to v3 which is no longer the recommended version