### PR TITLE
Delete db docker images after tests complete for a few large db docker images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21.x"
+          go-version: "1.22.x"
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.20.x", "1.21.x"]
+        go: ["1.21.x", "1.22.x"]
     steps:
       - uses: actions/checkout@v4
 
@@ -68,7 +68,7 @@ jobs:
           ruby-version: 2.7
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21.x"
+          go-version: "1.22.x"
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine3.19 AS builder
+FROM golang:1.22-alpine3.19 AS builder
 ARG VERSION
 
 RUN apk add --no-cache git gcc musl-dev make

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Coverage Status](https://img.shields.io/coveralls/github/golang-migrate/migrate/master.svg)](https://coveralls.io/github/golang-migrate/migrate?branch=master)
 [![packagecloud.io](https://img.shields.io/badge/deb-packagecloud.io-844fec.svg)](https://packagecloud.io/golang-migrate/migrate?filter=debs)
 [![Docker Pulls](https://img.shields.io/docker/pulls/migrate/migrate.svg)](https://hub.docker.com/r/migrate/migrate/)
-![Supported Go Versions](https://img.shields.io/badge/Go-1.20%2C%201.21-lightgrey.svg)
+![Supported Go Versions](https://img.shields.io/badge/Go-1.21%2C%201.22-lightgrey.svg)
 [![GitHub Release](https://img.shields.io/github/release/golang-migrate/migrate.svg)](https://github.com/golang-migrate/migrate/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/golang-migrate/migrate/v4)](https://goreportcard.com/report/github.com/golang-migrate/migrate/v4)
 

--- a/database/cassandra/cassandra_test.go
+++ b/database/cassandra/cassandra_test.go
@@ -61,6 +61,20 @@ func isReady(ctx context.Context, c dktest.ContainerInfo) bool {
 }
 
 func Test(t *testing.T) {
+	t.Run("test", test)
+	t.Run("testMigrate", testMigrate)
+
+	t.Cleanup(func() {
+		for _, spec := range specs {
+			t.Log("Cleaning up ", spec.ImageName)
+			if err := spec.Cleanup(); err != nil {
+				t.Error("Error removing ", spec.ImageName, "error:", err)
+			}
+		}
+	})
+}
+
+func test(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.Port(9042)
 		if err != nil {
@@ -81,7 +95,7 @@ func Test(t *testing.T) {
 	})
 }
 
-func TestMigrate(t *testing.T) {
+func testMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.Port(9042)
 		if err != nil {

--- a/database/mongodb/mongodb_test.go
+++ b/database/mongodb/mongodb_test.go
@@ -74,6 +74,22 @@ func isReady(ctx context.Context, c dktest.ContainerInfo) bool {
 }
 
 func Test(t *testing.T) {
+	t.Run("test", test)
+	t.Run("testMigrate", testMigrate)
+	t.Run("testWithAuth", testWithAuth)
+	t.Run("testLockWorks", testLockWorks)
+
+	t.Cleanup(func() {
+		for _, spec := range specs {
+			t.Log("Cleaning up ", spec.ImageName)
+			if err := spec.Cleanup(); err != nil {
+				t.Error("Error removing ", spec.ImageName, "error:", err)
+			}
+		}
+	})
+}
+
+func test(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()
 		if err != nil {
@@ -99,7 +115,7 @@ func Test(t *testing.T) {
 	})
 }
 
-func TestMigrate(t *testing.T) {
+func testMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()
 		if err != nil {
@@ -125,7 +141,7 @@ func TestMigrate(t *testing.T) {
 	})
 }
 
-func TestWithAuth(t *testing.T) {
+func testWithAuth(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()
 		if err != nil {
@@ -180,7 +196,7 @@ func TestWithAuth(t *testing.T) {
 	})
 }
 
-func TestLockWorks(t *testing.T) {
+func testLockWorks(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()
 		if err != nil {
@@ -241,6 +257,15 @@ func TestTransaction(t *testing.T) {
 		{ImageName: "mongo:4", Options: dktest.Options{PortRequired: true, ReadyFunc: isReady,
 			Cmd: []string{"mongod", "--bind_ip_all", "--replSet", "rs0"}}},
 	}
+	t.Cleanup(func() {
+		for _, spec := range transactionSpecs {
+			t.Log("Cleaning up ", spec.ImageName)
+			if err := spec.Cleanup(); err != nil {
+				t.Error("Error removing ", spec.ImageName, "error:", err)
+			}
+		}
+	})
+
 	dktesting.ParallelTest(t, transactionSpecs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()
 		if err != nil {

--- a/database/postgres/postgres_test.go
+++ b/database/postgres/postgres_test.go
@@ -85,6 +85,32 @@ func mustRun(t *testing.T, d database.Driver, statements []string) {
 }
 
 func Test(t *testing.T) {
+	t.Run("test", test)
+	t.Run("testMigrate", testMigrate)
+	t.Run("testMultipleStatements", testMultipleStatements)
+	t.Run("testMultipleStatementsInMultiStatementMode", testMultipleStatementsInMultiStatementMode)
+	t.Run("testErrorParsing", testErrorParsing)
+	t.Run("testFilterCustomQuery", testFilterCustomQuery)
+	t.Run("testWithSchema", testWithSchema)
+	t.Run("testMigrationTableOption", testMigrationTableOption)
+	t.Run("testFailToCreateTableWithoutPermissions", testFailToCreateTableWithoutPermissions)
+	t.Run("testCheckBeforeCreateTable", testCheckBeforeCreateTable)
+	t.Run("testParallelSchema", testParallelSchema)
+	t.Run("testPostgresLock", testPostgresLock)
+	t.Run("testWithInstanceConcurrent", testWithInstanceConcurrent)
+	t.Run("testWithConnection", testWithConnection)
+
+	t.Cleanup(func() {
+		for _, spec := range specs {
+			t.Log("Cleaning up ", spec.ImageName)
+			if err := spec.Cleanup(); err != nil {
+				t.Error("Error removing ", spec.ImageName, "error:", err)
+			}
+		}
+	})
+}
+
+func test(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()
 		if err != nil {
@@ -106,7 +132,7 @@ func Test(t *testing.T) {
 	})
 }
 
-func TestMigrate(t *testing.T) {
+func testMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()
 		if err != nil {
@@ -132,7 +158,7 @@ func TestMigrate(t *testing.T) {
 	})
 }
 
-func TestMultipleStatements(t *testing.T) {
+func testMultipleStatements(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()
 		if err != nil {
@@ -165,7 +191,7 @@ func TestMultipleStatements(t *testing.T) {
 	})
 }
 
-func TestMultipleStatementsInMultiStatementMode(t *testing.T) {
+func testMultipleStatementsInMultiStatementMode(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()
 		if err != nil {
@@ -198,7 +224,7 @@ func TestMultipleStatementsInMultiStatementMode(t *testing.T) {
 	})
 }
 
-func TestErrorParsing(t *testing.T) {
+func testErrorParsing(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()
 		if err != nil {
@@ -227,7 +253,7 @@ func TestErrorParsing(t *testing.T) {
 	})
 }
 
-func TestFilterCustomQuery(t *testing.T) {
+func testFilterCustomQuery(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()
 		if err != nil {
@@ -249,7 +275,7 @@ func TestFilterCustomQuery(t *testing.T) {
 	})
 }
 
-func TestWithSchema(t *testing.T) {
+func testWithSchema(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()
 		if err != nil {
@@ -319,7 +345,7 @@ func TestWithSchema(t *testing.T) {
 	})
 }
 
-func TestMigrationTableOption(t *testing.T) {
+func testMigrationTableOption(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()
 		if err != nil {
@@ -387,7 +413,7 @@ func TestMigrationTableOption(t *testing.T) {
 	})
 }
 
-func TestFailToCreateTableWithoutPermissions(t *testing.T) {
+func testFailToCreateTableWithoutPermissions(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()
 		if err != nil {
@@ -457,7 +483,7 @@ func TestFailToCreateTableWithoutPermissions(t *testing.T) {
 	})
 }
 
-func TestCheckBeforeCreateTable(t *testing.T) {
+func testCheckBeforeCreateTable(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()
 		if err != nil {
@@ -534,7 +560,7 @@ func TestCheckBeforeCreateTable(t *testing.T) {
 	})
 }
 
-func TestParallelSchema(t *testing.T) {
+func testParallelSchema(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()
 		if err != nil {
@@ -602,7 +628,7 @@ func TestParallelSchema(t *testing.T) {
 	})
 }
 
-func TestPostgres_Lock(t *testing.T) {
+func testPostgresLock(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()
 		if err != nil {
@@ -642,7 +668,7 @@ func TestPostgres_Lock(t *testing.T) {
 	})
 }
 
-func TestWithInstance_Concurrent(t *testing.T) {
+func testWithInstanceConcurrent(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()
 		if err != nil {
@@ -685,7 +711,7 @@ func TestWithInstance_Concurrent(t *testing.T) {
 	})
 }
 
-func TestWithConnection(t *testing.T) {
+func testWithConnection(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()
 		if err != nil {

--- a/database/sqlserver/sqlserver_test.go
+++ b/database/sqlserver/sqlserver_test.go
@@ -96,6 +96,26 @@ func SkipIfUnsupportedArch(t *testing.T, c dktest.ContainerInfo) {
 }
 
 func Test(t *testing.T) {
+	t.Run("test", test)
+	t.Run("testMigrate", testMigrate)
+	t.Run("testMultiStatement", testMultiStatement)
+	t.Run("testErrorParsing", testErrorParsing)
+	t.Run("testLockWorks", testLockWorks)
+	t.Run("testMsiTrue", testMsiTrue)
+	t.Run("testOpenWithPasswordAndMSI", testOpenWithPasswordAndMSI)
+	t.Run("testMsiFalse", testMsiFalse)
+
+	t.Cleanup(func() {
+		for _, spec := range specs {
+			t.Log("Cleaning up ", spec.ImageName)
+			if err := spec.Cleanup(); err != nil {
+				t.Error("Error removing ", spec.ImageName, "error:", err)
+			}
+		}
+	})
+}
+
+func test(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		SkipIfUnsupportedArch(t, c)
 		ip, port, err := c.Port(defaultPort)
@@ -120,7 +140,7 @@ func Test(t *testing.T) {
 	})
 }
 
-func TestMigrate(t *testing.T) {
+func testMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		SkipIfUnsupportedArch(t, c)
 		ip, port, err := c.Port(defaultPort)
@@ -149,7 +169,7 @@ func TestMigrate(t *testing.T) {
 	})
 }
 
-func TestMultiStatement(t *testing.T) {
+func testMultiStatement(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		SkipIfUnsupportedArch(t, c)
 		ip, port, err := c.Port(defaultPort)
@@ -183,7 +203,7 @@ func TestMultiStatement(t *testing.T) {
 	})
 }
 
-func TestErrorParsing(t *testing.T) {
+func testErrorParsing(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		SkipIfUnsupportedArch(t, c)
 		ip, port, err := c.Port(defaultPort)
@@ -215,7 +235,7 @@ func TestErrorParsing(t *testing.T) {
 	})
 }
 
-func TestLockWorks(t *testing.T) {
+func testLockWorks(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		SkipIfUnsupportedArch(t, c)
 		ip, port, err := c.Port(defaultPort)
@@ -254,7 +274,7 @@ func TestLockWorks(t *testing.T) {
 	})
 }
 
-func TestMsiTrue(t *testing.T) {
+func testMsiTrue(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		SkipIfUnsupportedArch(t, c)
 		ip, port, err := c.Port(defaultPort)
@@ -271,7 +291,7 @@ func TestMsiTrue(t *testing.T) {
 	})
 }
 
-func TestOpenWithPasswordAndMSI(t *testing.T) {
+func testOpenWithPasswordAndMSI(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		SkipIfUnsupportedArch(t, c)
 		ip, port, err := c.Port(defaultPort)
@@ -303,7 +323,7 @@ func TestOpenWithPasswordAndMSI(t *testing.T) {
 	})
 }
 
-func TestMsiFalse(t *testing.T) {
+func testMsiFalse(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		SkipIfUnsupportedArch(t, c)
 		ip, port, err := c.Port(defaultPort)

--- a/database/yugabytedb/yugabytedb_test.go
+++ b/database/yugabytedb/yugabytedb_test.go
@@ -91,6 +91,22 @@ func getConnectionString(ip, port string, options ...string) string {
 }
 
 func Test(t *testing.T) {
+	t.Run("test", test)
+	t.Run("testMigrate", testMigrate)
+	t.Run("testMultiStatement", testMultiStatement)
+	t.Run("testFilterCustomQuery", testFilterCustomQuery)
+
+	t.Cleanup(func() {
+		for _, spec := range specs {
+			t.Log("Cleaning up ", spec.ImageName)
+			if err := spec.Cleanup(); err != nil {
+				t.Error("Error removing ", spec.ImageName, "error:", err)
+			}
+		}
+	})
+}
+
+func test(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, ci dktest.ContainerInfo) {
 		createDB(t, ci)
 
@@ -109,7 +125,7 @@ func Test(t *testing.T) {
 	})
 }
 
-func TestMigrate(t *testing.T) {
+func testMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, ci dktest.ContainerInfo) {
 		createDB(t, ci)
 
@@ -133,7 +149,7 @@ func TestMigrate(t *testing.T) {
 	})
 }
 
-func TestMultiStatement(t *testing.T) {
+func testMultiStatement(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, ci dktest.ContainerInfo) {
 		createDB(t, ci)
 
@@ -163,7 +179,7 @@ func TestMultiStatement(t *testing.T) {
 	})
 }
 
-func TestFilterCustomQuery(t *testing.T) {
+func testFilterCustomQuery(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, ci dktest.ContainerInfo) {
 		createDB(t, ci)
 

--- a/dktesting/dktesting.go
+++ b/dktesting/dktesting.go
@@ -1,17 +1,41 @@
 package dktesting
 
 import (
+	"context"
+	"fmt"
 	"testing"
 )
 
 import (
 	"github.com/dhui/dktest"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 )
 
 // ContainerSpec holds Docker testing setup specifications
 type ContainerSpec struct {
 	ImageName string
 	Options   dktest.Options
+}
+
+// Cleanup cleanups the ContainerSpec after a test run by removing the ContainerSpec's image
+func (s *ContainerSpec) Cleanup() (retErr error) {
+	// copied from dktest.RunContext()
+	dc, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.41"))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := dc.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("error closing Docker client: %w", err)
+		}
+	}()
+	ctx, timeoutCancelFunc := context.WithTimeout(context.Background(), s.Options.CleanupTimeout)
+	defer timeoutCancelFunc()
+	if _, err := dc.ImageRemove(ctx, s.ImageName, types.ImageRemoveOptions{Force: true, PruneChildren: true}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // ParallelTest runs Docker tests in parallel

--- a/dktesting/dktesting.go
+++ b/dktesting/dktesting.go
@@ -30,7 +30,11 @@ func (s *ContainerSpec) Cleanup() (retErr error) {
 			retErr = fmt.Errorf("error closing Docker client: %w", err)
 		}
 	}()
-	ctx, timeoutCancelFunc := context.WithTimeout(context.Background(), s.Options.CleanupTimeout)
+	cleanupTimeout := s.Options.CleanupTimeout
+	if cleanupTimeout <= 0 {
+		cleanupTimeout = dktest.DefaultCleanupTimeout
+	}
+	ctx, timeoutCancelFunc := context.WithTimeout(context.Background(), cleanupTimeout)
 	defer timeoutCancelFunc()
 	if _, err := dc.ImageRemove(ctx, s.ImageName, types.ImageRemoveOptions{Force: true, PruneChildren: true}); err != nil {
 		return err


### PR DESCRIPTION
As titled.

This should fix the broken tests.

This PR also drops support for Go 1.20 and adds support for Go 1.22 (sorry for the messy PR organization but tests were failing...)