### PR TITLE
I have modified the conditions for cluster migrations in ClickHouse.

### DIFF
--- a/database/clickhouse/clickhouse.go
+++ b/database/clickhouse/clickhouse.go
@@ -248,7 +248,7 @@ func (ch *ClickHouse) ensureVersionTable() (err error) {
 			) Engine=%s`, ch.config.MigrationsTable, ch.config.MigrationsTableEngine)
 	}
 
-	if strings.HasSuffix(ch.config.MigrationsTableEngine, "Tree") {
+	if strings.Contains(ch.config.MigrationsTableEngine, "MergeTree") {
 		query = fmt.Sprintf(`%s ORDER BY sequence`, query)
 	}
 


### PR DESCRIPTION
Related https://github.com/golang-migrate/migrate/issues/1097

The table was created correctly.

`testdb │ schema_migrations                  │ ReplicatedMergeTree          │ ReplicatedMergeTree('/clickhouse/{cluster01}/testdb/tables/schema_migrations', '{replica01}') ORDER BY sequence SETTINGS index_granularity = 8192 
`

I launched it with these parameters.
`/usr/local/bin/migrate -source file://extracted/$(Build.DefinitionName)/ch/testdb/ -database "clickhouse://$dbhost:$port?username=$login&password=$password&database=testdb&x-cluster-name=clickhouse_cluster&x-migrations-table-engine=ReplicatedMergeTree('/clickhouse/{cluster01}/{database}/tables/{table}', '{replica01}')" up`

I have macros set up on my ClickHouse cluster for different internal clusters, shards, and replicas.