### PR TITLE
Add non-cgo sqlite support to released binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SOURCE ?= file go_bindata github github_ee bitbucket aws_s3 google_cloud_storage godoc_vfs gitlab
-DATABASE ?= postgres mysql redshift cassandra spanner cockroachdb yugabytedb clickhouse mongodb sqlserver firebird neo4j pgx
-DATABASE_TEST ?= $(DATABASE) sqlite sqlite3 sqlcipher
+DATABASE ?= sqlite postgres mysql redshift cassandra spanner cockroachdb yugabytedb clickhouse mongodb sqlserver firebird neo4j pgx
+DATABASE_TEST ?= $(DATABASE) sqlite3 sqlcipher
 VERSION ?= $(shell git describe --tags 2>/dev/null | cut -c 2-)
 TEST_FLAGS ?=
 REPO_OWNER ?= $(shell cd .. && basename "$$(pwd)")


### PR DESCRIPTION
In https://github.com/golang-migrate/migrate/commit/15611d4559ac626305655c5b2fa18b2cfe995f60 the `sqlite3` driver was removed from builds because of on-going cgo issues.

But the sqlite non-cgo version still works and can be built and released. This PR enables it.