### PR TITLE
feat: an option for crdb to wait util the lock is released to mimic pg locks behaviour

### DIFF
--- a/database/cockroachdb/README.md
+++ b/database/cockroachdb/README.md
@@ -2,18 +2,21 @@
 
 `cockroachdb://user:password@host:port/dbname?query` (`cockroach://`, and `crdb-postgres://` work, too)
 
-| URL Query  | WithInstance Config | Description |
-|------------|---------------------|-------------|
-| `x-migrations-table` | `MigrationsTable` | Name of the migrations table |
-| `x-lock-table` | `LockTable` | Name of the table which maintains the migration lock |
-| `x-force-lock` | `ForceLock` | Force lock acquisition to fix faulty migrations which may not have released the schema lock (Boolean, default is `false`) |
-| `dbname` | `DatabaseName` | The name of the database to connect to |
-| `user` | | The user to sign in as |
-| `password` | | The user's password |
-| `host` | | The host to connect to. Values that start with / are for unix domain sockets. (default is localhost) |
-| `port` | | The port to bind to. (default is 5432) |
-| `connect_timeout` | | Maximum wait for connection, in seconds. Zero or not specified means wait indefinitely. |
-| `sslcert` | | Cert file location. The file must contain PEM encoded data. |
-| `sslkey` | | Key file location. The file must contain PEM encoded data. |
-| `sslrootcert` | | The location of the root certificate file. The file must contain PEM encoded data. |
-| `sslmode` | | Whether or not to use SSL (disable\|require\|verify-ca\|verify-full) |
+| URL Query                   | WithInstance Config    | Description                                                                                                               |
+|-----------------------------|------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| `x-migrations-table`        | `MigrationsTable`      | Name of the migrations table                                                                                              |
+| `x-lock-table`              | `LockTable`            | Name of the table which maintains the migration lock                                                                      |
+| `x-force-lock`              | `ForceLock`            | Force lock acquisition to fix faulty migrations which may not have released the schema lock (Boolean, default is `false`) |
+| `x-lock-wait`               | `LockWait`             | If the lock is already acquired - wait for it to be released (Boolean, default is `false`)                                |
+| `x-lock-wait-timeout`       | `LockWaitTimeout`      | Max time to wait for the lock to be released (time.Duration, deefault is `30s`)                                           |
+| `x-lock-wait-poll-interval` | `LockWaitPollInterval` | How often should acquire a lock retry to happen (time.Duration, default is `1s`)                                          |
+| `dbname`                    | `DatabaseName`         | The name of the database to connect to                                                                                    |
+| `user`                      |                        | The user to sign in as                                                                                                    |
+| `password`                  |                        | The user's password                                                                                                       |
+| `host`                      |                        | The host to connect to. Values that start with / are for unix domain sockets. (default is localhost)                      |
+| `port`                      |                        | The port to bind to. (default is 5432)                                                                                    |
+| `connect_timeout`           |                        | Maximum wait for connection, in seconds. Zero or not specified means wait indefinitely.                                   |
+| `sslcert`                   |                        | Cert file location. The file must contain PEM encoded data.                                                               |
+| `sslkey`                    |                        | Key file location. The file must contain PEM encoded data.                                                                |
+| `sslrootcert`               |                        | The location of the root certificate file. The file must contain PEM encoded data.                                        |
+| `sslmode`                   |                        | Whether or not to use SSL (disable\|require\|verify-ca\|verify-full)                                                      |

--- a/database/cockroachdb/README.md
+++ b/database/cockroachdb/README.md
@@ -2,21 +2,21 @@
 
 `cockroachdb://user:password@host:port/dbname?query` (`cockroach://`, and `crdb-postgres://` work, too)
 
