### PR TITLE
fix issue of downloading and using github sourced migration files of …

### DIFF
--- a/source/github/github.go
+++ b/source/github/github.go
@@ -178,7 +178,7 @@ func (g *Github) ReadUp(version uint) (r io.ReadCloser, identifier string, err e
 	g.ensureFields()
 
 	if m, ok := g.migrations.Up(version); ok {
-		file, _, _, err := g.client.Repositories.GetContents(
+		r, _, err := g.client.Repositories.DownloadContents(
 			context.Background(),
 			g.config.Owner,
 			g.config.Repo,
@@ -189,13 +189,7 @@ func (g *Github) ReadUp(version uint) (r io.ReadCloser, identifier string, err e
 		if err != nil {
 			return nil, "", err
 		}
-		if file != nil {
-			r, err := file.GetContent()
-			if err != nil {
-				return nil, "", err
-			}
-			return io.NopCloser(strings.NewReader(r)), m.Identifier, nil
-		}
+		return r, m.Identifier, nil
 	}
 	return nil, "", &os.PathError{Op: fmt.Sprintf("read version %v", version), Path: g.config.Path, Err: os.ErrNotExist}
 }
@@ -204,7 +198,7 @@ func (g *Github) ReadDown(version uint) (r io.ReadCloser, identifier string, err
 	g.ensureFields()
 
 	if m, ok := g.migrations.Down(version); ok {
-		file, _, _, err := g.client.Repositories.GetContents(
+		r, _, err := g.client.Repositories.DownloadContents(
 			context.Background(),
 			g.config.Owner,
 			g.config.Repo,
@@ -215,13 +209,7 @@ func (g *Github) ReadDown(version uint) (r io.ReadCloser, identifier string, err
 		if err != nil {
 			return nil, "", err
 		}
-		if file != nil {
-			r, err := file.GetContent()
-			if err != nil {
-				return nil, "", err
-			}
-			return io.NopCloser(strings.NewReader(r)), m.Identifier, nil
-		}
+		return r, m.Identifier, nil
 	}
 	return nil, "", &os.PathError{Op: fmt.Sprintf("read version %v", version), Path: g.config.Path, Err: os.ErrNotExist}
 }


### PR DESCRIPTION
fix [issue](https://github.com/golang-migrate/migrate/issues/901) of downloading and using github sourced migration files of 100MB >=1Mb (which previously failed to download due to their size and the api call performed) by preferring the go-github client library method 'DownloadContents' for such operations (which doesn't have the same limitation)
