### PR TITLE
Support .deb package for Noble Numbat (24.04)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,6 +97,9 @@ jobs:
       - run: package_cloud push golang-migrate/migrate/ubuntu/jammy dist/migrate.linux-amd64.deb
         env:
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+      - run: package_cloud push golang-migrate/migrate/ubuntu/noble dist/migrate.linux-amd64.deb
+        env:
+          PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
       - run: package_cloud push golang-migrate/migrate/debian/buster dist/migrate.linux-amd64.deb
         env:
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}


### PR DESCRIPTION
This pull should close https://github.com/golang-migrate/migrate/pull/1067 as well.

Reasons for test failure don't seem to be caused by this pull:
```sh
2024-07-17T20:14:51.6878297Z FAIL
2024-07-17T20:14:51.6878525Z coverage: 8.3% of statements
2024-07-17T20:14:51.6894484Z exit status 1
2024-07-17T20:14:51.6895317Z FAIL	github.com/golang-migrate/migrate/v4/database/redshift	1.201s

Also

|No such image: postgres:8"
```