-| URL Query                   | WithInstance Config    | Description                                                                                                               |
-|-----------------------------|------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| `x-migrations-table`        | `MigrationsTable`      | Name of the migrations table                                                                                              |
-| `x-lock-table`              | `LockTable`            | Name of the table which maintains the migration lock                                                                      |
-| `x-force-lock`              | `ForceLock`            | Force lock acquisition to fix faulty migrations which may not have released the schema lock (Boolean, default is `false`) |
-| `x-lock-wait`               | `LockWait`             | If the lock is already acquired - wait for it to be released (Boolean, default is `false`)                                |
-| `x-lock-wait-timeout`       | `LockWaitTimeout`      | Max time to wait for the lock to be released (time.Duration, deefault is `30s`)                                           |
-| `x-lock-wait-poll-interval` | `LockWaitPollInterval` | How often should acquire a lock retry to happen (time.Duration, default is `1s`)                                          |
-| `dbname`                    | `DatabaseName`         | The name of the database to connect to                                                                                    |
-| `user`                      |                        | The user to sign in as                                                                                                    |
-| `password`                  |                        | The user's password                                                                                                       |
-| `host`                      |                        | The host to connect to. Values that start with / are for unix domain sockets. (default is localhost)                      |
-| `port`                      |                        | The port to bind to. (default is 5432)                                                                                    |
-| `connect_timeout`           |                        | Maximum wait for connection, in seconds. Zero or not specified means wait indefinitely.                                   |
-| `sslcert`                   |                        | Cert file location. The file must contain PEM encoded data.                                                               |
-| `sslkey`                    |                        | Key file location. The file must contain PEM encoded data.                                                                |
-| `sslrootcert`               |                        | The location of the root certificate file. The file must contain PEM encoded data.                                        |
-| `sslmode`                   |                        | Whether or not to use SSL (disable\|require\|verify-ca\|verify-full)                                                      |
+| URL Query                  | WithInstance Config   | Description                                                                                                                                                    |
+|----------------------------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `x-migrations-table`       | `MigrationsTable`     | Name of the migrations table                                                                                                                                   |
+| `x-lock-table`             | `LockTable`           | Name of the table which maintains the migration lock                                                                                                           |
+| `x-force-lock`             | `ForceLock`           | Force lock acquisition to fix faulty migrations which may not have released the schema lock (Boolean, default is `false`)                                      |
+| `x-max-retries`            | `MaxRetries`          | How many times retry queries on retryable errors (40001, 40P01, 08006, XX000). Default is 0 to keep the backward compatibility with the initial implementation |
+| `x-max-retry-interval`     | `MaxRetryInterval`    | Interval between retries increases exponentially. This option specifies maximum duration between retries. Default is `15s`                                     |
+| `x-max-retry-elapsed-time` | `MaxRetryElapsedTime` | Total retries timeout. Default is `30s`                                                                                                                        |
+| `dbname`                   | `DatabaseName`        | The name of the database to connect to                                                                                                                         |
+| `user`                     |                       | The user to sign in as                                                                                                                                         |
+| `password`                 |                       | The user's password                                                                                                                                            |
+| `host`                     |                       | The host to connect to. Values that start with / are for unix domain sockets. (default is localhost)                                                           |
+| `port`                     |                       | The port to bind to. (default is 5432)                                                                                                                         |
+| `connect_timeout`          |                       | Maximum wait for connection, in seconds. Zero or not specified means wait indefinitely.                                                                        |
+| `sslcert`                  |                       | Cert file location. The file must contain PEM encoded data.                                                                                                    |
+| `sslkey`                   |                       | Key file location. The file must contain PEM encoded data.                                                                                                     |
+| `sslrootcert`              |                       | The location of the root certificate file. The file must contain PEM encoded data.                                                                             |
+| `sslmode`                  |                       | Whether or not to use SSL (disable\|require\|verify-ca\|verify-full)                                                                                           |

--- a/database/cockroachdb/cockroachdb_test.go
+++ b/database/cockroachdb/cockroachdb_test.go
@@ -5,19 +5,18 @@ package cockroachdb
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
-	"github.com/golang-migrate/migrate/v4"
 	"log"
 	"strings"
 	"testing"
-)
+	"time"
 
-import (
 	"github.com/dhui/dktest"
 	_ "github.com/lib/pq"
-)
 
