### PR TITLE
Fix: ensureVersionTable & ensureLockTable perfomance.

### DIFF
--- a/database/cockroachdb/cockroachdb.go
+++ b/database/cockroachdb/cockroachdb.go
@@ -326,18 +326,8 @@ func (c *CockroachDb) ensureVersionTable() (err error) {
 		}
 	}()
 
-	// check if migration table exists
-	var count int
-	query := `SELECT COUNT(1) FROM information_schema.tables WHERE table_name = $1 AND table_schema = (SELECT current_schema()) LIMIT 1`
-	if err := c.db.QueryRow(query, c.config.MigrationsTable).Scan(&count); err != nil {
-		return &database.Error{OrigErr: err, Query: []byte(query)}
-	}
-	if count == 1 {
-		return nil
-	}
-
-	// if not, create the empty migration table
-	query = `CREATE TABLE "` + c.config.MigrationsTable + `" (version INT NOT NULL PRIMARY KEY, dirty BOOL NOT NULL)`
+	// create table query is idempotent.
+	query := `CREATE TABLE IF NOT EXISTS "` + c.config.MigrationsTable + `" (version INT NOT NULL PRIMARY KEY, dirty BOOL NOT NULL)`
 	if _, err := c.db.Exec(query); err != nil {
 		return &database.Error{OrigErr: err, Query: []byte(query)}
 	}
@@ -345,18 +335,8 @@ func (c *CockroachDb) ensureVersionTable() (err error) {
 }
 
 func (c *CockroachDb) ensureLockTable() error {
-	// check if lock table exists
-	var count int
-	query := `SELECT COUNT(1) FROM information_schema.tables WHERE table_name = $1 AND table_schema = (SELECT current_schema()) LIMIT 1`
-	if err := c.db.QueryRow(query, c.config.LockTable).Scan(&count); err != nil {
-		return &database.Error{OrigErr: err, Query: []byte(query)}
-	}
-	if count == 1 {
-		return nil
-	}
-
-	// if not, create the empty lock table
-	query = `CREATE TABLE "` + c.config.LockTable + `" (lock_id INT NOT NULL PRIMARY KEY)`
+	// create table query is idempotent. 
+	query := `CREATE TABLE IF NOT EXISTS "` + c.config.LockTable + `" (lock_id INT NOT NULL PRIMARY KEY)`
 	if _, err := c.db.Exec(query); err != nil {
 		return &database.Error{OrigErr: err, Query: []byte(query)}
 	}


### PR DESCRIPTION
`ensureLockTable` & `ensureLockTable` runs select query on `information_schema` to check weather tables exist.
such query are expensive. It takes around ~`15Sec`

We can avoid that and make the table creation query `Idempotent`. Which reduces the `latency to < 1Sec`