### PR TITLE
Add MSSQL DB Batch Statement Support

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ run:
 linters:
   enable:
     #- golint
-    - interfacer
+    # interfacer
     - unconvert
     #- dupl
     - goconst

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ deploy:
       - cli/build/migrate.linux-armv7.tar.gz
       - cli/build/migrate.linux-arm64.tar.gz
       - cli/build/migrate.darwin-amd64.tar.gz
+      - cli/build/migrate.darwin-arm64.tar.gz
       - cli/build/migrate.windows-amd64.exe.tar.gz
       - cli/build/migrate.windows-386.exe.tar.gz
       - cli/build/sha256sum.txt

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ build-cli: clean
 	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -a -o ../../cli/build/migrate.linux-armv7 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
 	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -o ../../cli/build/migrate.linux-arm64 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
 	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -a -o ../../cli/build/migrate.darwin-amd64 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
+	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -a -o ../../cli/build/migrate.darwin-arm64 -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
 	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -a -o ../../cli/build/migrate.windows-386.exe -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
 	cd ./cmd/migrate && CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -a -o ../../cli/build/migrate.windows-amd64.exe -ldflags='-X main.Version=$(VERSION) -extldflags "-static"' -tags '$(DATABASE) $(SOURCE)' .
 	cd ./cli/build && find . -name 'migrate*' | xargs -I{} tar czf {}.tar.gz {}

--- a/database/sqlserver/README.md
+++ b/database/sqlserver/README.md
@@ -5,7 +5,6 @@
 
 | URL Query  | WithInstance Config | Description |
 |------------|---------------------|-------------|
-| `x-migrations-table` | `MigrationsTable` | Name of the migrations table |
 | `username` | |  enter the SQL Server Authentication user id or the Windows Authentication user id in the DOMAIN\User format. On Windows, if user id is empty or missing Single-Sign-On is used. |
 | `password` | | The user's password. | 
 | `host` | | The host to connect to. |
@@ -17,6 +16,8 @@
 | `encrypt` | | `disable` - Data send between client and server is not encrypted. `false` - Data sent between client and server is not encrypted beyond the login packet (Default). `true` - Data sent between client and server is encrypted. |
 | `app+name` || The application name (default is go-mssqldb). |
 | `useMsi` | | `true` - Use Azure MSI Authentication for connecting to Sql Server. Must be running from an Azure VM/an instance with MSI enabled. `false` - Use password authentication (Default). See [here for Azure MSI Auth details](https://docs.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-connect-msi). NOTE: Since this cannot be tested locally, this is not officially supported.
+| `x-migrations-table` | `MigrationsTable` | Name of the migrations table |
+| `x-batch-enabled` | | Process batch statements using the go-mssqldb "batch" processor to support the SSMS `GO` statement. |
 
 See https://github.com/microsoft/go-mssqldb for full parameter list.
 

--- a/database/sqlserver/sqlserver.go
+++ b/database/sqlserver/sqlserver.go
@@ -268,7 +268,6 @@ func (ss *SQLServer) Run(migration io.Reader) error {
 			}
 			return database.Error{OrigErr: err, Err: "migration failed", Query: []byte(script)}
 		}
-		return database.Error{OrigErr: err, Err: "migration failed", Query: migr}
 	}
 
 	return nil

--- a/database/sqlserver/sqlserver.go
+++ b/database/sqlserver/sqlserver.go
@@ -258,7 +258,7 @@ func (ss *SQLServer) Run(migration io.Reader) error {
 	}
 
 	for _, script := range scripts {
-		if _, err := ss.conn.ExecContext(context.Background(), query); err != nil {
+		if _, err := ss.conn.ExecContext(context.Background(), script); err != nil {
 			if msErr, ok := err.(mssql.Error); ok {
 				message := fmt.Sprintf("migration failed: %s", msErr.Message)
 				if msErr.ProcName != "" {

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -275,7 +275,7 @@ Database drivers: `+strings.Join(database.List(), ", ")+"\n", createUsage, gotoU
 		if needsConfirm {
 			log.Println("Are you sure you want to apply all down migrations? [y/N]")
 			var response string
-			fmt.Scanln(&response)
+			_, _ = fmt.Scanln(&response)
 			response = strings.ToLower(strings.TrimSpace(response))
 
 			if response == "y" {
@@ -306,7 +306,7 @@ Database drivers: `+strings.Join(database.List(), ", ")+"\n", createUsage, gotoU
 		if !*forceDrop {
 			log.Println("Are you sure you want to drop the entire database schema? [y/N]")
 			var response string
-			fmt.Scanln(&response)
+			_, _ = fmt.Scanln(&response)
 			response = strings.ToLower(strings.TrimSpace(response))
 
 			if response == "y" {


### PR DESCRIPTION
Adds support for "batch" statements using the "GO" keyword supported by SQL IDEs such as SSMS or Azure Data Studio. 

This logic for parsing the batched statements is implemented by the standard MSSQL DB driver: `github.com/microsoft/go-mssqldb` and specifically included in the `github.com/microsoft/go-mssqldb/batch` package. 

By default this functionality is not enabled. To enable it, a configuration option named `BatchEnabled` must be set to true. 
This parameter can be set through the connection URL using the parameter `x-batch-enabled`. 

A common use case requiring batched statement is creating more than one view in a single file. SQL Server does not allow multiple views to be created in a single batch. Below is an example of multiple batches in a single migration file to create views: 

```sql
CREATE VIEW [dbo].VxTest1 AS SELECT 1; 

GO 

CREATE VIEW [dbo].VxTest1 AS SELECT 1; 

GO
```

This migration will result in an error about an unsupported command if the `BatchEnabled` option is not true. 

There is no breaking functionality. 

Additionally, this PR introduces a new build artifact for Apple Silicon chips (M1, M2, M3, etc). It is a Darwin ARM64 build.

