### PR TITLE
fix: install tzdata in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN make build-docker
 
 FROM alpine:3.19
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates tzdata
 
 COPY --from=builder /go/src/github.com/golang-migrate/migrate/build/migrate.linux-386 /usr/local/bin/migrate
 RUN ln -s /usr/local/bin/migrate /migrate


### PR DESCRIPTION
fixes the error

> error: could not load time location: unknown time zone Europe/Prague in line 0: SHOW TABLES FROM "omega" LIKE 'schema_migrations'

This error was discussed also in #494 and #201 but not solved.