### PR TITLE
Fix sqlserver lock

### DIFF
--- a/database/sqlserver/sqlserver.go
+++ b/database/sqlserver/sqlserver.go
@@ -198,10 +198,10 @@ func (ss *SQLServer) Lock() error {
 			return err
 		}
 
-		// This will either obtain the lock immediately and return true,
-		// or return false if the lock cannot be acquired immediately.
+		// This will either obtain the lock within 10 seconds and return true,
+		// or return false if the lock cannot be acquired within 10 seconds.
 		// MS Docs: sp_getapplock: https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-getapplock-transact-sql?view=sql-server-2017
-		query := `EXEC sp_getapplock @Resource = @p1, @LockMode = 'Update', @LockOwner = 'Session', @LockTimeout = 0`
+		query := `EXEC sp_getapplock @Resource = @p1, @LockMode = 'Update', @LockOwner = 'Session', @LockTimeout = 10000`
 
 		var status mssql.ReturnStatus
 		if _, err = ss.conn.ExecContext(context.Background(), query, aid, &status); err == nil && status > -1 {


### PR DESCRIPTION
# Problem
When acquiring the `sqlserver` lock, it fails immediately if the lock can't be acquired. When running multiple migrations concurrently, only one of them will succeed and the other ones will fail.

# Solution
Wait for up to 10 seconds when acquiring the lock. This way it lets the other entity that has acquired the lock do its job first. This is consistent with what this library does for `postgres` (though it waits indefinitely) and for `mysql`.

Fixes https://github.com/golang-migrate/migrate/issues/253