### PR TITLE
Use DELETE FROM instead of TRUNCATE for pgx

### DIFF
--- a/database/pgx/pgx.go
+++ b/database/pgx/pgx.go
@@ -229,7 +229,7 @@ func (p *Postgres) Lock() error {
 		}
 
 		// This will wait indefinitely until the lock can be acquired.
-		query := `SELECT pg_advisory_lock($1)`
+		query := `SELECT PG_ADVISORY_LOCK($1)`
 		if _, err := p.conn.ExecContext(context.Background(), query, aid); err != nil {
 			return &database.Error{OrigErr: err, Err: "try lock failed", Query: []byte(query)}
 		}
@@ -244,7 +244,7 @@ func (p *Postgres) Unlock() error {
 			return err
 		}
 
-		query := `SELECT pg_advisory_unlock($1)`
+		query := `SELECT PG_ADVISORY_UNLOCK($1)`
 		if _, err := p.conn.ExecContext(context.Background(), query, aid); err != nil {
 			return &database.Error{OrigErr: err, Query: []byte(query)}
 		}
@@ -345,7 +345,7 @@ func (p *Postgres) SetVersion(version int, dirty bool) error {
 		return &database.Error{OrigErr: err, Err: "transaction start failed"}
 	}
 
-	query := `TRUNCATE ` + quoteIdentifier(p.config.migrationsSchemaName) + `.` + quoteIdentifier(p.config.migrationsTableName)
+	query := `DELETE FROM ` + quoteIdentifier(p.config.migrationsSchemaName) + `.` + quoteIdentifier(p.config.migrationsTableName)
 	if _, err := tx.Exec(query); err != nil {
 		if errRollback := tx.Rollback(); errRollback != nil {
 			err = multierror.Append(err, errRollback)
@@ -395,7 +395,7 @@ func (p *Postgres) Version() (version int, dirty bool, err error) {
 
 func (p *Postgres) Drop() (err error) {
 	// select all tables in current schema
-	query := `SELECT table_name FROM information_schema.tables WHERE table_schema=(SELECT current_schema()) AND table_type='BASE TABLE'`
+	query := `SELECT table_name FROM information_schema.tables WHERE table_schema=(SELECT CURRENT_SCHEMA()) AND table_type='BASE TABLE'`
 	tables, err := p.conn.QueryContext(context.Background(), query)
 	if err != nil {
 		return &database.Error{OrigErr: err, Query: []byte(query)}


### PR DESCRIPTION
In PostgreSQL, TRUNCATE statements cannot run during a db backup.

Deployment would be blocked by `db_dump` if there would be migration to run.

`db_dump`  requires `ACCESS SHARE` LOCK
> Reference:
> [https://www.postgresql.org/docs/current/app-pgdump.html](https://www.postgresql.org/docs/current/app-pgdump.html)

And will conflict with `TRUNCATE` which requires `ACCESS EXCLUSIVE` LOCK 
> Reference:
> [https://www.postgresql.org/docs/current/sql-truncate.html](https://www.postgresql.org/docs/current/sql-truncate.html)