### PR TITLE
rqlite is spelled with all lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Database drivers run migrations. [Add a new database?](database/driver.go)
 * [ClickHouse](database/clickhouse)
 * [Firebird](database/firebird)
 * [MS SQL Server](database/sqlserver)
-* [RQLite](database/rqlite)
+* [rqlite](database/rqlite)
 
 ### Database URLs
 


### PR DESCRIPTION
I'm the creator of rqlite, so wanted to fix the title. See https://rqlite.io/