### PR TITLE
Update CLI readme to fix Linux installation issues

### DIFF
--- a/cmd/migrate/README.md
+++ b/cmd/migrate/README.md
@@ -27,10 +27,8 @@ $ scoop install migrate
 ### Linux (*.deb package)
 
 ```bash
-$ curl -L https://packagecloud.io/golang-migrate/migrate/gpgkey | apt-key add -
-$ echo "deb https://packagecloud.io/golang-migrate/migrate/ubuntu/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/migrate.list
-$ apt-get update
-$ apt-get install -y migrate
+wget http://github.com/golang-migrate/migrate/releases/latest/download/migrate.linux-amd64.deb
+sudo dpkg -i migrate.linux-amd64.deb
 ```
 
 ### With Go toolchain


### PR DESCRIPTION
I had issues installing through CLI on Linux, as have many other users: #872, #846, #828, #818.

[This post](https://github.com/golang-migrate/migrate/issues/818#issuecomment-1270444615) contained a workaround that solved the issue for me and other users.