### PR TITLE
Allow set session role for PostgreSQL and CockroachDB

### DIFF
--- a/database/cockroachdb/README.md
+++ b/database/cockroachdb/README.md
@@ -8,6 +8,7 @@
 | `x-lock-table` | `LockTable` | Name of the table which maintains the migration lock |
 | `x-force-lock` | `ForceLock` | Force lock acquisition to fix faulty migrations which may not have released the schema lock (Boolean, default is `false`) |
 | `dbname` | `DatabaseName` | The name of the database to connect to |
+| `x-role` | `Role` | The role to be set in case it differs from the user |
 | `user` | | The user to sign in as |
 | `password` | | The user's password |
 | `host` | | The host to connect to. Values that start with / are for unix domain sockets. (default is localhost) |

--- a/database/postgres/README.md
+++ b/database/postgres/README.md
@@ -9,6 +9,7 @@
 | `x-statement-timeout` | `StatementTimeout` | Abort any statement that takes more than the specified number of milliseconds |
 | `x-multi-statement` | `MultiStatementEnabled` | Enable multi-statement execution (default: false) |
 | `x-multi-statement-max-size` | `MultiStatementMaxSize` | Maximum size of single statement in bytes (default: 10MB) |
+| `x-role` | `Role` | The role to be set in case it differs from the user |
 | `dbname` | `DatabaseName` | The name of the database to connect to |
 | `search_path` | | This variable specifies the order in which schemas are searched when an object is referenced by a simple name with no schema specified. |
 | `user` | | The user to sign in as |

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -41,6 +41,7 @@ var (
 	ErrNoDatabaseName = fmt.Errorf("no database name")
 	ErrNoSchema       = fmt.Errorf("no schema")
 	ErrDatabaseDirty  = fmt.Errorf("database is dirty")
+	ErrNoSuchRole     = fmt.Errorf("no such role")
 )
 
 type Config struct {
@@ -53,6 +54,7 @@ type Config struct {
 	migrationsTableName   string
 	StatementTimeout      time.Duration
 	MultiStatementMaxSize int
+	Role                  string
 }
 
 type Postgres struct {
@@ -104,6 +106,18 @@ func WithConnection(ctx context.Context, conn *sql.Conn, config *Config) (*Postg
 
 	if len(config.MigrationsTable) == 0 {
 		config.MigrationsTable = DefaultMigrationsTable
+	}
+
+	if len(config.Role) > 0 {
+		var role string
+		query := `SELECT rolname FROM pg_roles WHERE rolname = $1`
+		if err := conn.QueryRowContext(ctx, query, config.Role).Scan(&role); err != nil {
+			if err == sql.ErrNoRows {
+				return nil, ErrNoSuchRole
+			}
+			return nil, &database.Error{OrigErr: err, Query: []byte(query)}
+		}
+		config.Role = role
 	}
 
 	config.migrationsSchemaName = config.SchemaName
@@ -202,6 +216,11 @@ func (p *Postgres) Open(url string) (database.Driver, error) {
 		}
 	}
 
+	role := ""
+	if s := purl.Query().Get("x-role"); len(s) > 0 {
+		role = s
+	}
+
 	px, err := WithInstance(db, &Config{
 		DatabaseName:          purl.Path,
 		MigrationsTable:       migrationsTable,
@@ -209,6 +228,7 @@ func (p *Postgres) Open(url string) (database.Driver, error) {
 		StatementTimeout:      time.Duration(statementTimeout) * time.Millisecond,
 		MultiStatementEnabled: multiStatementEnabled,
 		MultiStatementMaxSize: multiStatementMaxSize,
+		Role:                  role,
 	})
 
 	if err != nil {
@@ -290,6 +310,12 @@ func (p *Postgres) runStatement(statement []byte) error {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, p.config.StatementTimeout)
 		defer cancel()
+	}
+	if len(p.config.Role) > 0 {
+		query := "SET ROLE " + p.config.Role
+		if _, err := p.conn.ExecContext(ctx, query); err != nil {
+			return database.Error{OrigErr: err, Err: "failed to set role", Query: statement}
+		}
 	}
 	query := string(statement)
 	if strings.TrimSpace(query) == "" {

--- a/database/postgres/postgres_test.go
+++ b/database/postgres/postgres_test.go
@@ -801,3 +801,72 @@ func Test_computeLineFromPos(t *testing.T) {
 		})
 	}
 }
+
+func TestRole(t *testing.T) {
+	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ip, port, err := c.FirstPort()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		addr := pgConnectionString(ip, port)
+
+		// Check that opening the postgres connection returns NilVersion
+		p := &Postgres{}
+
+		d, err := p.Open(addr)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		defer func() {
+			if err := d.Close(); err != nil {
+				t.Error(err)
+			}
+		}()
+
+		mustRun(t, d, []string{
+			"CREATE USER _fa",
+			"GRANT CONNECT, CREATE, TEMPORARY ON DATABASE postgres TO _fa",
+			"CREATE USER deploy WITH ENCRYPTED PASSWORD '" + pgPassword + "'",
+			"GRANT _fa TO deploy",
+		})
+
+		// positive: connecting with deploy user and setting role to _fa
+		d2, err := p.Open(fmt.Sprintf("postgres://deploy:%s@%v:%v/postgres?sslmode=disable&x-role=_fa", pgPassword, ip, port))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := d2.Run(strings.NewReader("CREATE TABLE foo (foo text);")); err != nil {
+			t.Fatal(err)
+		}
+		var exists bool
+		if err := d2.(*Postgres).conn.QueryRowContext(context.Background(), "SELECT EXISTS (SELECT 1 FROM pg_tables WHERE tablename = 'foo' AND tableowner = '_fa');").Scan(&exists); err != nil {
+			t.Fatal(err)
+		}
+		if !exists {
+			t.Fatalf("expected table foo owned by _fa role to exist")
+		}
+
+		// negative: connecting with deploy user and trying to set not existing role
+		_, err = p.Open(fmt.Sprintf("postgres://deploy:%s@%v:%v/postgres?sslmode=disable&x-role=not_existing_role", pgPassword, ip, port))
+		if err != ErrNoSuchRole {
+			t.Fatal(fmt.Errorf("expected %w, but got %w", ErrNoSuchRole, err))
+		}
+
+		// negative: connecting with deploy user and trying to set not granted role
+		d3, err := p.Open(fmt.Sprintf("postgres://deploy:%s@%v:%v/postgres?sslmode=disable&x-role=postgres", pgPassword, ip, port))
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = d3.Run(strings.NewReader("CREATE TABLE imdasuperuser (foo text);"))
+		var e database.Error
+		if !errors.As(err, &e) || err == nil {
+			t.Fatal(fmt.Errorf("unexpected success, wanted permission denied error, got: %w", err))
+		}
+		if !strings.Contains(e.OrigErr.Error(), "permission denied to set role") {
+			t.Fatal(fmt.Errorf("unexpected error, wanted permission denied error, got: %w", err))
+		}
+	})
+}


### PR DESCRIPTION
Similar reasons as it described in #909, also it would be nice to have it for CockroachDB.

Allowing to set session-scope role while applying migrations.
Used `x-` prefixed param as it not supported by underlying drivers.

Also bumped CockroachDB versions on tests to a bit newer and fixed start params to make it working.

