### PR TITLE
feat: enable to choose warehouse and role for snowflake table migration

### DIFF
--- a/database/snowflake/README.md
+++ b/database/snowflake/README.md
@@ -7,6 +7,8 @@
 Example URL is as follows:
 `snowflake://user:password@accountname/schema/dbname?role=SYSADMIN&warehouse=compute_wh`
 
+- `accountname`: <account_locator>.<region>.<cloud_plotform> (e.g. AB12345.ap-northeast-1.aws)
+
 | URL Query  | WithInstance Config | Description | Optional | Default |
 |------------|---------------------|-------------|----------|---------|
 | `x-migrations-table` | `MigrationsTable` | Name of the migrations table | yes | schema_migrations |

--- a/database/snowflake/README.md
+++ b/database/snowflake/README.md
@@ -2,9 +2,16 @@
 
 `snowflake://user:password@accountname/schema/dbname?query`
 
-| URL Query  | WithInstance Config | Description |
-|------------|---------------------|-------------|
-| `x-migrations-table` | `MigrationsTable` | Name of the migrations table |
+## Example
+
+Example URL is as follows:
+`snowflake://user:password@accountname/schema/dbname?role=SYSADMIN&warehouse=compute_wh`
+
+| URL Query  | WithInstance Config | Description | Optional | Default |
+|------------|---------------------|-------------|----------|---------|
+| `x-migrations-table` | `MigrationsTable` | Name of the migrations table | yes | schema_migrations |
+| `role` | - | Name of the role | yes | `default_role` of the login user |
+| `warehouse` | - | Name of the warehouse | yes | `default_warehouse` of the login user |
 
 Snowflake is PostgreSQL compatible but has some specific features (or lack thereof) that require slightly different behavior.
 

--- a/database/snowflake/snowflake.go
+++ b/database/snowflake/snowflake.go
@@ -238,8 +238,8 @@ func (p *Snowflake) SetVersion(version int, dirty bool) error {
 	// empty schema version for failed down migration on the first migration
 	// See: https://github.com/golang-migrate/migrate/issues/330
 	if version >= 0 || (version == database.NilVersion && dirty) {
-		query := fmt.Sprintf(`INSERT INTO "%s" (version, dirty) VALUES (?, ?)`, p.config.MigrationsTable)
-		if _, err := tx.Exec(query, strconv.FormatInt(int64(version), 10), strconv.FormatBool(dirty)); err != nil {
+		query := fmt.Sprintf(`INSERT INTO "%s" (version, dirty) VALUES (%v, %v)`, p.config.MigrationsTable, strconv.FormatInt(int64(version), 10), strconv.FormatBool(dirty))
+		if _, err := tx.Exec(query); err != nil {
 			if errRollback := tx.Rollback(); errRollback != nil {
 				err = multierror.Append(err, errRollback)
 			}


### PR DESCRIPTION
There are some old PRs to implement this functionality, which is unable to choose a snowflake warehouse and role for table migration.
However, they took lots of time to fix their comment. I think they may not be fixed anymore, so I request this feature.

Further, this PR includes fixes to simplify the construction of SQL statements.

I checked this code work locally by a simple test, using an actual Snowflake Account.

The test code is like below:
```go
package snowflake

import (
	"fmt"
	"testing"

	dt "github.com/golang-migrate/migrate/v4/database/testing"
)

const (
	testUserName = "TEST_USER"
	testPassword = "xxxx"
	testAccount  = "<account_locator>.ap-northeast-1.aws"
	testDatabase = "DB_NAME"
	testSchema   = "SCHEMA_NAME"
	testWH       = "WH_NAME"
)

func Test(t *testing.T) {
	sf := &Snowflake{}
	url := fmt.Sprintf(
		"snowflake://%s:%s@%s/%s/%s?role=SYSADMIN&warehouse=%s",
		testUserName, testPassword, testAccount, testDatabase, testSchema, testWH)
	d, err := sf.Open(url)
	if err != nil {
		t.Fatal(err)
	}
	dt.Test(t, d, []byte("CREATE TABLE t (Qty int, Name string);"))
}
```

Then, output is like:
```shell
=== RUN   Test
=== RUN   Test/set_1_dirty
=== RUN   Test/re-set_1_dirty
=== RUN   Test/set_2_clean
=== RUN   Test/re-set_2_clean
=== RUN   Test/last_migration_dirty
=== RUN   Test/last_migration_clean
--- PASS: Test (14.03s)
    --- PASS: Test/set_1_dirty (1.61s)
    --- PASS: Test/re-set_1_dirty (2.37s)
    --- PASS: Test/set_2_clean (1.89s)
    --- PASS: Test/re-set_2_clean (1.61s)
    --- PASS: Test/last_migration_dirty (1.92s)
    --- PASS: Test/last_migration_clean (1.27s)
PASS
ok      command-line-arguments  14.663s
```
