### PR TITLE
use lowercase current_schema() method to support PgAdapter for GCP Spanner

### DIFF
--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -89,7 +89,7 @@ func WithConnection(ctx context.Context, conn *sql.Conn, config *Config) (*Postg
 	}
 
 	if config.SchemaName == "" {
-		query := `SELECT CURRENT_SCHEMA()`
+		query := `SELECT current_schema()`
 		var schemaName sql.NullString
 		if err := conn.QueryRowContext(ctx, query).Scan(&schemaName); err != nil {
 			return nil, &database.Error{OrigErr: err, Query: []byte(query)}
@@ -210,7 +210,6 @@ func (p *Postgres) Open(url string) (database.Driver, error) {
 		MultiStatementEnabled: multiStatementEnabled,
 		MultiStatementMaxSize: multiStatementMaxSize,
 	})
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hi!

We I have been experimenting with using the [Postgres adapter](https://github.com/GoogleCloudPlatform/pgadapter) for GCP Spanner that would let you use Postgres tools to interact with Spanner. However, it only supports the l[owercase version of `CURRENT_SCHEMA()`](https://github.com/GoogleCloudPlatform/pgadapter/pull/273), which is used in the migration. This PR simply changes the function to the lowercase one. This will not effect any Postgres functionality, but will let people use the Postgres Adapter for Spanner.  