### PR TITLE
feature: Add new error type for version not found

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -36,6 +36,22 @@ var (
 	ErrLockTimeout    = errors.New("timeout: can't acquire database lock")
 )
 
+// ErrorVersionNotFound is an error returned when a migration version
+// is not found in the source.
+type ErrorVersionNotFound struct {
+	Version uint
+	Err     error
+}
+
+func (e ErrorVersionNotFound) Error() string {
+	return fmt.Sprintf("no migration found for version %d: %s", e.Version, e.Err.Error())
+}
+
+// We need to keep the original error when unwrapping for compatibility in case someone if validating the error type
+func (e ErrorVersionNotFound) Unwrap() error {
+	return e.Err
+}
+
 // ErrShortLimit is an error returned when not enough migrations
 // can be returned by a source for a given limit.
 type ErrShortLimit struct {
@@ -806,7 +822,7 @@ func (m *Migrate) versionExists(version uint) (result error) {
 		return err
 	}
 
-	err = fmt.Errorf("no migration found for version %d: %w", version, err)
+	err = ErrorVersionNotFound{Version: version, Err: err}
 	m.logErr(err)
 	return err
 }

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -243,7 +243,7 @@ func TestMigrate(t *testing.T) {
 		expectVersion uint
 		expectSeq     migrationSequence
 	}{
-		// migrate all the way Up in single steps
+		// // migrate all the way Up in single steps
 		{
 			version:   0,
 			expectErr: os.ErrNotExist,
@@ -731,7 +731,7 @@ func TestSteps(t *testing.T) {
 
 	for i, v := range tt {
 		err := m.Steps(v.steps)
-		if (v.expectErr == os.ErrNotExist && !errors.Is(err, os.ErrNotExist)) ||
+		if (v.expectErr == os.ErrNotExist && !errors.Is(err, os.ErrNotExist)) && isVersionNotFoundError(err) ||
 			(v.expectErr != os.ErrNotExist && err != v.expectErr) {
 			t.Errorf("expected err %v, got %v, in %v", v.expectErr, err, i)
 
@@ -1413,4 +1413,9 @@ func equalDbSeq(t *testing.T, i int, expected migrationSequence, got *dStub.Stub
 	if !got.EqualSequence(bs) {
 		t.Fatalf("\nexpected sequence %v,\ngot               %v, in %v", bs, got.MigrationSequence, i)
 	}
+}
+
+func isVersionNotFoundError(err error) bool {
+	var errV ErrorVersionNotFound
+	return !errors.As(err, &errV)
 }


### PR DESCRIPTION
Hello @dhui @Fontinalis!

Currently, when there is an error in the `versionExists` function, we return the one we have received from the functions called inside of this one. After some investigation I found out that when the version does not exist (and all the internal function logic goes well) the error return is `os.ErrNotExist`. This works fine. However, in my opinion, this is a bit confusing since it's does not tell me directly that the version does not exist

**Proposal**

In this PR, I have added a new error type called `ErrorVersionNotFound` to better reference that a version does not exist for the specific migration. It still wraps the original error to ensure compatibility.

**Why have this?**

I think that having this error type will help users better control this particular case (to be honest, I came up with this idea because to me getting a `os.ErrNotExist` was a bit "vague") instead of having to compare the error message, they can just import the error and validate if they receive that type.

Thank you very much and congrats on the project, I'm really enjoying working with it

Best Regards
Simeon