### PR TITLE
Make MySQL SetVersion compatible with sql_safe_update

### DIFF
--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -361,7 +361,7 @@ func (m *Mysql) SetVersion(version int, dirty bool) error {
 		return &database.Error{OrigErr: err, Err: "transaction start failed"}
 	}
 
-	query := "DELETE FROM `" + m.config.MigrationsTable + "`"
+	query := "DELETE FROM `" + m.config.MigrationsTable + "` LIMIT 1"
 	if _, err := tx.ExecContext(context.Background(), query); err != nil {
 		if errRollback := tx.Rollback(); errRollback != nil {
 			err = multierror.Append(err, errRollback)


### PR DESCRIPTION
After change in #656 SetVersion implementation isn't compliant with mysql safe updates mode. Setting limit on delete is enough to make it work with safe update enabled. This should solve #864 