### PR TITLE
Improve Snowflake support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SOURCE ?= file go_bindata github github_ee bitbucket aws_s3 google_cloud_storage godoc_vfs gitlab
-DATABASE ?= postgres mysql redshift cassandra spanner cockroachdb yugabytedb clickhouse mongodb sqlserver firebird neo4j pgx pgx5 rqlite
+DATABASE ?= postgres mysql redshift cassandra spanner cockroachdb yugabytedb clickhouse mongodb sqlserver firebird neo4j pgx pgx5 rqlite snowflake
 DATABASE_TEST ?= $(DATABASE) sqlite sqlite3 sqlcipher
 VERSION ?= $(shell git describe --tags 2>/dev/null | cut -c 2-)
 TEST_FLAGS ?=

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SOURCE ?= file go_bindata github github_ee bitbucket aws_s3 google_cloud_storage godoc_vfs gitlab
-DATABASE ?= postgres mysql redshift cassandra spanner cockroachdb yugabytedb clickhouse mongodb sqlserver firebird neo4j pgx pgx5 rqlite snowflake
+DATABASE ?= postgres mysql redshift cassandra spanner cockroachdb yugabytedb clickhouse mongodb sqlserver firebird neo4j pgx pgx5 rqlite
 DATABASE_TEST ?= $(DATABASE) sqlite sqlite3 sqlcipher
 VERSION ?= $(shell git describe --tags 2>/dev/null | cut -c 2-)
 TEST_FLAGS ?=

--- a/database/snowflake/README.md
+++ b/database/snowflake/README.md
@@ -2,11 +2,14 @@
 
 `snowflake://user:password@accountname/schema/dbname?query`
 
-| URL Query  | WithInstance Config | Description |
-|------------|---------------------|-------------|
-| `x-migrations-table` | `MigrationsTable` | Name of the migrations table |
+| URL Query            | WithInstance Config | Description                  |
+| -------------------- | ------------------- | ---------------------------- |
+| `x-migrations-table` | `MigrationsTable`   | Name of the migrations table |
+| `warehouse`          |                     | Snowflake warehouse to use   |
 
-Snowflake is PostgreSQL compatible but has some specific features (or lack thereof) that require slightly different behavior.
+Snowflake is PostgreSQL compatible but has some specific features (or lack
+thereof) that require slightly different behavior.
 
 ## Status
+
 This driver is not officially supported as there are no tests for it.


### PR DESCRIPTION
Improve support for Snowflake migrations

- Allow specifying Snowflake warehouse to apply migrations against.
- Use [Snowflake multi-statement support](https://docs.snowflake.com/en/developer-guide/sql-api/submitting-multiple-statements) to bundle SQL batches in migrations.