### PR TITLE
ci: restore golangci-lint GHA actions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,6 @@ run:
 linters:
   enable:
     #- golint
-    - interfacer
     - unconvert
     #- dupl
     - goconst


### PR DESCRIPTION
the linter cannot work since they decided to report blocking errors on
outdated/deprecated linters.

The golangci-lint configuration should be reviewed fully, but this commit
will fix the CI and restore the ability to merge code.
