### PR TITLE
test(redshift): use updated PostgreSQL 8 Docker image

### DIFF
--- a/database/redshift/redshift_test.go
+++ b/database/redshift/redshift_test.go
@@ -31,7 +31,7 @@ import (
 var (
 	opts  = dktest.Options{PortRequired: true, ReadyFunc: isReady}
 	specs = []dktesting.ContainerSpec{
-		{ImageName: "postgres:8", Options: opts},
+		{ImageName: "joschi/postgres8:8", Options: opts},
 	}
 )
 


### PR DESCRIPTION
Current versions of the Docker Engine stopped supporting old Docker images using Docker Image Format v1 and Docker Image manifest v2, schema 1.

```
dktest.go:53: Error parsing image pull response: [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/library/postgres:8 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
```

New image: https://hub.docker.com/r/joschi/postgres8