### PR TITLE
CORRECTION DONE near m.Step(2) if you want to explicitly set the number of migrations to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ func main() {
     m, err := migrate.NewWithDatabaseInstance(
         "file:///migrations",
         "postgres", driver)
-    m.Up() // or m.Step(2) if you want to explicitly set the number of migrations to run
+    m.Up() // or m.Steps(2) if you want to explicitly set the number of migrations to run
 }
 ```
 


### PR DESCRIPTION
if you want to explicitly set the number of migrations to run, the README.md needs a correction, there should "Steps()" and not Step()