### PR TITLE
Move supported go version to standard place

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/golang-migrate/migrate/v4
 
+go 1.18
+
 require (
 	cloud.google.com/go/spanner v1.44.0
 	cloud.google.com/go/storage v1.27.0
@@ -164,5 +166,3 @@ require (
 	modernc.org/token v1.0.0 // indirect
 	modernc.org/zappy v1.0.0 // indirect
 )
-
-go 1.18


### PR DESCRIPTION
This was changed in #815 to quite odd position.