### PR TITLE
feat(spanner): Add option to disable closing spanner clients

### DIFF
--- a/database/spanner/spanner.go
+++ b/database/spanner/spanner.go
@@ -56,6 +56,9 @@ type Config struct {
 	// Parsing outputs clean DDL statements such as reformatted
 	// and void of comments.
 	CleanStatements bool
+	// DoNotCloseSpannerClients turns Close() into a no-op so the
+	// provided spanner clients are not closed
+	DoNotCloseSpannerClients bool
 }
 
 // Spanner implements database.Driver for Google Cloud Spanner
@@ -146,6 +149,9 @@ func (s *Spanner) Open(url string) (database.Driver, error) {
 
 // Close implements database.Driver
 func (s *Spanner) Close() error {
+	if s.config.DoNotCloseSpannerClients {
+		return nil
+	}
 	s.db.data.Close()
 	return s.db.admin.Close()
 }


### PR DESCRIPTION
Provide an option to prevent the provided `*spanner.Client` and `*database.DatabaseAdminClient` from being closed when `migrate` closes `Spanner`

Spanner does not have the same concepts as PostgreSQL and MySQL, where it makes sense to use a `WithConnection()` function as the signature would be identical to that of `WithInstance()`. It could appear that they are interchangeable when really one closes the connection, and the other does not.

I chose to take a simple path of adding an option to the `Config`, `DoNotCloseSpannerClients`. This is a very simple change that is clear about its effect and does not change the default behavior of `WithInstance()`.

But this is not in line with the other drivers implementing this same feature, so feels a little inconsistent.

Maybe someone has a better idea.

See the following thread for reference:
 - How it was implemented for PostgreSQL: #659
 - how it was implemented for MySQL: #578 #583