-import (
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/database"
 	dt "github.com/golang-migrate/migrate/v4/database/testing"
 	"github.com/golang-migrate/migrate/v4/dktesting"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
@@ -169,6 +168,101 @@ func TestFilterCustomQuery(t *testing.T) {
 		_, err = c.Open(addr)
 		if err != nil {
 			t.Fatal(err)
+		}
+	})
+}
+
+func TestLockDefault(t *testing.T) {
+	dktesting.ParallelTest(t, specs, func(t *testing.T, ci dktest.ContainerInfo) {
+		createDB(t, ci)
+
+		ip, port, err := ci.Port(26257)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		addr := fmt.Sprintf("cockroach://root@%v:%v/migrate?sslmode=disable", ip, port)
+		c := &CockroachDb{}
+		d1, err := c.Open(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		d2, err := c.Open(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := d1.Lock(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := d2.Lock(); err == nil || !errors.Is(err, database.ErrLocked) {
+			t.Fatalf("expected error %v, got %v", database.ErrLocked, err)
+		}
+
+		if err := d1.Unlock(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := d2.Lock(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := d2.Unlock(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestLockWait(t *testing.T) {
+	dktesting.ParallelTest(t, specs, func(t *testing.T, ci dktest.ContainerInfo) {
+		createDB(t, ci)
+
+		ip, port, err := ci.Port(26257)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		addr := fmt.Sprintf("cockroach://root@%v:%v/migrate?sslmode=disable&x-lock-wait=true", ip, port)
+		c := &CockroachDb{}
+		d1, err := c.Open(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		d2, err := c.Open(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := d1.Lock(); err != nil {
+			t.Fatal(err)
+		}
+
+		// lock d2 in a goroutine to make it wait a bit
+		done := make(chan struct{})
+		waiting := make(chan struct{})
+		go func() {
+			defer close(done)
+
+			close(waiting) // signal that the goroutine started and is waiting
+			if err := d2.Lock(); err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		<-waiting // ensure the goroutine started and is waiting
+
+		if err := d1.Unlock(); err != nil {
+			t.Fatal(err)
+		}
+
+		select {
+		case <-done: // we should get here once the d2 lock is acquired
+			break
+		case <-time.After(DefaultLockWaitPollInterval * 2): // wait for at least one poll
+			t.Fatal("expected lock to be acquired by d2")
 		}
 	})
 }

--- a/database/cockroachdb/cockroachdb_test.go
+++ b/database/cockroachdb/cockroachdb_test.go
@@ -224,7 +224,7 @@ func TestLockWait(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		addr := fmt.Sprintf("cockroach://root@%v:%v/migrate?sslmode=disable&x-lock-wait=true", ip, port)
+		addr := fmt.Sprintf("cockroach://root@%v:%v/migrate?sslmode=disable&x-max-retries=10", ip, port)
 		c := &CockroachDb{}
 		d1, err := c.Open(addr)
 		if err != nil {
@@ -261,7 +261,7 @@ func TestLockWait(t *testing.T) {
 		select {
 		case <-done: // we should get here once the d2 lock is acquired
 			break
-		case <-time.After(DefaultLockWaitPollInterval * 2): // wait for at least one poll
+		case <-time.After(DefaultMaxRetryInterval): // wait for at least one poll
 			t.Fatal("expected lock to be acquired by d2")
 		}
 	})

--- a/dktesting/dktesting.go
+++ b/dktesting/dktesting.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
-)
 
-import (
 	"github.com/dhui/dktest"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -53,11 +51,12 @@ func ParallelTest(t *testing.T, specs []ContainerSpec,
 		// TODO: order is random, maybe always pick first version instead?
 		if i > 0 && testing.Short() {
 			t.Logf("Skipping %v in short mode", spec.ImageName)
-		} else {
-			t.Run(spec.ImageName, func(t *testing.T) {
-				t.Parallel()
-				dktest.Run(t, spec.ImageName, spec.Options, testFunc)
-			})
+			continue
 		}
+
+		t.Run(spec.ImageName, func(t *testing.T) {
+			t.Parallel()
+			dktest.Run(t, spec.ImageName, spec.Options, testFunc)
+		})
 	}
 }


### PR DESCRIPTION
In PostgreSQL `pg_advisory_lock()` is used to put a DB-level lock before applying migrations. The side-effect of this way of locking is that operation is waiting indefinitely until the lock can be acquired.

CockroachDB is pg-compatible DB that does not support advisory locks, so locking is implemented using the lock table. The main issue when trying to switch from PG to CRDB is that migration is failing right away if another process is already applying them to the DB. For most of the cases this is fine, but for some, e.g. mine, some apps are already relying on the side-effect of advisory locks and apps are starting to conflict with each other and failing, instead of waiting and running sequentially.

This PR adds `retries` feature to the CRDB that mimics pg lock behaviour, so that apps may continue to use migration tool capabilities to apply migrations sequentially instead of managing this behaviour in the calling side. Implementation is aligned with the retries/backoff in yugabytedb, but the default value for the retry is set to 0 to keep the current behaviour unchanged.

PS: my editor applied some formatting to the edited files that are not directly related to the change, pls let me know if I need to rollback some of them, like imports sorting