### PR TITLE
test(mysql): run tests with MySQL 8.0, 8.4, and 9.0

### DIFF
--- a/database/mysql/mysql_test.go
+++ b/database/mysql/mysql_test.go
@@ -43,13 +43,17 @@ var (
 		{ImageName: "mysql:5.5", Options: opts},
 		{ImageName: "mysql:5.6", Options: opts},
 		{ImageName: "mysql:5.7", Options: opts},
-		{ImageName: "mysql:8", Options: opts},
+		{ImageName: "mysql:8.0", Options: opts},
+		{ImageName: "mysql:8.4", Options: opts},
+		{ImageName: "mysql:9.0", Options: opts},
 	}
 	specsAnsiQuotes = []dktesting.ContainerSpec{
 		{ImageName: "mysql:5.5", Options: optsAnsiQuotes},
 		{ImageName: "mysql:5.6", Options: optsAnsiQuotes},
 		{ImageName: "mysql:5.7", Options: optsAnsiQuotes},
-		{ImageName: "mysql:8", Options: optsAnsiQuotes},
+		{ImageName: "mysql:8.0", Options: optsAnsiQuotes},
+		{ImageName: "mysql:8.4", Options: optsAnsiQuotes},
+		{ImageName: "mysql:9.0", Options: optsAnsiQuotes},
 	}
 )
 


### PR DESCRIPTION
Run `mysql` tests with MySQL 8.0, 8.4, and 9.0.