### PR TITLE
change separator with slash in file driver

### DIFF
--- a/source/file/file.go
+++ b/source/file/file.go
@@ -35,6 +35,9 @@ func (f *File) Open(url string) (source.Driver, error) {
 }
 
 func parseURL(url string) (string, error) {
+	// change separators with slash in url
+	url = filepath.ToSlash(url)
+
 	u, err := nurl.Parse(url)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
this pull request is for fixing the file source driver problem .in some os like windows separator is \\ by default and it causes problems when we want to parse the path from the URL by approving this, we can close some related issues like [https://github.com/golang-migrate/migrate/issues/247(https://github.com/golang-migrate/migrate/issues/247)  [https://github.com/golang-migrate/migrate/issues/552](https://github.com/golang-migrate/migrate/issues/552)
also, I think we don't want to add tests because the current file test is complete and sufficient for testing that, and as I checked fortunately all tests passed after that change (in windows os).