### PR TITLE
Fix CockroachDB tutorial's link being relative to 'GETTING_STARTED.md'

### DIFF
--- a/database/cockroachdb/TUTORIAL.md
+++ b/database/cockroachdb/TUTORIAL.md
@@ -50,7 +50,7 @@ And in the `.down.sql` let's delete it:
 ```
 DROP TABLE IF EXISTS example.users;
 ```
-By adding `IF EXISTS/IF NOT EXISTS` we are making migrations idempotent - you can read more about idempotency in [getting started](https://github.com/golang-migrate/migrate/blob/master/GETTING_STARTED.md#create-migrations)
+By adding `IF EXISTS/IF NOT EXISTS` we are making migrations idempotent - you can read more about idempotency in [getting started](/GETTING_STARTED.md#create-migrations)
 
 ## Run migrations
 ```

--- a/database/cockroachdb/TUTORIAL.md
+++ b/database/cockroachdb/TUTORIAL.md
@@ -50,7 +50,7 @@ And in the `.down.sql` let's delete it:
 ```
 DROP TABLE IF EXISTS example.users;
 ```
-By adding `IF EXISTS/IF NOT EXISTS` we are making migrations idempotent - you can read more about idempotency in [getting started](GETTING_STARTED.md#create-migrations)
+By adding `IF EXISTS/IF NOT EXISTS` we are making migrations idempotent - you can read more about idempotency in [getting started](https://github.com/golang-migrate/migrate/blob/master/GETTING_STARTED.md#create-migrations)
 
 ## Run migrations
 ```


### PR DESCRIPTION
Fix the link root so that it doesn't point relatively. Currently the link points to `/blob/master/database/cockroachdb/GETTING_STARTED.md` while it should be pointing to `/blob/master/GETTING_STARTED.md#create-migrations`