### PR TITLE
Removed tx level serializable

### DIFF
--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -356,7 +356,7 @@ func (m *Mysql) Run(migration io.Reader) error {
 }
 
 func (m *Mysql) SetVersion(version int, dirty bool) error {
-	tx, err := m.conn.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable})
+	tx, err := m.conn.BeginTx(context.Background(), &sql.TxOptions{})
 	if err != nil {
 		return &database.Error{OrigErr: err, Err: "transaction start failed"}
 	}


### PR DESCRIPTION
Transaction level serializable is not supported by tidb, here's the error example:
```
error: transaction start failed in line 0:  (details: Error 8048: The isolation level 'SERIALIZABLE' is not supported. Set tidb_skip_isolation_level_check=1 to skip this error)
```

Transaction level serializable was originally introduced in this [PR](https://github.com/golang-migrate/migrate/pull/656/files)