### PR TITLE
chore: add context.Context everywhere

### DIFF
--- a/database/cassandra/cassandra_test.go
+++ b/database/cassandra/cassandra_test.go
@@ -76,18 +76,19 @@ func Test(t *testing.T) {
 
 func test(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.Port(9042)
 		if err != nil {
 			t.Fatal("Unable to get mapped port:", err)
 		}
 		addr := fmt.Sprintf("cassandra://%v:%v/testks", ip, port)
 		p := &Cassandra{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
@@ -97,23 +98,24 @@ func test(t *testing.T) {
 
 func testMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.Port(9042)
 		if err != nil {
 			t.Fatal("Unable to get mapped port:", err)
 		}
 		addr := fmt.Sprintf("cassandra://%v:%v/testks", ip, port)
 		p := &Cassandra{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
-		m, err := migrate.NewWithDatabaseInstance("file://./examples/migrations", "testks", d)
+		m, err := migrate.NewWithDatabaseInstance(ctx, "file://./examples/migrations", "testks", d)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/database/clickhouse/clickhouse_test.go
+++ b/database/clickhouse/clickhouse_test.go
@@ -85,6 +85,7 @@ func TestCases(t *testing.T) {
 
 func testSimple(t *testing.T, engine string) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
@@ -92,12 +93,12 @@ func testSimple(t *testing.T, engine string) {
 
 		addr := clickhouseConnectionString(ip, port, engine)
 		p := &clickhouse.ClickHouse{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
@@ -108,6 +109,7 @@ func testSimple(t *testing.T, engine string) {
 
 func testSimpleWithInstanceDefaultConfigValues(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
@@ -118,13 +120,13 @@ func testSimpleWithInstanceDefaultConfigValues(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		d, err := clickhouse.WithInstance(conn, &clickhouse.Config{})
+		d, err := clickhouse.WithInstance(ctx, conn, &clickhouse.Config{})
 		if err != nil {
 			_ = conn.Close()
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
@@ -135,6 +137,7 @@ func testSimpleWithInstanceDefaultConfigValues(t *testing.T) {
 
 func testMigrate(t *testing.T, engine string) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
@@ -142,16 +145,16 @@ func testMigrate(t *testing.T, engine string) {
 
 		addr := clickhouseConnectionString(ip, port, engine)
 		p := &clickhouse.ClickHouse{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
-		m, err := migrate.NewWithDatabaseInstance("file://./examples/migrations", "db", d)
+		m, err := migrate.NewWithDatabaseInstance(ctx, "file://./examples/migrations", "db", d)
 
 		if err != nil {
 			t.Fatal(err)
@@ -164,6 +167,7 @@ func testVersion(t *testing.T, engine string) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		expectedVersion := 1
 
+		ctx := context.Background()
 		ip, port, err := c.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
@@ -171,22 +175,22 @@ func testVersion(t *testing.T, engine string) {
 
 		addr := clickhouseConnectionString(ip, port, engine)
 		p := &clickhouse.ClickHouse{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
-		err = d.SetVersion(expectedVersion, false)
+		err = d.SetVersion(ctx, expectedVersion, false)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		version, _, err := d.Version()
+		version, _, err := d.Version(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -199,6 +203,7 @@ func testVersion(t *testing.T, engine string) {
 
 func testDrop(t *testing.T, engine string) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
@@ -206,17 +211,17 @@ func testDrop(t *testing.T, engine string) {
 
 		addr := clickhouseConnectionString(ip, port, engine)
 		p := &clickhouse.ClickHouse{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
-		err = d.Drop()
+		err = d.Drop(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/database/cockroachdb/cockroachdb_test.go
+++ b/database/cockroachdb/cockroachdb_test.go
@@ -86,6 +86,7 @@ func Test(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, ci dktest.ContainerInfo) {
 		createDB(t, ci)
 
+		ctx := context.Background()
 		ip, port, err := ci.Port(26257)
 		if err != nil {
 			t.Fatal(err)
@@ -93,7 +94,7 @@ func Test(t *testing.T) {
 
 		addr := fmt.Sprintf("cockroach://root@%v:%v/migrate?sslmode=disable", ip, port)
 		c := &CockroachDb{}
-		d, err := c.Open(addr)
+		d, err := c.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -105,6 +106,7 @@ func TestMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, ci dktest.ContainerInfo) {
 		createDB(t, ci)
 
+		ctx := context.Background()
 		ip, port, err := ci.Port(26257)
 		if err != nil {
 			t.Fatal(err)
@@ -112,12 +114,12 @@ func TestMigrate(t *testing.T) {
 
 		addr := fmt.Sprintf("cockroach://root@%v:%v/migrate?sslmode=disable", ip, port)
 		c := &CockroachDb{}
-		d, err := c.Open(addr)
+		d, err := c.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		m, err := migrate.NewWithDatabaseInstance("file://./examples/migrations", "migrate", d)
+		m, err := migrate.NewWithDatabaseInstance(ctx, "file://./examples/migrations", "migrate", d)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -129,6 +131,7 @@ func TestMultiStatement(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, ci dktest.ContainerInfo) {
 		createDB(t, ci)
 
+		ctx := context.Background()
 		ip, port, err := ci.Port(26257)
 		if err != nil {
 			t.Fatal(err)
@@ -136,11 +139,11 @@ func TestMultiStatement(t *testing.T) {
 
 		addr := fmt.Sprintf("cockroach://root@%v:%v/migrate?sslmode=disable", ip, port)
 		c := &CockroachDb{}
-		d, err := c.Open(addr)
+		d, err := c.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := d.Run(strings.NewReader("CREATE TABLE foo (foo text); CREATE TABLE bar (bar text);")); err != nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE TABLE foo (foo text); CREATE TABLE bar (bar text);")); err != nil {
 			t.Fatalf("expected err to be nil, got %v", err)
 		}
 
@@ -159,6 +162,7 @@ func TestFilterCustomQuery(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, ci dktest.ContainerInfo) {
 		createDB(t, ci)
 
+		ctx := context.Background()
 		ip, port, err := ci.Port(26257)
 		if err != nil {
 			t.Fatal(err)
@@ -166,7 +170,7 @@ func TestFilterCustomQuery(t *testing.T) {
 
 		addr := fmt.Sprintf("cockroach://root@%v:%v/migrate?sslmode=disable&x-custom=foobar", ip, port)
 		c := &CockroachDb{}
-		_, err = c.Open(addr)
+		_, err = c.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/database/driver_test.go
+++ b/database/driver_test.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"io"
 	"testing"
 )
@@ -18,37 +19,37 @@ type mockDriver struct {
 	url string
 }
 
-func (m *mockDriver) Open(url string) (Driver, error) {
+func (m *mockDriver) Open(ctx context.Context, url string) (Driver, error) {
 	return &mockDriver{
 		url: url,
 	}, nil
 }
 
-func (m *mockDriver) Close() error {
+func (m *mockDriver) Close(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockDriver) Lock() error {
+func (m *mockDriver) Lock(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockDriver) Unlock() error {
+func (m *mockDriver) Unlock(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockDriver) Run(migration io.Reader) error {
+func (m *mockDriver) Run(ctx context.Context, migration io.Reader) error {
 	return nil
 }
 
-func (m *mockDriver) SetVersion(version int, dirty bool) error {
+func (m *mockDriver) SetVersion(ctx context.Context, version int, dirty bool) error {
 	return nil
 }
 
-func (m *mockDriver) Version() (version int, dirty bool, err error) {
+func (m *mockDriver) Version(ctx context.Context) (version int, dirty bool, err error) {
 	return 0, false, nil
 }
 
-func (m *mockDriver) Drop() error {
+func (m *mockDriver) Drop(ctx context.Context) error {
 	return nil
 }
 
@@ -95,7 +96,7 @@ func TestOpen(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.url, func(t *testing.T) {
-			d, err := Open(c.url)
+			d, err := Open(context.Background(), c.url)
 
 			if err == nil {
 				if c.err {

--- a/database/firebird/firebird.go
+++ b/database/firebird/firebird.go
@@ -44,7 +44,7 @@ type Firebird struct {
 	config *Config
 }
 
-func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
+func WithInstance(ctx context.Context, instance *sql.DB, config *Config) (database.Driver, error) {
 	if config == nil {
 		return nil, ErrNilConfig
 	}
@@ -68,14 +68,14 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 		config: config,
 	}
 
-	if err := fb.ensureVersionTable(); err != nil {
+	if err := fb.ensureVersionTable(ctx); err != nil {
 		return nil, err
 	}
 
 	return fb, nil
 }
 
-func (f *Firebird) Open(dsn string) (database.Driver, error) {
+func (f *Firebird) Open(ctx context.Context, dsn string) (database.Driver, error) {
 	purl, err := nurl.Parse(dsn)
 	if err != nil {
 		return nil, err
@@ -86,7 +86,7 @@ func (f *Firebird) Open(dsn string) (database.Driver, error) {
 		return nil, err
 	}
 
-	px, err := WithInstance(db, &Config{
+	px, err := WithInstance(ctx, db, &Config{
 		MigrationsTable: purl.Query().Get("x-migrations-table"),
 		DatabaseName:    purl.Path,
 	})
@@ -98,7 +98,7 @@ func (f *Firebird) Open(dsn string) (database.Driver, error) {
 	return px, nil
 }
 
-func (f *Firebird) Close() error {
+func (f *Firebird) Close(ctx context.Context) error {
 	connErr := f.conn.Close()
 	dbErr := f.db.Close()
 	if connErr != nil || dbErr != nil {
@@ -107,21 +107,21 @@ func (f *Firebird) Close() error {
 	return nil
 }
 
-func (f *Firebird) Lock() error {
+func (f *Firebird) Lock(ctx context.Context) error {
 	if !f.isLocked.CAS(false, true) {
 		return database.ErrLocked
 	}
 	return nil
 }
 
-func (f *Firebird) Unlock() error {
+func (f *Firebird) Unlock(ctx context.Context) error {
 	if !f.isLocked.CAS(true, false) {
 		return database.ErrNotLocked
 	}
 	return nil
 }
 
-func (f *Firebird) Run(migration io.Reader) error {
+func (f *Firebird) Run(ctx context.Context, migration io.Reader) error {
 	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
@@ -136,7 +136,7 @@ func (f *Firebird) Run(migration io.Reader) error {
 	return nil
 }
 
-func (f *Firebird) SetVersion(version int, dirty bool) error {
+func (f *Firebird) SetVersion(ctx context.Context, version int, dirty bool) error {
 	// Always re-write the schema version to prevent empty schema version
 	// for failed down migration on the first migration
 	// See: https://github.com/golang-migrate/migrate/issues/330
@@ -157,7 +157,7 @@ func (f *Firebird) SetVersion(version int, dirty bool) error {
 	return nil
 }
 
-func (f *Firebird) Version() (version int, dirty bool, err error) {
+func (f *Firebird) Version(ctx context.Context) (version int, dirty bool, err error) {
 	var d int
 	query := fmt.Sprintf(`SELECT FIRST 1 version, dirty FROM "%v"`, f.config.MigrationsTable)
 	err = f.conn.QueryRowContext(context.Background(), query).Scan(&version, &d)
@@ -172,7 +172,7 @@ func (f *Firebird) Version() (version int, dirty bool, err error) {
 	}
 }
 
-func (f *Firebird) Drop() (err error) {
+func (f *Firebird) Drop(ctx context.Context) (err error) {
 	// select all tables
 	query := `SELECT rdb$relation_name FROM rdb$relations WHERE rdb$view_blr IS NULL AND (rdb$system_flag IS NULL OR rdb$system_flag = 0);`
 	tables, err := f.conn.QueryContext(context.Background(), query)
@@ -217,13 +217,13 @@ func (f *Firebird) Drop() (err error) {
 }
 
 // ensureVersionTable checks if versions table exists and, if not, creates it.
-func (f *Firebird) ensureVersionTable() (err error) {
-	if err = f.Lock(); err != nil {
+func (f *Firebird) ensureVersionTable(ctx context.Context) (err error) {
+	if err = f.Lock(ctx); err != nil {
 		return err
 	}
 
 	defer func() {
-		if e := f.Unlock(); e != nil {
+		if e := f.Unlock(ctx); e != nil {
 			if err == nil {
 				err = e
 			} else {

--- a/database/firebird/firebird_test.go
+++ b/database/firebird/firebird_test.go
@@ -79,6 +79,7 @@ func isReady(ctx context.Context, c dktest.ContainerInfo) bool {
 
 func Test(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -86,12 +87,12 @@ func Test(t *testing.T) {
 
 		addr := fbConnectionString(ip, port)
 		p := &Firebird{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
@@ -101,6 +102,7 @@ func Test(t *testing.T) {
 
 func TestMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -108,16 +110,16 @@ func TestMigrate(t *testing.T) {
 
 		addr := fbConnectionString(ip, port)
 		p := &Firebird{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
-		m, err := migrate.NewWithDatabaseInstance("file://./examples/migrations", "firebirdsql", d)
+		m, err := migrate.NewWithDatabaseInstance(ctx, "file://./examples/migrations", "firebirdsql", d)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -127,6 +129,7 @@ func TestMigrate(t *testing.T) {
 
 func TestErrorParsing(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -134,12 +137,12 @@ func TestErrorParsing(t *testing.T) {
 
 		addr := fbConnectionString(ip, port)
 		p := &Firebird{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
@@ -150,7 +153,7 @@ Token unknown - line 1, column 8
 TABLEE
 )`
 
-		if err := d.Run(strings.NewReader("CREATE TABLEE foo (foo varchar(40));")); err == nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE TABLEE foo (foo varchar(40));")); err == nil {
 			t.Fatal("expected err but got nil")
 		} else if err.Error() != wantErr {
 			msg := err.Error()
@@ -161,6 +164,7 @@ TABLEE
 
 func TestFilterCustomQuery(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -168,12 +172,12 @@ func TestFilterCustomQuery(t *testing.T) {
 
 		addr := fbConnectionString(ip, port) + "?sslmode=disable&x-custom=foobar"
 		p := &Firebird{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
@@ -182,6 +186,7 @@ func TestFilterCustomQuery(t *testing.T) {
 
 func Test_Lock(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -189,12 +194,12 @@ func Test_Lock(t *testing.T) {
 
 		addr := fbConnectionString(ip, port)
 		p := &Firebird{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
@@ -203,22 +208,22 @@ func Test_Lock(t *testing.T) {
 
 		ps := d.(*Firebird)
 
-		err = ps.Lock()
+		err = ps.Lock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = ps.Unlock()
+		err = ps.Unlock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = ps.Lock()
+		err = ps.Lock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = ps.Unlock()
+		err = ps.Unlock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/database/mongodb/mongodb.go
+++ b/database/mongodb/mongodb.go
@@ -75,7 +75,7 @@ type findFilter struct {
 	Key int `bson:"locking_key"`
 }
 
-func WithInstance(instance *mongo.Client, config *Config) (database.Driver, error) {
+func WithInstance(ctx context.Context, instance *mongo.Client, config *Config) (database.Driver, error) {
 	if config == nil {
 		return nil, ErrNilConfig
 	}
@@ -106,14 +106,14 @@ func WithInstance(instance *mongo.Client, config *Config) (database.Driver, erro
 			return nil, err
 		}
 	}
-	if err := mc.ensureVersionTable(); err != nil {
+	if err := mc.ensureVersionTable(ctx); err != nil {
 		return nil, err
 	}
 
 	return mc, nil
 }
 
-func (m *Mongo) Open(dsn string) (database.Driver, error) {
+func (m *Mongo) Open(ctx context.Context, dsn string) (database.Driver, error) {
 	// connstring is experimental package, but it used for parse connection string in mongo.Connect function
 	uri, err := connstring.Parse(dsn)
 	if err != nil {
@@ -165,7 +165,7 @@ func (m *Mongo) Open(dsn string) (database.Driver, error) {
 	if err = client.Ping(context.TODO(), nil); err != nil {
 		return nil, err
 	}
-	mc, err := WithInstance(client, &Config{
+	mc, err := WithInstance(ctx, client, &Config{
 		DatabaseName:         uri.Database,
 		MigrationsCollection: migrationsCollection,
 		TransactionMode:      transactionMode,
@@ -215,7 +215,7 @@ func parseInt(urlParam string, defaultValue int) (int, error) {
 	// if no url Param passed, return default value
 	return defaultValue, nil
 }
-func (m *Mongo) SetVersion(version int, dirty bool) error {
+func (m *Mongo) SetVersion(ctx context.Context, version int, dirty bool) error {
 	migrationsCollection := m.db.Collection(m.config.MigrationsCollection)
 	if err := migrationsCollection.Drop(context.TODO()); err != nil {
 		return &database.Error{OrigErr: err, Err: "drop migrations collection failed"}
@@ -227,7 +227,7 @@ func (m *Mongo) SetVersion(version int, dirty bool) error {
 	return nil
 }
 
-func (m *Mongo) Version() (version int, dirty bool, err error) {
+func (m *Mongo) Version(ctx context.Context) (version int, dirty bool, err error) {
 	var versionInfo versionInfo
 	err = m.db.Collection(m.config.MigrationsCollection).FindOne(context.TODO(), bson.M{}).Decode(&versionInfo)
 	switch {
@@ -240,7 +240,7 @@ func (m *Mongo) Version() (version int, dirty bool, err error) {
 	}
 }
 
-func (m *Mongo) Run(migration io.Reader) error {
+func (m *Mongo) Run(ctx context.Context, migration io.Reader) error {
 	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
@@ -293,11 +293,11 @@ func (m *Mongo) executeCommands(ctx context.Context, cmds []bson.D) error {
 	return nil
 }
 
-func (m *Mongo) Close() error {
+func (m *Mongo) Close(ctx context.Context) error {
 	return m.client.Disconnect(context.TODO())
 }
 
-func (m *Mongo) Drop() error {
+func (m *Mongo) Drop(ctx context.Context) error {
 	return m.db.Drop(context.TODO())
 }
 
@@ -318,13 +318,13 @@ func (m *Mongo) ensureLockTable() error {
 // ensureVersionTable checks if versions table exists and, if not, creates it.
 // Note that this function locks the database, which deviates from the usual
 // convention of "caller locks" in the MongoDb type.
-func (m *Mongo) ensureVersionTable() (err error) {
-	if err = m.Lock(); err != nil {
+func (m *Mongo) ensureVersionTable(ctx context.Context) (err error) {
+	if err = m.Lock(ctx); err != nil {
 		return err
 	}
 
 	defer func() {
-		if e := m.Unlock(); e != nil {
+		if e := m.Unlock(ctx); e != nil {
 			if err == nil {
 				err = e
 			} else {
@@ -336,7 +336,7 @@ func (m *Mongo) ensureVersionTable() (err error) {
 	if err != nil {
 		return err
 	}
-	if _, _, err = m.Version(); err != nil {
+	if _, _, err = m.Version(ctx); err != nil {
 		return err
 	}
 	return nil
@@ -344,7 +344,7 @@ func (m *Mongo) ensureVersionTable() (err error) {
 
 // Utilizes advisory locking on the config.LockingCollection collection
 // This uses a unique index on the `locking_key` field.
-func (m *Mongo) Lock() error {
+func (m *Mongo) Lock(ctx context.Context) error {
 	return database.CasRestoreOnErr(&m.isLocked, false, true, database.ErrLocked, func() error {
 		if !m.config.Locking.Enabled {
 			return nil
@@ -382,7 +382,7 @@ func (m *Mongo) Lock() error {
 	})
 }
 
-func (m *Mongo) Unlock() error {
+func (m *Mongo) Unlock(ctx context.Context) error {
 	return database.CasRestoreOnErr(&m.isLocked, true, false, database.ErrNotLocked, func() error {
 		if !m.config.Locking.Enabled {
 			return nil

--- a/database/mysql/mysql_test.go
+++ b/database/mysql/mysql_test.go
@@ -85,6 +85,7 @@ func Test(t *testing.T) {
 	// mysql.SetLogger(mysql.Logger(log.New(io.Discard, "", log.Ltime)))
 
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
@@ -92,23 +93,23 @@ func Test(t *testing.T) {
 
 		addr := fmt.Sprintf("mysql://root:root@tcp(%v:%v)/public", ip, port)
 		p := &Mysql{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 		dt.Test(t, d, []byte("SELECT 1"))
 
 		// check ensureVersionTable
-		if err := d.(*Mysql).ensureVersionTable(); err != nil {
+		if err := d.(*Mysql).ensureVersionTable(ctx); err != nil {
 			t.Fatal(err)
 		}
 		// check again
-		if err := d.(*Mysql).ensureVersionTable(); err != nil {
+		if err := d.(*Mysql).ensureVersionTable(ctx); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -118,6 +119,7 @@ func TestMigrate(t *testing.T) {
 	// mysql.SetLogger(mysql.Logger(log.New(io.Discard, "", log.Ltime)))
 
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
@@ -125,28 +127,28 @@ func TestMigrate(t *testing.T) {
 
 		addr := fmt.Sprintf("mysql://root:root@tcp(%v:%v)/public", ip, port)
 		p := &Mysql{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
-		m, err := migrate.NewWithDatabaseInstance("file://./examples/migrations", "public", d)
+		m, err := migrate.NewWithDatabaseInstance(ctx, "file://./examples/migrations", "public", d)
 		if err != nil {
 			t.Fatal(err)
 		}
 		dt.TestMigrate(t, m)
 
 		// check ensureVersionTable
-		if err := d.(*Mysql).ensureVersionTable(); err != nil {
+		if err := d.(*Mysql).ensureVersionTable(ctx); err != nil {
 			t.Fatal(err)
 		}
 		// check again
-		if err := d.(*Mysql).ensureVersionTable(); err != nil {
+		if err := d.(*Mysql).ensureVersionTable(ctx); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -156,6 +158,7 @@ func TestMigrateAnsiQuotes(t *testing.T) {
 	// mysql.SetLogger(mysql.Logger(log.New(io.Discard, "", log.Ltime)))
 
 	dktesting.ParallelTest(t, specsAnsiQuotes, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
@@ -163,28 +166,28 @@ func TestMigrateAnsiQuotes(t *testing.T) {
 
 		addr := fmt.Sprintf("mysql://root:root@tcp(%v:%v)/public", ip, port)
 		p := &Mysql{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
-		m, err := migrate.NewWithDatabaseInstance("file://./examples/migrations", "public", d)
+		m, err := migrate.NewWithDatabaseInstance(ctx, "file://./examples/migrations", "public", d)
 		if err != nil {
 			t.Fatal(err)
 		}
 		dt.TestMigrate(t, m)
 
 		// check ensureVersionTable
-		if err := d.(*Mysql).ensureVersionTable(); err != nil {
+		if err := d.(*Mysql).ensureVersionTable(ctx); err != nil {
 			t.Fatal(err)
 		}
 		// check again
-		if err := d.(*Mysql).ensureVersionTable(); err != nil {
+		if err := d.(*Mysql).ensureVersionTable(ctx); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -192,6 +195,7 @@ func TestMigrateAnsiQuotes(t *testing.T) {
 
 func TestLockWorks(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
@@ -199,7 +203,7 @@ func TestLockWorks(t *testing.T) {
 
 		addr := fmt.Sprintf("mysql://root:root@tcp(%v:%v)/public", ip, port)
 		p := &Mysql{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -207,21 +211,21 @@ func TestLockWorks(t *testing.T) {
 
 		ms := d.(*Mysql)
 
-		err = ms.Lock()
+		err = ms.Lock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = ms.Unlock()
+		err = ms.Unlock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		// make sure the 2nd lock works (RELEASE_LOCK is very finicky)
-		err = ms.Lock()
+		err = ms.Lock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = ms.Unlock()
+		err = ms.Unlock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -229,11 +233,12 @@ func TestLockWorks(t *testing.T) {
 }
 
 func TestNoLockParamValidation(t *testing.T) {
+	ctx := context.Background()
 	ip := "127.0.0.1"
 	port := 3306
 	addr := fmt.Sprintf("mysql://root:root@tcp(%v:%v)/public", ip, port)
 	p := &Mysql{}
-	_, err := p.Open(addr + "?x-no-lock=not-a-bool")
+	_, err := p.Open(ctx, addr+"?x-no-lock=not-a-bool")
 	if !errors.Is(err, strconv.ErrSyntax) {
 		t.Fatal("Expected syntax error when passing a non-bool as x-no-lock parameter")
 	}
@@ -241,6 +246,7 @@ func TestNoLockParamValidation(t *testing.T) {
 
 func TestNoLockWorks(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
@@ -248,7 +254,7 @@ func TestNoLockWorks(t *testing.T) {
 
 		addr := fmt.Sprintf("mysql://root:root@tcp(%v:%v)/public", ip, port)
 		p := &Mysql{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -256,7 +262,7 @@ func TestNoLockWorks(t *testing.T) {
 		lock := d.(*Mysql)
 
 		p = &Mysql{}
-		d, err = p.Open(addr + "?x-no-lock=true")
+		d, err = p.Open(ctx, addr+"?x-no-lock=true")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -264,16 +270,16 @@ func TestNoLockWorks(t *testing.T) {
 		noLock := d.(*Mysql)
 
 		// Should be possible to take real lock and no-lock at the same time
-		if err = lock.Lock(); err != nil {
+		if err = lock.Lock(ctx); err != nil {
 			t.Fatal(err)
 		}
-		if err = noLock.Lock(); err != nil {
+		if err = noLock.Lock(ctx); err != nil {
 			t.Fatal(err)
 		}
-		if err = lock.Unlock(); err != nil {
+		if err = lock.Unlock(ctx); err != nil {
 			t.Fatal(err)
 		}
-		if err = noLock.Unlock(); err != nil {
+		if err = noLock.Unlock(ctx); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/database/neo4j/neo4j_test.go
+++ b/database/neo4j/neo4j_test.go
@@ -67,18 +67,19 @@ func isReady(ctx context.Context, c dktest.ContainerInfo) bool {
 
 func Test(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.Port(7687)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		n := &Neo4j{}
-		d, err := n.Open(neoConnectionString(ip, port))
+		d, err := n.Open(ctx, neoConnectionString(ip, port))
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
@@ -88,6 +89,7 @@ func Test(t *testing.T) {
 
 func TestMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.Port(7687)
 		if err != nil {
 			t.Fatal(err)
@@ -95,16 +97,16 @@ func TestMigrate(t *testing.T) {
 
 		n := &Neo4j{}
 		neoUrl := neoConnectionString(ip, port) + "/?x-multi-statement=true"
-		d, err := n.Open(neoUrl)
+		d, err := n.Open(ctx, neoUrl)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
-		m, err := migrate.NewWithDatabaseInstance("file://./examples/migrations", "neo4j", d)
+		m, err := migrate.NewWithDatabaseInstance(ctx, "file://./examples/migrations", "neo4j", d)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -114,24 +116,25 @@ func TestMigrate(t *testing.T) {
 
 func TestMalformed(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.Port(7687)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		n := &Neo4j{}
-		d, err := n.Open(neoConnectionString(ip, port))
+		d, err := n.Open(ctx, neoConnectionString(ip, port))
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
 		migration := bytes.NewReader([]byte("CREATE (a {qid: 1) RETURN a"))
-		if err := d.Run(migration); err == nil {
+		if err := d.Run(ctx, migration); err == nil {
 			t.Fatal("expected failure for malformed migration")
 		}
 	})

--- a/database/pgx/pgx_test.go
+++ b/database/pgx/pgx_test.go
@@ -78,9 +78,9 @@ func isReady(ctx context.Context, c dktest.ContainerInfo) bool {
 	return true
 }
 
-func mustRun(t *testing.T, d database.Driver, statements []string) {
+func mustRun(t *testing.T, ctx context.Context, d database.Driver, statements []string) {
 	for _, statement := range statements {
-		if err := d.Run(strings.NewReader(statement)); err != nil {
+		if err := d.Run(ctx, strings.NewReader(statement)); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -88,6 +88,7 @@ func mustRun(t *testing.T, d database.Driver, statements []string) {
 
 func Test(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -95,12 +96,12 @@ func Test(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
@@ -110,6 +111,7 @@ func Test(t *testing.T) {
 
 func TestMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -117,16 +119,16 @@ func TestMigrate(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
-		m, err := migrate.NewWithDatabaseInstance("file://./examples/migrations", "pgx", d)
+		m, err := migrate.NewWithDatabaseInstance(ctx, "file://./examples/migrations", "pgx", d)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -136,6 +138,7 @@ func TestMigrate(t *testing.T) {
 
 func TestMigrateLockTable(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -143,16 +146,16 @@ func TestMigrateLockTable(t *testing.T) {
 
 		addr := pgConnectionString(ip, port, "x-lock-strategy=table", "x-lock-table=lock_table")
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
-		m, err := migrate.NewWithDatabaseInstance("file://./examples/migrations", "pgx", d)
+		m, err := migrate.NewWithDatabaseInstance(ctx, "file://./examples/migrations", "pgx", d)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -162,6 +165,7 @@ func TestMigrateLockTable(t *testing.T) {
 
 func TestMultipleStatements(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -169,16 +173,16 @@ func TestMultipleStatements(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
-		if err := d.Run(strings.NewReader("CREATE TABLE foo (foo text); CREATE TABLE bar (bar text);")); err != nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE TABLE foo (foo text); CREATE TABLE bar (bar text);")); err != nil {
 			t.Fatalf("expected err to be nil, got %v", err)
 		}
 
@@ -195,6 +199,7 @@ func TestMultipleStatements(t *testing.T) {
 
 func TestMultipleStatementsInMultiStatementMode(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -202,16 +207,16 @@ func TestMultipleStatementsInMultiStatementMode(t *testing.T) {
 
 		addr := pgConnectionString(ip, port, "x-multi-statement=true")
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
-		if err := d.Run(strings.NewReader("CREATE TABLE foo (foo text); CREATE INDEX CONCURRENTLY idx_foo ON foo (foo);")); err != nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE TABLE foo (foo text); CREATE INDEX CONCURRENTLY idx_foo ON foo (foo);")); err != nil {
 			t.Fatalf("expected err to be nil, got %v", err)
 		}
 
@@ -228,6 +233,7 @@ func TestMultipleStatementsInMultiStatementMode(t *testing.T) {
 
 func TestErrorParsing(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -235,19 +241,19 @@ func TestErrorParsing(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
 		wantErr := `migration failed: syntax error at or near "TABLEE" (column 37) in line 1: CREATE TABLE foo ` +
 			`(foo text); CREATE TABLEE bar (bar text); (details: ERROR: syntax error at or near "TABLEE" (SQLSTATE 42601))`
-		if err := d.Run(strings.NewReader("CREATE TABLE foo (foo text); CREATE TABLEE bar (bar text);")); err == nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE TABLE foo (foo text); CREATE TABLEE bar (bar text);")); err == nil {
 			t.Fatal("expected err but got nil")
 		} else if err.Error() != wantErr {
 			t.Fatalf("expected '%s' but got '%s'", wantErr, err.Error())
@@ -257,6 +263,7 @@ func TestErrorParsing(t *testing.T) {
 
 func TestFilterCustomQuery(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -264,12 +271,12 @@ func TestFilterCustomQuery(t *testing.T) {
 
 		addr := pgConnectionString(ip, port, "x-custom=foobar")
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
@@ -278,6 +285,7 @@ func TestFilterCustomQuery(t *testing.T) {
 
 func TestWithSchema(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -285,36 +293,36 @@ func TestWithSchema(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Fatal(err)
 			}
 		}()
 
 		// create foobar schema
-		if err := d.Run(strings.NewReader("CREATE SCHEMA foobar AUTHORIZATION postgres")); err != nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE SCHEMA foobar AUTHORIZATION postgres")); err != nil {
 			t.Fatal(err)
 		}
-		if err := d.SetVersion(1, false); err != nil {
+		if err := d.SetVersion(ctx, 1, false); err != nil {
 			t.Fatal(err)
 		}
 
 		// re-connect using that schema
-		d2, err := p.Open(pgConnectionString(ip, port, "search_path=foobar"))
+		d2, err := p.Open(ctx, pgConnectionString(ip, port, "search_path=foobar"))
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d2.Close(); err != nil {
+			if err := d2.Close(ctx); err != nil {
 				t.Fatal(err)
 			}
 		}()
 
-		version, _, err := d2.Version()
+		version, _, err := d2.Version(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -323,10 +331,10 @@ func TestWithSchema(t *testing.T) {
 		}
 
 		// now update version and compare
-		if err := d2.SetVersion(2, false); err != nil {
+		if err := d2.SetVersion(ctx, 2, false); err != nil {
 			t.Fatal(err)
 		}
-		version, _, err = d2.Version()
+		version, _, err = d2.Version(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -335,7 +343,7 @@ func TestWithSchema(t *testing.T) {
 		}
 
 		// meanwhile, the public schema still has the other version
-		version, _, err = d.Version()
+		version, _, err = d.Version(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -347,6 +355,7 @@ func TestWithSchema(t *testing.T) {
 
 func TestMigrationTableOption(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -354,21 +363,21 @@ func TestMigrationTableOption(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, _ := p.Open(addr)
+		d, _ := p.Open(ctx, addr)
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Fatal(err)
 			}
 		}()
 
 		// create migrate schema
-		if err := d.Run(strings.NewReader("CREATE SCHEMA migrate AUTHORIZATION postgres")); err != nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE SCHEMA migrate AUTHORIZATION postgres")); err != nil {
 			t.Fatal(err)
 		}
 
 		// bad unquoted x-migrations-table parameter
 		wantErr := "x-migrations-table must be quoted (for instance '\"migrate\".\"schema_migrations\"') when x-migrations-table-quoted is enabled, current value is: migrate.schema_migrations"
-		d, err = p.Open(fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=migrate.schema_migrations&x-migrations-table-quoted=1",
+		d, err = p.Open(ctx, fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=migrate.schema_migrations&x-migrations-table-quoted=1",
 			pgPassword, ip, port))
 		if (err != nil) && (err.Error() != wantErr) {
 			t.Fatalf("expected '%s' but got '%s'", wantErr, err.Error())
@@ -376,14 +385,14 @@ func TestMigrationTableOption(t *testing.T) {
 
 		// too many quoted x-migrations-table parameters
 		wantErr = "\"\"migrate\".\"schema_migrations\".\"toomany\"\" MigrationsTable contains too many dot characters"
-		d, err = p.Open(fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=\"migrate\".\"schema_migrations\".\"toomany\"&x-migrations-table-quoted=1",
+		d, err = p.Open(ctx, fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=\"migrate\".\"schema_migrations\".\"toomany\"&x-migrations-table-quoted=1",
 			pgPassword, ip, port))
 		if (err != nil) && (err.Error() != wantErr) {
 			t.Fatalf("expected '%s' but got '%s'", wantErr, err.Error())
 		}
 
 		// good quoted x-migrations-table parameter
-		d, err = p.Open(fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=\"migrate\".\"schema_migrations\"&x-migrations-table-quoted=1",
+		d, err = p.Open(ctx, fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=\"migrate\".\"schema_migrations\"&x-migrations-table-quoted=1",
 			pgPassword, ip, port))
 		if err != nil {
 			t.Fatal(err)
@@ -398,7 +407,7 @@ func TestMigrationTableOption(t *testing.T) {
 			t.Fatalf("expected table migrate.schema_migrations to exist")
 		}
 
-		d, err = p.Open(fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=migrate.schema_migrations",
+		d, err = p.Open(ctx, fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=migrate.schema_migrations",
 			pgPassword, ip, port))
 		if err != nil {
 			t.Fatal(err)
@@ -415,6 +424,7 @@ func TestMigrationTableOption(t *testing.T) {
 
 func TestFailToCreateTableWithoutPermissions(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -425,21 +435,21 @@ func TestFailToCreateTableWithoutPermissions(t *testing.T) {
 		// Check that opening the postgres connection returns NilVersion
 		p := &Postgres{}
 
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
 		// create user who is not the owner. Although we're concatenating strings in an sql statement it should be fine
 		// since this is a test environment and we're not expecting to the pgPassword to be malicious
-		mustRun(t, d, []string{
+		mustRun(t, ctx, d, []string{
 			"CREATE USER not_owner WITH ENCRYPTED PASSWORD '" + pgPassword + "'",
 			"CREATE SCHEMA barfoo AUTHORIZATION postgres",
 			"GRANT USAGE ON SCHEMA barfoo TO not_owner",
@@ -448,14 +458,14 @@ func TestFailToCreateTableWithoutPermissions(t *testing.T) {
 		})
 
 		// re-connect using that schema
-		d2, err := p.Open(fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&search_path=barfoo",
+		d2, err := p.Open(ctx, fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&search_path=barfoo",
 			pgPassword, ip, port))
 
 		defer func() {
 			if d2 == nil {
 				return
 			}
-			if err := d2.Close(); err != nil {
+			if err := d2.Close(ctx); err != nil {
 				t.Fatal(err)
 			}
 		}()
@@ -470,7 +480,7 @@ func TestFailToCreateTableWithoutPermissions(t *testing.T) {
 		}
 
 		// re-connect using that x-migrations-table and x-migrations-table-quoted
-		d2, err = p.Open(fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=\"barfoo\".\"schema_migrations\"&x-migrations-table-quoted=1",
+		d2, err = p.Open(ctx, fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=\"barfoo\".\"schema_migrations\"&x-migrations-table-quoted=1",
 			pgPassword, ip, port))
 
 		if !errors.As(err, &e) || err == nil {
@@ -485,6 +495,7 @@ func TestFailToCreateTableWithoutPermissions(t *testing.T) {
 
 func TestCheckBeforeCreateTable(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -495,21 +506,21 @@ func TestCheckBeforeCreateTable(t *testing.T) {
 		// Check that opening the postgres connection returns NilVersion
 		p := &Postgres{}
 
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
 		// create user who is not the owner. Although we're concatenating strings in an sql statement it should be fine
 		// since this is a test environment and we're not expecting to the pgPassword to be malicious
-		mustRun(t, d, []string{
+		mustRun(t, ctx, d, []string{
 			"CREATE USER not_owner WITH ENCRYPTED PASSWORD '" + pgPassword + "'",
 			"CREATE SCHEMA barfoo AUTHORIZATION postgres",
 			"GRANT USAGE ON SCHEMA barfoo TO not_owner",
@@ -517,32 +528,32 @@ func TestCheckBeforeCreateTable(t *testing.T) {
 		})
 
 		// re-connect using that schema
-		d2, err := p.Open(fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&search_path=barfoo",
+		d2, err := p.Open(ctx, fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&search_path=barfoo",
 			pgPassword, ip, port))
 
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if err := d2.Close(); err != nil {
+		if err := d2.Close(ctx); err != nil {
 			t.Fatal(err)
 		}
 
 		// revoke privileges
-		mustRun(t, d, []string{
+		mustRun(t, ctx, d, []string{
 			"REVOKE CREATE ON SCHEMA barfoo FROM PUBLIC",
 			"REVOKE CREATE ON SCHEMA barfoo FROM not_owner",
 		})
 
 		// re-connect using that schema
-		d3, err := p.Open(fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&search_path=barfoo",
+		d3, err := p.Open(ctx, fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&search_path=barfoo",
 			pgPassword, ip, port))
 
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		version, _, err := d3.Version()
+		version, _, err := d3.Version(ctx)
 
 		if err != nil {
 			t.Fatal(err)
@@ -553,7 +564,7 @@ func TestCheckBeforeCreateTable(t *testing.T) {
 		}
 
 		defer func() {
-			if err := d3.Close(); err != nil {
+			if err := d3.Close(ctx); err != nil {
 				t.Fatal(err)
 			}
 		}()
@@ -562,6 +573,7 @@ func TestCheckBeforeCreateTable(t *testing.T) {
 
 func TestParallelSchema(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -569,58 +581,58 @@ func TestParallelSchema(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
 		// create foo and bar schemas
-		if err := d.Run(strings.NewReader("CREATE SCHEMA foo AUTHORIZATION postgres")); err != nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE SCHEMA foo AUTHORIZATION postgres")); err != nil {
 			t.Fatal(err)
 		}
-		if err := d.Run(strings.NewReader("CREATE SCHEMA bar AUTHORIZATION postgres")); err != nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE SCHEMA bar AUTHORIZATION postgres")); err != nil {
 			t.Fatal(err)
 		}
 
 		// re-connect using that schemas
-		dfoo, err := p.Open(pgConnectionString(ip, port, "search_path=foo"))
+		dfoo, err := p.Open(ctx, pgConnectionString(ip, port, "search_path=foo"))
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := dfoo.Close(); err != nil {
+			if err := dfoo.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
-		dbar, err := p.Open(pgConnectionString(ip, port, "search_path=bar"))
+		dbar, err := p.Open(ctx, pgConnectionString(ip, port, "search_path=bar"))
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := dbar.Close(); err != nil {
+			if err := dbar.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
-		if err := dfoo.Lock(); err != nil {
+		if err := dfoo.Lock(ctx); err != nil {
 			t.Fatal(err)
 		}
 
-		if err := dbar.Lock(); err != nil {
+		if err := dbar.Lock(ctx); err != nil {
 			t.Fatal(err)
 		}
 
-		if err := dbar.Unlock(); err != nil {
+		if err := dbar.Unlock(ctx); err != nil {
 			t.Fatal(err)
 		}
 
-		if err := dfoo.Unlock(); err != nil {
+		if err := dfoo.Unlock(ctx); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -628,6 +640,7 @@ func TestParallelSchema(t *testing.T) {
 
 func TestPostgres_Lock(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -635,7 +648,7 @@ func TestPostgres_Lock(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -644,22 +657,22 @@ func TestPostgres_Lock(t *testing.T) {
 
 		ps := d.(*Postgres)
 
-		err = ps.Lock()
+		err = ps.Lock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = ps.Unlock()
+		err = ps.Unlock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = ps.Lock()
+		err = ps.Lock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = ps.Unlock()
+		err = ps.Unlock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -668,6 +681,7 @@ func TestPostgres_Lock(t *testing.T) {
 
 func TestWithInstance_Concurrent(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -700,7 +714,7 @@ func TestWithInstance_Concurrent(t *testing.T) {
 		for i := 0; i < concurrency; i++ {
 			go func(i int) {
 				defer wg.Done()
-				_, err := WithInstance(db, &Config{})
+				_, err := WithInstance(ctx, db, &Config{})
 				if err != nil {
 					t.Errorf("process %d error: %s", i, err)
 				}

--- a/database/pgx/v5/pgx_test.go
+++ b/database/pgx/v5/pgx_test.go
@@ -79,9 +79,9 @@ func isReady(ctx context.Context, c dktest.ContainerInfo) bool {
 	return true
 }
 
-func mustRun(t *testing.T, d database.Driver, statements []string) {
+func mustRun(t *testing.T, ctx context.Context, d database.Driver, statements []string) {
 	for _, statement := range statements {
-		if err := d.Run(strings.NewReader(statement)); err != nil {
+		if err := d.Run(ctx, strings.NewReader(statement)); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -89,6 +89,7 @@ func mustRun(t *testing.T, d database.Driver, statements []string) {
 
 func Test(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -96,12 +97,12 @@ func Test(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
@@ -111,6 +112,7 @@ func Test(t *testing.T) {
 
 func TestMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -118,16 +120,16 @@ func TestMigrate(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
-		m, err := migrate.NewWithDatabaseInstance("file://../examples/migrations", "pgx", d)
+		m, err := migrate.NewWithDatabaseInstance(ctx, "file://../examples/migrations", "pgx", d)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -137,6 +139,7 @@ func TestMigrate(t *testing.T) {
 
 func TestMultipleStatements(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -144,16 +147,16 @@ func TestMultipleStatements(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
-		if err := d.Run(strings.NewReader("CREATE TABLE foo (foo text); CREATE TABLE bar (bar text);")); err != nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE TABLE foo (foo text); CREATE TABLE bar (bar text);")); err != nil {
 			t.Fatalf("expected err to be nil, got %v", err)
 		}
 
@@ -170,6 +173,7 @@ func TestMultipleStatements(t *testing.T) {
 
 func TestMultipleStatementsInMultiStatementMode(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -177,16 +181,16 @@ func TestMultipleStatementsInMultiStatementMode(t *testing.T) {
 
 		addr := pgConnectionString(ip, port, "x-multi-statement=true")
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
-		if err := d.Run(strings.NewReader("CREATE TABLE foo (foo text); CREATE INDEX CONCURRENTLY idx_foo ON foo (foo);")); err != nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE TABLE foo (foo text); CREATE INDEX CONCURRENTLY idx_foo ON foo (foo);")); err != nil {
 			t.Fatalf("expected err to be nil, got %v", err)
 		}
 
@@ -203,6 +207,7 @@ func TestMultipleStatementsInMultiStatementMode(t *testing.T) {
 
 func TestErrorParsing(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -210,19 +215,19 @@ func TestErrorParsing(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
 		wantErr := `migration failed: syntax error at or near "TABLEE" (column 37) in line 1: CREATE TABLE foo ` +
 			`(foo text); CREATE TABLEE bar (bar text); (details: ERROR: syntax error at or near "TABLEE" (SQLSTATE 42601))`
-		if err := d.Run(strings.NewReader("CREATE TABLE foo (foo text); CREATE TABLEE bar (bar text);")); err == nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE TABLE foo (foo text); CREATE TABLEE bar (bar text);")); err == nil {
 			t.Fatal("expected err but got nil")
 		} else if err.Error() != wantErr {
 			t.Fatalf("expected '%s' but got '%s'", wantErr, err.Error())
@@ -232,6 +237,7 @@ func TestErrorParsing(t *testing.T) {
 
 func TestFilterCustomQuery(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -239,12 +245,12 @@ func TestFilterCustomQuery(t *testing.T) {
 
 		addr := pgConnectionString(ip, port, "x-custom=foobar")
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
@@ -253,6 +259,7 @@ func TestFilterCustomQuery(t *testing.T) {
 
 func TestWithSchema(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -260,36 +267,36 @@ func TestWithSchema(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Fatal(err)
 			}
 		}()
 
 		// create foobar schema
-		if err := d.Run(strings.NewReader("CREATE SCHEMA foobar AUTHORIZATION postgres")); err != nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE SCHEMA foobar AUTHORIZATION postgres")); err != nil {
 			t.Fatal(err)
 		}
-		if err := d.SetVersion(1, false); err != nil {
+		if err := d.SetVersion(ctx, 1, false); err != nil {
 			t.Fatal(err)
 		}
 
 		// re-connect using that schema
-		d2, err := p.Open(pgConnectionString(ip, port, "search_path=foobar"))
+		d2, err := p.Open(ctx, pgConnectionString(ip, port, "search_path=foobar"))
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d2.Close(); err != nil {
+			if err := d2.Close(ctx); err != nil {
 				t.Fatal(err)
 			}
 		}()
 
-		version, _, err := d2.Version()
+		version, _, err := d2.Version(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -298,10 +305,10 @@ func TestWithSchema(t *testing.T) {
 		}
 
 		// now update version and compare
-		if err := d2.SetVersion(2, false); err != nil {
+		if err := d2.SetVersion(ctx, 2, false); err != nil {
 			t.Fatal(err)
 		}
-		version, _, err = d2.Version()
+		version, _, err = d2.Version(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -310,7 +317,7 @@ func TestWithSchema(t *testing.T) {
 		}
 
 		// meanwhile, the public schema still has the other version
-		version, _, err = d.Version()
+		version, _, err = d.Version(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -322,6 +329,7 @@ func TestWithSchema(t *testing.T) {
 
 func TestMigrationTableOption(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -329,21 +337,21 @@ func TestMigrationTableOption(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, _ := p.Open(addr)
+		d, _ := p.Open(ctx, addr)
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Fatal(err)
 			}
 		}()
 
 		// create migrate schema
-		if err := d.Run(strings.NewReader("CREATE SCHEMA migrate AUTHORIZATION postgres")); err != nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE SCHEMA migrate AUTHORIZATION postgres")); err != nil {
 			t.Fatal(err)
 		}
 
 		// bad unquoted x-migrations-table parameter
 		wantErr := "x-migrations-table must be quoted (for instance '\"migrate\".\"schema_migrations\"') when x-migrations-table-quoted is enabled, current value is: migrate.schema_migrations"
-		d, err = p.Open(fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=migrate.schema_migrations&x-migrations-table-quoted=1",
+		d, err = p.Open(ctx, fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=migrate.schema_migrations&x-migrations-table-quoted=1",
 			pgPassword, ip, port))
 		if (err != nil) && (err.Error() != wantErr) {
 			t.Fatalf("expected '%s' but got '%s'", wantErr, err.Error())
@@ -351,14 +359,14 @@ func TestMigrationTableOption(t *testing.T) {
 
 		// too many quoted x-migrations-table parameters
 		wantErr = "\"\"migrate\".\"schema_migrations\".\"toomany\"\" MigrationsTable contains too many dot characters"
-		d, err = p.Open(fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=\"migrate\".\"schema_migrations\".\"toomany\"&x-migrations-table-quoted=1",
+		d, err = p.Open(ctx, fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=\"migrate\".\"schema_migrations\".\"toomany\"&x-migrations-table-quoted=1",
 			pgPassword, ip, port))
 		if (err != nil) && (err.Error() != wantErr) {
 			t.Fatalf("expected '%s' but got '%s'", wantErr, err.Error())
 		}
 
 		// good quoted x-migrations-table parameter
-		d, err = p.Open(fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=\"migrate\".\"schema_migrations\"&x-migrations-table-quoted=1",
+		d, err = p.Open(ctx, fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=\"migrate\".\"schema_migrations\"&x-migrations-table-quoted=1",
 			pgPassword, ip, port))
 		if err != nil {
 			t.Fatal(err)
@@ -373,7 +381,7 @@ func TestMigrationTableOption(t *testing.T) {
 			t.Fatalf("expected table migrate.schema_migrations to exist")
 		}
 
-		d, err = p.Open(fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=migrate.schema_migrations",
+		d, err = p.Open(ctx, fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=migrate.schema_migrations",
 			pgPassword, ip, port))
 		if err != nil {
 			t.Fatal(err)
@@ -390,6 +398,7 @@ func TestMigrationTableOption(t *testing.T) {
 
 func TestFailToCreateTableWithoutPermissions(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -400,21 +409,21 @@ func TestFailToCreateTableWithoutPermissions(t *testing.T) {
 		// Check that opening the postgres connection returns NilVersion
 		p := &Postgres{}
 
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
 		// create user who is not the owner. Although we're concatenating strings in an sql statement it should be fine
 		// since this is a test environment and we're not expecting to the pgPassword to be malicious
-		mustRun(t, d, []string{
+		mustRun(t, ctx, d, []string{
 			"CREATE USER not_owner WITH ENCRYPTED PASSWORD '" + pgPassword + "'",
 			"CREATE SCHEMA barfoo AUTHORIZATION postgres",
 			"GRANT USAGE ON SCHEMA barfoo TO not_owner",
@@ -423,14 +432,14 @@ func TestFailToCreateTableWithoutPermissions(t *testing.T) {
 		})
 
 		// re-connect using that schema
-		d2, err := p.Open(fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&search_path=barfoo",
+		d2, err := p.Open(ctx, fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&search_path=barfoo",
 			pgPassword, ip, port))
 
 		defer func() {
 			if d2 == nil {
 				return
 			}
-			if err := d2.Close(); err != nil {
+			if err := d2.Close(ctx); err != nil {
 				t.Fatal(err)
 			}
 		}()
@@ -445,7 +454,7 @@ func TestFailToCreateTableWithoutPermissions(t *testing.T) {
 		}
 
 		// re-connect using that x-migrations-table and x-migrations-table-quoted
-		d2, err = p.Open(fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=\"barfoo\".\"schema_migrations\"&x-migrations-table-quoted=1",
+		d2, err = p.Open(ctx, fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=\"barfoo\".\"schema_migrations\"&x-migrations-table-quoted=1",
 			pgPassword, ip, port))
 
 		if !errors.As(err, &e) || err == nil {
@@ -460,6 +469,7 @@ func TestFailToCreateTableWithoutPermissions(t *testing.T) {
 
 func TestCheckBeforeCreateTable(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -470,21 +480,21 @@ func TestCheckBeforeCreateTable(t *testing.T) {
 		// Check that opening the postgres connection returns NilVersion
 		p := &Postgres{}
 
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
 		// create user who is not the owner. Although we're concatenating strings in an sql statement it should be fine
 		// since this is a test environment and we're not expecting to the pgPassword to be malicious
-		mustRun(t, d, []string{
+		mustRun(t, ctx, d, []string{
 			"CREATE USER not_owner WITH ENCRYPTED PASSWORD '" + pgPassword + "'",
 			"CREATE SCHEMA barfoo AUTHORIZATION postgres",
 			"GRANT USAGE ON SCHEMA barfoo TO not_owner",
@@ -492,32 +502,32 @@ func TestCheckBeforeCreateTable(t *testing.T) {
 		})
 
 		// re-connect using that schema
-		d2, err := p.Open(fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&search_path=barfoo",
+		d2, err := p.Open(ctx, fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&search_path=barfoo",
 			pgPassword, ip, port))
 
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if err := d2.Close(); err != nil {
+		if err := d2.Close(ctx); err != nil {
 			t.Fatal(err)
 		}
 
 		// revoke privileges
-		mustRun(t, d, []string{
+		mustRun(t, ctx, d, []string{
 			"REVOKE CREATE ON SCHEMA barfoo FROM PUBLIC",
 			"REVOKE CREATE ON SCHEMA barfoo FROM not_owner",
 		})
 
 		// re-connect using that schema
-		d3, err := p.Open(fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&search_path=barfoo",
+		d3, err := p.Open(ctx, fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&search_path=barfoo",
 			pgPassword, ip, port))
 
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		version, _, err := d3.Version()
+		version, _, err := d3.Version(ctx)
 
 		if err != nil {
 			t.Fatal(err)
@@ -528,7 +538,7 @@ func TestCheckBeforeCreateTable(t *testing.T) {
 		}
 
 		defer func() {
-			if err := d3.Close(); err != nil {
+			if err := d3.Close(ctx); err != nil {
 				t.Fatal(err)
 			}
 		}()
@@ -537,6 +547,7 @@ func TestCheckBeforeCreateTable(t *testing.T) {
 
 func TestParallelSchema(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -544,58 +555,58 @@ func TestParallelSchema(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
 		// create foo and bar schemas
-		if err := d.Run(strings.NewReader("CREATE SCHEMA foo AUTHORIZATION postgres")); err != nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE SCHEMA foo AUTHORIZATION postgres")); err != nil {
 			t.Fatal(err)
 		}
-		if err := d.Run(strings.NewReader("CREATE SCHEMA bar AUTHORIZATION postgres")); err != nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE SCHEMA bar AUTHORIZATION postgres")); err != nil {
 			t.Fatal(err)
 		}
 
 		// re-connect using that schemas
-		dfoo, err := p.Open(pgConnectionString(ip, port, "search_path=foo"))
+		dfoo, err := p.Open(ctx, pgConnectionString(ip, port, "search_path=foo"))
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := dfoo.Close(); err != nil {
+			if err := dfoo.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
-		dbar, err := p.Open(pgConnectionString(ip, port, "search_path=bar"))
+		dbar, err := p.Open(ctx, pgConnectionString(ip, port, "search_path=bar"))
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := dbar.Close(); err != nil {
+			if err := dbar.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
-		if err := dfoo.Lock(); err != nil {
+		if err := dfoo.Lock(ctx); err != nil {
 			t.Fatal(err)
 		}
 
-		if err := dbar.Lock(); err != nil {
+		if err := dbar.Lock(ctx); err != nil {
 			t.Fatal(err)
 		}
 
-		if err := dbar.Unlock(); err != nil {
+		if err := dbar.Unlock(ctx); err != nil {
 			t.Fatal(err)
 		}
 
-		if err := dfoo.Unlock(); err != nil {
+		if err := dfoo.Unlock(ctx); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -603,6 +614,7 @@ func TestParallelSchema(t *testing.T) {
 
 func TestPostgres_Lock(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -610,7 +622,7 @@ func TestPostgres_Lock(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -619,22 +631,22 @@ func TestPostgres_Lock(t *testing.T) {
 
 		ps := d.(*Postgres)
 
-		err = ps.Lock()
+		err = ps.Lock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = ps.Unlock()
+		err = ps.Unlock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = ps.Lock()
+		err = ps.Lock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = ps.Unlock()
+		err = ps.Unlock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -643,6 +655,7 @@ func TestPostgres_Lock(t *testing.T) {
 
 func TestWithInstance_Concurrent(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -675,7 +688,7 @@ func TestWithInstance_Concurrent(t *testing.T) {
 		for i := 0; i < concurrency; i++ {
 			go func(i int) {
 				defer wg.Done()
-				_, err := WithInstance(db, &Config{})
+				_, err := WithInstance(ctx, db, &Config{})
 				if err != nil {
 					t.Errorf("process %d error: %s", i, err)
 				}

--- a/database/postgres/postgres_test.go
+++ b/database/postgres/postgres_test.go
@@ -76,9 +76,9 @@ func isReady(ctx context.Context, c dktest.ContainerInfo) bool {
 	return true
 }
 
-func mustRun(t *testing.T, d database.Driver, statements []string) {
+func mustRun(t *testing.T, ctx context.Context, d database.Driver, statements []string) {
 	for _, statement := range statements {
-		if err := d.Run(strings.NewReader(statement)); err != nil {
+		if err := d.Run(ctx, strings.NewReader(statement)); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -112,6 +112,7 @@ func Test(t *testing.T) {
 
 func test(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -119,12 +120,12 @@ func test(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
@@ -134,6 +135,7 @@ func test(t *testing.T) {
 
 func testMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -141,16 +143,16 @@ func testMigrate(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
-		m, err := migrate.NewWithDatabaseInstance("file://./examples/migrations", "postgres", d)
+		m, err := migrate.NewWithDatabaseInstance(ctx, "file://./examples/migrations", "postgres", d)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -160,6 +162,7 @@ func testMigrate(t *testing.T) {
 
 func testMultipleStatements(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -167,16 +170,16 @@ func testMultipleStatements(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
-		if err := d.Run(strings.NewReader("CREATE TABLE foo (foo text); CREATE TABLE bar (bar text);")); err != nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE TABLE foo (foo text); CREATE TABLE bar (bar text);")); err != nil {
 			t.Fatalf("expected err to be nil, got %v", err)
 		}
 
@@ -193,6 +196,7 @@ func testMultipleStatements(t *testing.T) {
 
 func testMultipleStatementsInMultiStatementMode(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -200,16 +204,16 @@ func testMultipleStatementsInMultiStatementMode(t *testing.T) {
 
 		addr := pgConnectionString(ip, port, "x-multi-statement=true")
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
-		if err := d.Run(strings.NewReader("CREATE TABLE foo (foo text); CREATE INDEX CONCURRENTLY idx_foo ON foo (foo);")); err != nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE TABLE foo (foo text); CREATE INDEX CONCURRENTLY idx_foo ON foo (foo);")); err != nil {
 			t.Fatalf("expected err to be nil, got %v", err)
 		}
 
@@ -226,6 +230,7 @@ func testMultipleStatementsInMultiStatementMode(t *testing.T) {
 
 func testErrorParsing(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -233,19 +238,19 @@ func testErrorParsing(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
 		wantErr := `migration failed: syntax error at or near "TABLEE" (column 37) in line 1: CREATE TABLE foo ` +
 			`(foo text); CREATE TABLEE bar (bar text); (details: pq: syntax error at or near "TABLEE")`
-		if err := d.Run(strings.NewReader("CREATE TABLE foo (foo text); CREATE TABLEE bar (bar text);")); err == nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE TABLE foo (foo text); CREATE TABLEE bar (bar text);")); err == nil {
 			t.Fatal("expected err but got nil")
 		} else if err.Error() != wantErr {
 			t.Fatalf("expected '%s' but got '%s'", wantErr, err.Error())
@@ -255,6 +260,7 @@ func testErrorParsing(t *testing.T) {
 
 func testFilterCustomQuery(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -263,12 +269,12 @@ func testFilterCustomQuery(t *testing.T) {
 		addr := fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-custom=foobar",
 			pgPassword, ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
@@ -277,6 +283,7 @@ func testFilterCustomQuery(t *testing.T) {
 
 func testWithSchema(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -284,37 +291,37 @@ func testWithSchema(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Fatal(err)
 			}
 		}()
 
 		// create foobar schema
-		if err := d.Run(strings.NewReader("CREATE SCHEMA foobar AUTHORIZATION postgres")); err != nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE SCHEMA foobar AUTHORIZATION postgres")); err != nil {
 			t.Fatal(err)
 		}
-		if err := d.SetVersion(1, false); err != nil {
+		if err := d.SetVersion(ctx, 1, false); err != nil {
 			t.Fatal(err)
 		}
 
 		// re-connect using that schema
-		d2, err := p.Open(fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&search_path=foobar",
+		d2, err := p.Open(ctx, fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&search_path=foobar",
 			pgPassword, ip, port))
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d2.Close(); err != nil {
+			if err := d2.Close(ctx); err != nil {
 				t.Fatal(err)
 			}
 		}()
 
-		version, _, err := d2.Version()
+		version, _, err := d2.Version(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -323,10 +330,10 @@ func testWithSchema(t *testing.T) {
 		}
 
 		// now update version and compare
-		if err := d2.SetVersion(2, false); err != nil {
+		if err := d2.SetVersion(ctx, 2, false); err != nil {
 			t.Fatal(err)
 		}
-		version, _, err = d2.Version()
+		version, _, err = d2.Version(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -335,7 +342,7 @@ func testWithSchema(t *testing.T) {
 		}
 
 		// meanwhile, the public schema still has the other version
-		version, _, err = d.Version()
+		version, _, err = d.Version(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -347,6 +354,7 @@ func testWithSchema(t *testing.T) {
 
 func testMigrationTableOption(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -354,21 +362,21 @@ func testMigrationTableOption(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, _ := p.Open(addr)
+		d, _ := p.Open(ctx, addr)
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Fatal(err)
 			}
 		}()
 
 		// create migrate schema
-		if err := d.Run(strings.NewReader("CREATE SCHEMA migrate AUTHORIZATION postgres")); err != nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE SCHEMA migrate AUTHORIZATION postgres")); err != nil {
 			t.Fatal(err)
 		}
 
 		// bad unquoted x-migrations-table parameter
 		wantErr := "x-migrations-table must be quoted (for instance '\"migrate\".\"schema_migrations\"') when x-migrations-table-quoted is enabled, current value is: migrate.schema_migrations"
-		d, err = p.Open(fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=migrate.schema_migrations&x-migrations-table-quoted=1",
+		d, err = p.Open(ctx, fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=migrate.schema_migrations&x-migrations-table-quoted=1",
 			pgPassword, ip, port))
 		if (err != nil) && (err.Error() != wantErr) {
 			t.Fatalf("expected '%s' but got '%s'", wantErr, err.Error())
@@ -376,14 +384,14 @@ func testMigrationTableOption(t *testing.T) {
 
 		// too many quoted x-migrations-table parameters
 		wantErr = "\"\"migrate\".\"schema_migrations\".\"toomany\"\" MigrationsTable contains too many dot characters"
-		d, err = p.Open(fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=\"migrate\".\"schema_migrations\".\"toomany\"&x-migrations-table-quoted=1",
+		d, err = p.Open(ctx, fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=\"migrate\".\"schema_migrations\".\"toomany\"&x-migrations-table-quoted=1",
 			pgPassword, ip, port))
 		if (err != nil) && (err.Error() != wantErr) {
 			t.Fatalf("expected '%s' but got '%s'", wantErr, err.Error())
 		}
 
 		// good quoted x-migrations-table parameter
-		d, err = p.Open(fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=\"migrate\".\"schema_migrations\"&x-migrations-table-quoted=1",
+		d, err = p.Open(ctx, fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=\"migrate\".\"schema_migrations\"&x-migrations-table-quoted=1",
 			pgPassword, ip, port))
 		if err != nil {
 			t.Fatal(err)
@@ -398,7 +406,7 @@ func testMigrationTableOption(t *testing.T) {
 			t.Fatalf("expected table migrate.schema_migrations to exist")
 		}
 
-		d, err = p.Open(fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=migrate.schema_migrations",
+		d, err = p.Open(ctx, fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=migrate.schema_migrations",
 			pgPassword, ip, port))
 		if err != nil {
 			t.Fatal(err)
@@ -415,6 +423,7 @@ func testMigrationTableOption(t *testing.T) {
 
 func testFailToCreateTableWithoutPermissions(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -425,21 +434,21 @@ func testFailToCreateTableWithoutPermissions(t *testing.T) {
 		// Check that opening the postgres connection returns NilVersion
 		p := &Postgres{}
 
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
 		// create user who is not the owner. Although we're concatenating strings in an sql statement it should be fine
 		// since this is a test environment and we're not expecting to the pgPassword to be malicious
-		mustRun(t, d, []string{
+		mustRun(t, ctx, d, []string{
 			"CREATE USER not_owner WITH ENCRYPTED PASSWORD '" + pgPassword + "'",
 			"CREATE SCHEMA barfoo AUTHORIZATION postgres",
 			"GRANT USAGE ON SCHEMA barfoo TO not_owner",
@@ -448,14 +457,14 @@ func testFailToCreateTableWithoutPermissions(t *testing.T) {
 		})
 
 		// re-connect using that schema
-		d2, err := p.Open(fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&search_path=barfoo",
+		d2, err := p.Open(ctx, fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&search_path=barfoo",
 			pgPassword, ip, port))
 
 		defer func() {
 			if d2 == nil {
 				return
 			}
-			if err := d2.Close(); err != nil {
+			if err := d2.Close(ctx); err != nil {
 				t.Fatal(err)
 			}
 		}()
@@ -470,7 +479,7 @@ func testFailToCreateTableWithoutPermissions(t *testing.T) {
 		}
 
 		// re-connect using that x-migrations-table and x-migrations-table-quoted
-		d2, err = p.Open(fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=\"barfoo\".\"schema_migrations\"&x-migrations-table-quoted=1",
+		d2, err = p.Open(ctx, fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&x-migrations-table=\"barfoo\".\"schema_migrations\"&x-migrations-table-quoted=1",
 			pgPassword, ip, port))
 
 		if !errors.As(err, &e) || err == nil {
@@ -485,6 +494,7 @@ func testFailToCreateTableWithoutPermissions(t *testing.T) {
 
 func testCheckBeforeCreateTable(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -495,21 +505,21 @@ func testCheckBeforeCreateTable(t *testing.T) {
 		// Check that opening the postgres connection returns NilVersion
 		p := &Postgres{}
 
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
 		// create user who is not the owner. Although we're concatenating strings in an sql statement it should be fine
 		// since this is a test environment and we're not expecting to the pgPassword to be malicious
-		mustRun(t, d, []string{
+		mustRun(t, ctx, d, []string{
 			"CREATE USER not_owner WITH ENCRYPTED PASSWORD '" + pgPassword + "'",
 			"CREATE SCHEMA barfoo AUTHORIZATION postgres",
 			"GRANT USAGE ON SCHEMA barfoo TO not_owner",
@@ -517,32 +527,32 @@ func testCheckBeforeCreateTable(t *testing.T) {
 		})
 
 		// re-connect using that schema
-		d2, err := p.Open(fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&search_path=barfoo",
+		d2, err := p.Open(ctx, fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&search_path=barfoo",
 			pgPassword, ip, port))
 
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if err := d2.Close(); err != nil {
+		if err := d2.Close(ctx); err != nil {
 			t.Fatal(err)
 		}
 
 		// revoke privileges
-		mustRun(t, d, []string{
+		mustRun(t, ctx, d, []string{
 			"REVOKE CREATE ON SCHEMA barfoo FROM PUBLIC",
 			"REVOKE CREATE ON SCHEMA barfoo FROM not_owner",
 		})
 
 		// re-connect using that schema
-		d3, err := p.Open(fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&search_path=barfoo",
+		d3, err := p.Open(ctx, fmt.Sprintf("postgres://not_owner:%s@%v:%v/postgres?sslmode=disable&search_path=barfoo",
 			pgPassword, ip, port))
 
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		version, _, err := d3.Version()
+		version, _, err := d3.Version(ctx)
 
 		if err != nil {
 			t.Fatal(err)
@@ -553,7 +563,7 @@ func testCheckBeforeCreateTable(t *testing.T) {
 		}
 
 		defer func() {
-			if err := d3.Close(); err != nil {
+			if err := d3.Close(ctx); err != nil {
 				t.Fatal(err)
 			}
 		}()
@@ -562,6 +572,7 @@ func testCheckBeforeCreateTable(t *testing.T) {
 
 func testParallelSchema(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -569,60 +580,60 @@ func testParallelSchema(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
 		// create foo and bar schemas
-		if err := d.Run(strings.NewReader("CREATE SCHEMA foo AUTHORIZATION postgres")); err != nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE SCHEMA foo AUTHORIZATION postgres")); err != nil {
 			t.Fatal(err)
 		}
-		if err := d.Run(strings.NewReader("CREATE SCHEMA bar AUTHORIZATION postgres")); err != nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE SCHEMA bar AUTHORIZATION postgres")); err != nil {
 			t.Fatal(err)
 		}
 
 		// re-connect using that schemas
-		dfoo, err := p.Open(fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&search_path=foo",
+		dfoo, err := p.Open(ctx, fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&search_path=foo",
 			pgPassword, ip, port))
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := dfoo.Close(); err != nil {
+			if err := dfoo.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
-		dbar, err := p.Open(fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&search_path=bar",
+		dbar, err := p.Open(ctx, fmt.Sprintf("postgres://postgres:%s@%v:%v/postgres?sslmode=disable&search_path=bar",
 			pgPassword, ip, port))
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := dbar.Close(); err != nil {
+			if err := dbar.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
-		if err := dfoo.Lock(); err != nil {
+		if err := dfoo.Lock(ctx); err != nil {
 			t.Fatal(err)
 		}
 
-		if err := dbar.Lock(); err != nil {
+		if err := dbar.Lock(ctx); err != nil {
 			t.Fatal(err)
 		}
 
-		if err := dbar.Unlock(); err != nil {
+		if err := dbar.Unlock(ctx); err != nil {
 			t.Fatal(err)
 		}
 
-		if err := dfoo.Unlock(); err != nil {
+		if err := dfoo.Unlock(ctx); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -630,6 +641,7 @@ func testParallelSchema(t *testing.T) {
 
 func testPostgresLock(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -637,7 +649,7 @@ func testPostgresLock(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Postgres{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -646,22 +658,22 @@ func testPostgresLock(t *testing.T) {
 
 		ps := d.(*Postgres)
 
-		err = ps.Lock()
+		err = ps.Lock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = ps.Unlock()
+		err = ps.Unlock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = ps.Lock()
+		err = ps.Lock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = ps.Unlock()
+		err = ps.Unlock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -670,6 +682,7 @@ func testPostgresLock(t *testing.T) {
 
 func testWithInstanceConcurrent(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -702,7 +715,7 @@ func testWithInstanceConcurrent(t *testing.T) {
 		for i := 0; i < concurrency; i++ {
 			go func(i int) {
 				defer wg.Done()
-				_, err := WithInstance(db, &Config{})
+				_, err := WithInstance(ctx, db, &Config{})
 				if err != nil {
 					t.Errorf("process %d error: %s", i, err)
 				}
@@ -740,7 +753,7 @@ func testWithConnection(t *testing.T) {
 		}
 
 		defer func() {
-			if err := p.Close(); err != nil {
+			if err := p.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()

--- a/database/ql/ql.go
+++ b/database/ql/ql.go
@@ -1,6 +1,7 @@
 package ql
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io"
@@ -39,7 +40,7 @@ type Ql struct {
 	config *Config
 }
 
-func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
+func WithInstance(ctx context.Context, instance *sql.DB, config *Config) (database.Driver, error) {
 	if config == nil {
 		return nil, ErrNilConfig
 	}
@@ -56,7 +57,7 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 		db:     instance,
 		config: config,
 	}
-	if err := mx.ensureVersionTable(); err != nil {
+	if err := mx.ensureVersionTable(ctx); err != nil {
 		return nil, err
 	}
 	return mx, nil
@@ -65,13 +66,13 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 // ensureVersionTable checks if versions table exists and, if not, creates it.
 // Note that this function locks the database, which deviates from the usual
 // convention of "caller locks" in the Ql type.
-func (m *Ql) ensureVersionTable() (err error) {
-	if err = m.Lock(); err != nil {
+func (m *Ql) ensureVersionTable(ctx context.Context) (err error) {
+	if err = m.Lock(ctx); err != nil {
 		return err
 	}
 
 	defer func() {
-		if e := m.Unlock(); e != nil {
+		if e := m.Unlock(ctx); e != nil {
 			if err == nil {
 				err = e
 			} else {
@@ -99,7 +100,7 @@ func (m *Ql) ensureVersionTable() (err error) {
 	return nil
 }
 
-func (m *Ql) Open(url string) (database.Driver, error) {
+func (m *Ql) Open(ctx context.Context, url string) (database.Driver, error) {
 	purl, err := nurl.Parse(url)
 	if err != nil {
 		return nil, err
@@ -113,7 +114,7 @@ func (m *Ql) Open(url string) (database.Driver, error) {
 	if len(migrationsTable) == 0 {
 		migrationsTable = DefaultMigrationsTable
 	}
-	mx, err := WithInstance(db, &Config{
+	mx, err := WithInstance(ctx, db, &Config{
 		DatabaseName:    purl.Path,
 		MigrationsTable: migrationsTable,
 	})
@@ -122,10 +123,10 @@ func (m *Ql) Open(url string) (database.Driver, error) {
 	}
 	return mx, nil
 }
-func (m *Ql) Close() error {
+func (m *Ql) Close(ctx context.Context) error {
 	return m.db.Close()
 }
-func (m *Ql) Drop() (err error) {
+func (m *Ql) Drop(ctx context.Context) (err error) {
 	query := `SELECT Name FROM __Table`
 	tables, err := m.db.Query(query)
 	if err != nil {
@@ -165,19 +166,19 @@ func (m *Ql) Drop() (err error) {
 
 	return nil
 }
-func (m *Ql) Lock() error {
+func (m *Ql) Lock(ctx context.Context) error {
 	if !m.isLocked.CAS(false, true) {
 		return database.ErrLocked
 	}
 	return nil
 }
-func (m *Ql) Unlock() error {
+func (m *Ql) Unlock(ctx context.Context) error {
 	if !m.isLocked.CAS(true, false) {
 		return database.ErrNotLocked
 	}
 	return nil
 }
-func (m *Ql) Run(migration io.Reader) error {
+func (m *Ql) Run(ctx context.Context, migration io.Reader) error {
 	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
@@ -202,7 +203,7 @@ func (m *Ql) executeQuery(query string) error {
 	}
 	return nil
 }
-func (m *Ql) SetVersion(version int, dirty bool) error {
+func (m *Ql) SetVersion(ctx context.Context, version int, dirty bool) error {
 	tx, err := m.db.Begin()
 	if err != nil {
 		return &database.Error{OrigErr: err, Err: "transaction start failed"}
@@ -234,7 +235,7 @@ func (m *Ql) SetVersion(version int, dirty bool) error {
 	return nil
 }
 
-func (m *Ql) Version() (version int, dirty bool, err error) {
+func (m *Ql) Version(ctx context.Context) (version int, dirty bool, err error) {
 	query := "SELECT version, dirty FROM " + m.config.MigrationsTable + " LIMIT 1"
 	err = m.db.QueryRow(query).Scan(&version, &dirty)
 	if err != nil {

--- a/database/ql/ql_test.go
+++ b/database/ql/ql_test.go
@@ -1,6 +1,7 @@
 package ql
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"path/filepath"
@@ -15,9 +16,10 @@ import (
 func Test(t *testing.T) {
 	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "ql.db"))
+	ctx := context.Background()
 	p := &Ql{}
 	addr := fmt.Sprintf("ql://%s", filepath.Join(dir, "ql.db"))
-	d, err := p.Open(addr)
+	d, err := p.Open(ctx, addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,6 +40,7 @@ func TestMigrate(t *testing.T) {
 	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "ql.db"))
 
+	ctx := context.Background()
 	db, err := sql.Open("ql", filepath.Join(dir, "ql.db"))
 	if err != nil {
 		return
@@ -48,12 +51,12 @@ func TestMigrate(t *testing.T) {
 		}
 	}()
 
-	driver, err := WithInstance(db, &Config{})
+	driver, err := WithInstance(ctx, db, &Config{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	m, err := migrate.NewWithDatabaseInstance(
+	m, err := migrate.NewWithDatabaseInstance(ctx,
 		"file://./examples/migrations",
 		"ql", driver)
 	if err != nil {

--- a/database/redshift/redshift_test.go
+++ b/database/redshift/redshift_test.go
@@ -77,6 +77,7 @@ func isReady(ctx context.Context, c dktest.ContainerInfo) bool {
 
 func Test(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -84,12 +85,12 @@ func Test(t *testing.T) {
 
 		addr := redshiftConnectionString(ip, port)
 		p := &Redshift{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
@@ -99,6 +100,7 @@ func Test(t *testing.T) {
 
 func TestMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -106,16 +108,16 @@ func TestMigrate(t *testing.T) {
 
 		addr := redshiftConnectionString(ip, port)
 		p := &Redshift{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
-		m, err := migrate.NewWithDatabaseInstance("file://./examples/migrations", "postgres", d)
+		m, err := migrate.NewWithDatabaseInstance(ctx, "file://./examples/migrations", "postgres", d)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -125,6 +127,7 @@ func TestMigrate(t *testing.T) {
 
 func TestMultiStatement(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -132,16 +135,16 @@ func TestMultiStatement(t *testing.T) {
 
 		addr := redshiftConnectionString(ip, port)
 		p := &Redshift{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
-		if err := d.Run(bytes.NewReader([]byte("CREATE TABLE foo (foo text); CREATE TABLE bar (bar text);"))); err != nil {
+		if err := d.Run(ctx, bytes.NewReader([]byte("CREATE TABLE foo (foo text); CREATE TABLE bar (bar text);"))); err != nil {
 			t.Fatalf("expected err to be nil, got %v", err)
 		}
 
@@ -158,6 +161,7 @@ func TestMultiStatement(t *testing.T) {
 
 func TestErrorParsing(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -165,19 +169,19 @@ func TestErrorParsing(t *testing.T) {
 
 		addr := redshiftConnectionString(ip, port)
 		p := &Redshift{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
 		wantErr := `migration failed: syntax error at or near "TABLEE" (column 37) in line 1: CREATE TABLE foo ` +
 			`(foo text); CREATE TABLEE bar (bar text); (details: pq: syntax error at or near "TABLEE")`
-		if err := d.Run(bytes.NewReader([]byte("CREATE TABLE foo (foo text); CREATE TABLEE bar (bar text);"))); err == nil {
+		if err := d.Run(ctx, bytes.NewReader([]byte("CREATE TABLE foo (foo text); CREATE TABLEE bar (bar text);"))); err == nil {
 			t.Fatal("expected err but got nil")
 		} else if err.Error() != wantErr {
 			t.Fatalf("expected '%s' but got '%s'", wantErr, err.Error())
@@ -187,6 +191,7 @@ func TestErrorParsing(t *testing.T) {
 
 func TestFilterCustomQuery(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -194,12 +199,12 @@ func TestFilterCustomQuery(t *testing.T) {
 
 		addr := fmt.Sprintf("postgres://postgres@%v:%v/postgres?sslmode=disable&x-custom=foobar", ip, port)
 		p := &Redshift{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
@@ -208,6 +213,7 @@ func TestFilterCustomQuery(t *testing.T) {
 
 func TestWithSchema(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -215,36 +221,36 @@ func TestWithSchema(t *testing.T) {
 
 		addr := redshiftConnectionString(ip, port)
 		p := &Redshift{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d.Close(); err != nil {
+			if err := d.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
 		// create foobar schema
-		if err := d.Run(bytes.NewReader([]byte("CREATE SCHEMA foobar AUTHORIZATION postgres"))); err != nil {
+		if err := d.Run(ctx, bytes.NewReader([]byte("CREATE SCHEMA foobar AUTHORIZATION postgres"))); err != nil {
 			t.Fatal(err)
 		}
-		if err := d.SetVersion(1, false); err != nil {
+		if err := d.SetVersion(ctx, 1, false); err != nil {
 			t.Fatal(err)
 		}
 
 		// re-connect using that schema
-		d2, err := p.Open(fmt.Sprintf("postgres://postgres@%v:%v/postgres?sslmode=disable&search_path=foobar", ip, port))
+		d2, err := p.Open(ctx, fmt.Sprintf("postgres://postgres@%v:%v/postgres?sslmode=disable&search_path=foobar", ip, port))
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := d2.Close(); err != nil {
+			if err := d2.Close(ctx); err != nil {
 				t.Error(err)
 			}
 		}()
 
-		version, _, err := d2.Version()
+		version, _, err := d2.Version(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -253,10 +259,10 @@ func TestWithSchema(t *testing.T) {
 		}
 
 		// now update version and compare
-		if err := d2.SetVersion(2, false); err != nil {
+		if err := d2.SetVersion(ctx, 2, false); err != nil {
 			t.Fatal(err)
 		}
-		version, _, err = d2.Version()
+		version, _, err = d2.Version(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -265,7 +271,7 @@ func TestWithSchema(t *testing.T) {
 		}
 
 		// meanwhile, the public schema still has the other version
-		version, _, err = d.Version()
+		version, _, err = d.Version(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -281,6 +287,7 @@ func TestWithInstance(t *testing.T) {
 
 func TestRedshift_Lock(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ctx := context.Background()
 		ip, port, err := c.FirstPort()
 		if err != nil {
 			t.Fatal(err)
@@ -288,7 +295,7 @@ func TestRedshift_Lock(t *testing.T) {
 
 		addr := pgConnectionString(ip, port)
 		p := &Redshift{}
-		d, err := p.Open(addr)
+		d, err := p.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -297,22 +304,22 @@ func TestRedshift_Lock(t *testing.T) {
 
 		ps := d.(*Redshift)
 
-		err = ps.Lock()
+		err = ps.Lock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = ps.Unlock()
+		err = ps.Unlock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = ps.Lock()
+		err = ps.Lock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = ps.Unlock()
+		err = ps.Unlock(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/database/spanner/spanner_test.go
+++ b/database/spanner/spanner_test.go
@@ -1,6 +1,7 @@
 package spanner
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -35,9 +36,10 @@ const db = "projects/abc/instances/def/databases/testdb"
 
 func Test(t *testing.T) {
 	withSpannerEmulator(t, func(t *testing.T) {
+		ctx := context.Background()
 		uri := fmt.Sprintf("spanner://%s", db)
 		s := &Spanner{}
-		d, err := s.Open(uri)
+		d, err := s.Open(ctx, uri)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -47,13 +49,14 @@ func Test(t *testing.T) {
 
 func TestMigrate(t *testing.T) {
 	withSpannerEmulator(t, func(t *testing.T) {
+		ctx := context.Background()
 		s := &Spanner{}
 		uri := fmt.Sprintf("spanner://%s", db)
-		d, err := s.Open(uri)
+		d, err := s.Open(ctx, uri)
 		if err != nil {
 			t.Fatal(err)
 		}
-		m, err := migrate.NewWithDatabaseInstance("file://./examples/migrations", uri, d)
+		m, err := migrate.NewWithDatabaseInstance(ctx, "file://./examples/migrations", uri, d)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/database/sqlcipher/sqlcipher_test.go
+++ b/database/sqlcipher/sqlcipher_test.go
@@ -1,6 +1,7 @@
 package sqlcipher
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"path/filepath"
@@ -17,9 +18,10 @@ import (
 func Test(t *testing.T) {
 	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
+	ctx := context.Background()
 	p := &Sqlite{}
 	addr := fmt.Sprintf("sqlite3://%s", filepath.Join(dir, "sqlite3.db"))
-	d, err := p.Open(addr)
+	d, err := p.Open(ctx, addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,6 +32,7 @@ func TestMigrate(t *testing.T) {
 	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
 
+	ctx := context.Background()
 	db, err := sql.Open("sqlite3", filepath.Join(dir, "sqlite3.db"))
 	if err != nil {
 		return
@@ -39,12 +42,12 @@ func TestMigrate(t *testing.T) {
 			return
 		}
 	}()
-	driver, err := WithInstance(db, &Config{})
+	driver, err := WithInstance(ctx, db, &Config{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	m, err := migrate.NewWithDatabaseInstance(
+	m, err := migrate.NewWithDatabaseInstance(ctx,
 		"file://./examples/migrations",
 		"ql", driver)
 	if err != nil {
@@ -58,6 +61,7 @@ func TestMigrationTable(t *testing.T) {
 
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
 
+	ctx := context.Background()
 	db, err := sql.Open("sqlite3", filepath.Join(dir, "sqlite3.db"))
 	if err != nil {
 		return
@@ -71,18 +75,18 @@ func TestMigrationTable(t *testing.T) {
 	config := &Config{
 		MigrationsTable: "my_migration_table",
 	}
-	driver, err := WithInstance(db, config)
+	driver, err := WithInstance(ctx, db, config)
 	if err != nil {
 		t.Fatal(err)
 	}
-	m, err := migrate.NewWithDatabaseInstance(
+	m, err := migrate.NewWithDatabaseInstance(ctx,
 		"file://./examples/migrations",
 		"ql", driver)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Log("UP")
-	err = m.Up()
+	err = m.Up(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,9 +100,10 @@ func TestMigrationTable(t *testing.T) {
 func TestNoTxWrap(t *testing.T) {
 	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
+	ctx := context.Background()
 	p := &Sqlite{}
 	addr := fmt.Sprintf("sqlite3://%s?x-no-tx-wrap=true", filepath.Join(dir, "sqlite3.db"))
-	d, err := p.Open(addr)
+	d, err := p.Open(ctx, addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,9 +115,10 @@ func TestNoTxWrap(t *testing.T) {
 func TestNoTxWrapInvalidValue(t *testing.T) {
 	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
+	ctx := context.Background()
 	p := &Sqlite{}
 	addr := fmt.Sprintf("sqlite3://%s?x-no-tx-wrap=yeppers", filepath.Join(dir, "sqlite3.db"))
-	_, err := p.Open(addr)
+	_, err := p.Open(ctx, addr)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "x-no-tx-wrap")
 		assert.Contains(t, err.Error(), "invalid syntax")

--- a/database/sqlite/sqlite.go
+++ b/database/sqlite/sqlite.go
@@ -1,6 +1,7 @@
 package sqlite
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io"
@@ -40,7 +41,7 @@ type Sqlite struct {
 	config *Config
 }
 
-func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
+func WithInstance(ctx context.Context, instance *sql.DB, config *Config) (database.Driver, error) {
 	if config == nil {
 		return nil, ErrNilConfig
 	}
@@ -57,7 +58,7 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 		db:     instance,
 		config: config,
 	}
-	if err := mx.ensureVersionTable(); err != nil {
+	if err := mx.ensureVersionTable(ctx); err != nil {
 		return nil, err
 	}
 	return mx, nil
@@ -66,13 +67,13 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 // ensureVersionTable checks if versions table exists and, if not, creates it.
 // Note that this function locks the database, which deviates from the usual
 // convention of "caller locks" in the Sqlite type.
-func (m *Sqlite) ensureVersionTable() (err error) {
-	if err = m.Lock(); err != nil {
+func (m *Sqlite) ensureVersionTable(ctx context.Context) (err error) {
+	if err = m.Lock(ctx); err != nil {
 		return err
 	}
 
 	defer func() {
-		if e := m.Unlock(); e != nil {
+		if e := m.Unlock(ctx); e != nil {
 			if err == nil {
 				err = e
 			} else {
@@ -92,7 +93,7 @@ func (m *Sqlite) ensureVersionTable() (err error) {
 	return nil
 }
 
-func (m *Sqlite) Open(url string) (database.Driver, error) {
+func (m *Sqlite) Open(ctx context.Context, url string) (database.Driver, error) {
 	purl, err := nurl.Parse(url)
 	if err != nil {
 		return nil, err
@@ -118,7 +119,7 @@ func (m *Sqlite) Open(url string) (database.Driver, error) {
 		}
 	}
 
-	mx, err := WithInstance(db, &Config{
+	mx, err := WithInstance(ctx, db, &Config{
 		DatabaseName:    purl.Path,
 		MigrationsTable: migrationsTable,
 		NoTxWrap:        noTxWrap,
@@ -129,11 +130,11 @@ func (m *Sqlite) Open(url string) (database.Driver, error) {
 	return mx, nil
 }
 
-func (m *Sqlite) Close() error {
+func (m *Sqlite) Close(ctx context.Context) error {
 	return m.db.Close()
 }
 
-func (m *Sqlite) Drop() (err error) {
+func (m *Sqlite) Drop(ctx context.Context) (err error) {
 	query := `SELECT name FROM sqlite_master WHERE type = 'table';`
 	tables, err := m.db.Query(query)
 	if err != nil {
@@ -177,21 +178,21 @@ func (m *Sqlite) Drop() (err error) {
 	return nil
 }
 
-func (m *Sqlite) Lock() error {
+func (m *Sqlite) Lock(ctx context.Context) error {
 	if !m.isLocked.CAS(false, true) {
 		return database.ErrLocked
 	}
 	return nil
 }
 
-func (m *Sqlite) Unlock() error {
+func (m *Sqlite) Unlock(ctx context.Context) error {
 	if !m.isLocked.CAS(true, false) {
 		return database.ErrNotLocked
 	}
 	return nil
 }
 
-func (m *Sqlite) Run(migration io.Reader) error {
+func (m *Sqlite) Run(ctx context.Context, migration io.Reader) error {
 	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
@@ -228,7 +229,7 @@ func (m *Sqlite) executeQueryNoTx(query string) error {
 	return nil
 }
 
-func (m *Sqlite) SetVersion(version int, dirty bool) error {
+func (m *Sqlite) SetVersion(ctx context.Context, version int, dirty bool) error {
 	tx, err := m.db.Begin()
 	if err != nil {
 		return &database.Error{OrigErr: err, Err: "transaction start failed"}
@@ -259,7 +260,7 @@ func (m *Sqlite) SetVersion(version int, dirty bool) error {
 	return nil
 }
 
-func (m *Sqlite) Version() (version int, dirty bool, err error) {
+func (m *Sqlite) Version(ctx context.Context) (version int, dirty bool, err error) {
 	query := "SELECT version, dirty FROM " + m.config.MigrationsTable + " LIMIT 1"
 	err = m.db.QueryRow(query).Scan(&version, &dirty)
 	if err != nil {

--- a/database/sqlite/sqlite_test.go
+++ b/database/sqlite/sqlite_test.go
@@ -1,6 +1,7 @@
 package sqlite
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"path/filepath"
@@ -17,9 +18,10 @@ import (
 func Test(t *testing.T) {
 	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite.db"))
+	ctx := context.Background()
 	p := &Sqlite{}
 	addr := fmt.Sprintf("sqlite://%s", filepath.Join(dir, "sqlite.db"))
-	d, err := p.Open(addr)
+	d, err := p.Open(ctx, addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,6 +32,7 @@ func TestMigrate(t *testing.T) {
 	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite.db"))
 
+	ctx := context.Background()
 	db, err := sql.Open("sqlite", filepath.Join(dir, "sqlite.db"))
 	if err != nil {
 		return
@@ -39,12 +42,12 @@ func TestMigrate(t *testing.T) {
 			return
 		}
 	}()
-	driver, err := WithInstance(db, &Config{})
+	driver, err := WithInstance(ctx, db, &Config{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	m, err := migrate.NewWithDatabaseInstance(
+	m, err := migrate.NewWithDatabaseInstance(ctx,
 		"file://./examples/migrations",
 		"ql", driver)
 	if err != nil {
@@ -58,6 +61,7 @@ func TestMigrationTable(t *testing.T) {
 
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite.db"))
 
+	ctx := context.Background()
 	db, err := sql.Open("sqlite", filepath.Join(dir, "sqlite.db"))
 	if err != nil {
 		return
@@ -71,18 +75,18 @@ func TestMigrationTable(t *testing.T) {
 	config := &Config{
 		MigrationsTable: "my_migration_table",
 	}
-	driver, err := WithInstance(db, config)
+	driver, err := WithInstance(ctx, db, config)
 	if err != nil {
 		t.Fatal(err)
 	}
-	m, err := migrate.NewWithDatabaseInstance(
+	m, err := migrate.NewWithDatabaseInstance(ctx,
 		"file://./examples/migrations",
 		"ql", driver)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Log("UP")
-	err = m.Up()
+	err = m.Up(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,9 +100,10 @@ func TestMigrationTable(t *testing.T) {
 func TestNoTxWrap(t *testing.T) {
 	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite.db"))
+	ctx := context.Background()
 	p := &Sqlite{}
 	addr := fmt.Sprintf("sqlite://%s?x-no-tx-wrap=true", filepath.Join(dir, "sqlite.db"))
-	d, err := p.Open(addr)
+	d, err := p.Open(ctx, addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,9 +115,10 @@ func TestNoTxWrap(t *testing.T) {
 func TestNoTxWrapInvalidValue(t *testing.T) {
 	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite.db"))
+	ctx := context.Background()
 	p := &Sqlite{}
 	addr := fmt.Sprintf("sqlite://%s?x-no-tx-wrap=yeppers", filepath.Join(dir, "sqlite.db"))
-	_, err := p.Open(addr)
+	_, err := p.Open(ctx, addr)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "x-no-tx-wrap")
 		assert.Contains(t, err.Error(), "invalid syntax")
@@ -123,9 +129,10 @@ func TestMigrateWithDirectoryNameContainsWhitespaces(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "sqlite.db")
 	t.Logf("DB path : %s\n", dbPath)
+	ctx := context.Background()
 	p := &Sqlite{}
 	addr := fmt.Sprintf("sqlite://file:%s", dbPath)
-	d, err := p.Open(addr)
+	d, err := p.Open(ctx, addr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/database/sqlite3/sqlite3.go
+++ b/database/sqlite3/sqlite3.go
@@ -1,6 +1,7 @@
 package sqlite3
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io"
@@ -40,7 +41,7 @@ type Sqlite struct {
 	config *Config
 }
 
-func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
+func WithInstance(ctx context.Context, instance *sql.DB, config *Config) (database.Driver, error) {
 	if config == nil {
 		return nil, ErrNilConfig
 	}
@@ -57,7 +58,7 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 		db:     instance,
 		config: config,
 	}
-	if err := mx.ensureVersionTable(); err != nil {
+	if err := mx.ensureVersionTable(ctx); err != nil {
 		return nil, err
 	}
 	return mx, nil
@@ -66,13 +67,13 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 // ensureVersionTable checks if versions table exists and, if not, creates it.
 // Note that this function locks the database, which deviates from the usual
 // convention of "caller locks" in the Sqlite type.
-func (m *Sqlite) ensureVersionTable() (err error) {
-	if err = m.Lock(); err != nil {
+func (m *Sqlite) ensureVersionTable(ctx context.Context) (err error) {
+	if err = m.Lock(ctx); err != nil {
 		return err
 	}
 
 	defer func() {
-		if e := m.Unlock(); e != nil {
+		if e := m.Unlock(ctx); e != nil {
 			if err == nil {
 				err = e
 			} else {
@@ -92,7 +93,7 @@ func (m *Sqlite) ensureVersionTable() (err error) {
 	return nil
 }
 
-func (m *Sqlite) Open(url string) (database.Driver, error) {
+func (m *Sqlite) Open(ctx context.Context, url string) (database.Driver, error) {
 	purl, err := nurl.Parse(url)
 	if err != nil {
 		return nil, err
@@ -118,7 +119,7 @@ func (m *Sqlite) Open(url string) (database.Driver, error) {
 		}
 	}
 
-	mx, err := WithInstance(db, &Config{
+	mx, err := WithInstance(ctx, db, &Config{
 		DatabaseName:    purl.Path,
 		MigrationsTable: migrationsTable,
 		NoTxWrap:        noTxWrap,
@@ -129,11 +130,11 @@ func (m *Sqlite) Open(url string) (database.Driver, error) {
 	return mx, nil
 }
 
-func (m *Sqlite) Close() error {
+func (m *Sqlite) Close(ctx context.Context) error {
 	return m.db.Close()
 }
 
-func (m *Sqlite) Drop() (err error) {
+func (m *Sqlite) Drop(ctx context.Context) (err error) {
 	query := `SELECT name FROM sqlite_master WHERE type = 'table';`
 	tables, err := m.db.Query(query)
 	if err != nil {
@@ -177,21 +178,21 @@ func (m *Sqlite) Drop() (err error) {
 	return nil
 }
 
-func (m *Sqlite) Lock() error {
+func (m *Sqlite) Lock(ctx context.Context) error {
 	if !m.isLocked.CAS(false, true) {
 		return database.ErrLocked
 	}
 	return nil
 }
 
-func (m *Sqlite) Unlock() error {
+func (m *Sqlite) Unlock(ctx context.Context) error {
 	if !m.isLocked.CAS(true, false) {
 		return database.ErrNotLocked
 	}
 	return nil
 }
 
-func (m *Sqlite) Run(migration io.Reader) error {
+func (m *Sqlite) Run(ctx context.Context, migration io.Reader) error {
 	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
@@ -228,7 +229,7 @@ func (m *Sqlite) executeQueryNoTx(query string) error {
 	return nil
 }
 
-func (m *Sqlite) SetVersion(version int, dirty bool) error {
+func (m *Sqlite) SetVersion(ctx context.Context, version int, dirty bool) error {
 	tx, err := m.db.Begin()
 	if err != nil {
 		return &database.Error{OrigErr: err, Err: "transaction start failed"}
@@ -259,7 +260,7 @@ func (m *Sqlite) SetVersion(version int, dirty bool) error {
 	return nil
 }
 
-func (m *Sqlite) Version() (version int, dirty bool, err error) {
+func (m *Sqlite) Version(ctx context.Context) (version int, dirty bool, err error) {
 	query := "SELECT version, dirty FROM " + m.config.MigrationsTable + " LIMIT 1"
 	err = m.db.QueryRow(query).Scan(&version, &dirty)
 	if err != nil {

--- a/database/sqlite3/sqlite3_test.go
+++ b/database/sqlite3/sqlite3_test.go
@@ -1,6 +1,7 @@
 package sqlite3
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"path/filepath"
@@ -17,9 +18,10 @@ import (
 func Test(t *testing.T) {
 	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
+	ctx := context.Background()
 	p := &Sqlite{}
 	addr := fmt.Sprintf("sqlite3://%s", filepath.Join(dir, "sqlite3.db"))
-	d, err := p.Open(addr)
+	d, err := p.Open(ctx, addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,6 +32,7 @@ func TestMigrate(t *testing.T) {
 	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
 
+	ctx := context.Background()
 	db, err := sql.Open("sqlite3", filepath.Join(dir, "sqlite3.db"))
 	if err != nil {
 		return
@@ -39,12 +42,12 @@ func TestMigrate(t *testing.T) {
 			return
 		}
 	}()
-	driver, err := WithInstance(db, &Config{})
+	driver, err := WithInstance(ctx, db, &Config{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	m, err := migrate.NewWithDatabaseInstance(
+	m, err := migrate.NewWithDatabaseInstance(ctx,
 		"file://./examples/migrations",
 		"ql", driver)
 	if err != nil {
@@ -58,6 +61,7 @@ func TestMigrationTable(t *testing.T) {
 
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
 
+	ctx := context.Background()
 	db, err := sql.Open("sqlite3", filepath.Join(dir, "sqlite3.db"))
 	if err != nil {
 		return
@@ -71,18 +75,18 @@ func TestMigrationTable(t *testing.T) {
 	config := &Config{
 		MigrationsTable: "my_migration_table",
 	}
-	driver, err := WithInstance(db, config)
+	driver, err := WithInstance(ctx, db, config)
 	if err != nil {
 		t.Fatal(err)
 	}
-	m, err := migrate.NewWithDatabaseInstance(
+	m, err := migrate.NewWithDatabaseInstance(ctx,
 		"file://./examples/migrations",
 		"ql", driver)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Log("UP")
-	err = m.Up()
+	err = m.Up(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,9 +100,10 @@ func TestMigrationTable(t *testing.T) {
 func TestNoTxWrap(t *testing.T) {
 	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
+	ctx := context.Background()
 	p := &Sqlite{}
 	addr := fmt.Sprintf("sqlite3://%s?x-no-tx-wrap=true", filepath.Join(dir, "sqlite3.db"))
-	d, err := p.Open(addr)
+	d, err := p.Open(ctx, addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,9 +115,10 @@ func TestNoTxWrap(t *testing.T) {
 func TestNoTxWrapInvalidValue(t *testing.T) {
 	dir := t.TempDir()
 	t.Logf("DB path : %s\n", filepath.Join(dir, "sqlite3.db"))
+	ctx := context.Background()
 	p := &Sqlite{}
 	addr := fmt.Sprintf("sqlite3://%s?x-no-tx-wrap=yeppers", filepath.Join(dir, "sqlite3.db"))
-	_, err := p.Open(addr)
+	_, err := p.Open(ctx, addr)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "x-no-tx-wrap")
 		assert.Contains(t, err.Error(), "invalid syntax")
@@ -123,9 +129,10 @@ func TestMigrateWithDirectoryNameContainsWhitespaces(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "sqlite3.db")
 	t.Logf("DB path : %s\n", dbPath)
+	ctx := context.Background()
 	p := &Sqlite{}
 	addr := fmt.Sprintf("sqlite3://file:%s", dbPath)
-	d, err := p.Open(addr)
+	d, err := p.Open(ctx, addr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/database/sqlserver/sqlserver.go
+++ b/database/sqlserver/sqlserver.go
@@ -61,7 +61,7 @@ type SQLServer struct {
 // WithInstance returns a database instance from an already created database connection.
 //
 // Note that the deprecated `mssql` driver is not supported. Please use the newer `sqlserver` driver.
-func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
+func WithInstance(ctx context.Context, instance *sql.DB, config *Config) (database.Driver, error) {
 	if config == nil {
 		return nil, ErrNilConfig
 	}
@@ -114,7 +114,7 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 		config: config,
 	}
 
-	if err := ss.ensureVersionTable(); err != nil {
+	if err := ss.ensureVersionTable(ctx); err != nil {
 		return nil, err
 	}
 
@@ -122,7 +122,7 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 }
 
 // Open a connection to the database.
-func (ss *SQLServer) Open(url string) (database.Driver, error) {
+func (ss *SQLServer) Open(ctx context.Context, url string) (database.Driver, error) {
 	purl, err := nurl.Parse(url)
 	if err != nil {
 		return nil, err
@@ -168,7 +168,7 @@ func (ss *SQLServer) Open(url string) (database.Driver, error) {
 
 	migrationsTable := purl.Query().Get("x-migrations-table")
 
-	px, err := WithInstance(db, &Config{
+	px, err := WithInstance(ctx, db, &Config{
 		DatabaseName:    purl.Path,
 		MigrationsTable: migrationsTable,
 	})
@@ -181,7 +181,7 @@ func (ss *SQLServer) Open(url string) (database.Driver, error) {
 }
 
 // Close the database connection
-func (ss *SQLServer) Close() error {
+func (ss *SQLServer) Close(ctx context.Context) error {
 	connErr := ss.conn.Close()
 	dbErr := ss.db.Close()
 	if connErr != nil || dbErr != nil {
@@ -191,7 +191,7 @@ func (ss *SQLServer) Close() error {
 }
 
 // Lock creates an advisory local on the database to prevent multiple migrations from running at the same time.
-func (ss *SQLServer) Lock() error {
+func (ss *SQLServer) Lock(ctx context.Context) error {
 	return database.CasRestoreOnErr(&ss.isLocked, false, true, database.ErrLocked, func() error {
 		aid, err := database.GenerateAdvisoryLockId(ss.config.DatabaseName, ss.config.SchemaName)
 		if err != nil {
@@ -215,7 +215,7 @@ func (ss *SQLServer) Lock() error {
 }
 
 // Unlock froms the migration lock from the database
-func (ss *SQLServer) Unlock() error {
+func (ss *SQLServer) Unlock(ctx context.Context) error {
 	return database.CasRestoreOnErr(&ss.isLocked, true, false, database.ErrNotLocked, func() error {
 		aid, err := database.GenerateAdvisoryLockId(ss.config.DatabaseName, ss.config.SchemaName)
 		if err != nil {
@@ -233,7 +233,7 @@ func (ss *SQLServer) Unlock() error {
 }
 
 // Run the migrations for the database
-func (ss *SQLServer) Run(migration io.Reader) error {
+func (ss *SQLServer) Run(ctx context.Context, migration io.Reader) error {
 	migr, err := io.ReadAll(migration)
 	if err != nil {
 		return err
@@ -256,7 +256,7 @@ func (ss *SQLServer) Run(migration io.Reader) error {
 }
 
 // SetVersion for the current database
-func (ss *SQLServer) SetVersion(version int, dirty bool) error {
+func (ss *SQLServer) SetVersion(ctx context.Context, version int, dirty bool) error {
 
 	tx, err := ss.conn.BeginTx(context.Background(), &sql.TxOptions{})
 	if err != nil {
@@ -296,7 +296,7 @@ func (ss *SQLServer) SetVersion(version int, dirty bool) error {
 }
 
 // Version of the current database state
-func (ss *SQLServer) Version() (version int, dirty bool, err error) {
+func (ss *SQLServer) Version(ctx context.Context) (version int, dirty bool, err error) {
 	query := `SELECT TOP 1 version, dirty FROM ` + ss.getMigrationTable()
 	err = ss.conn.QueryRowContext(context.Background(), query).Scan(&version, &dirty)
 	switch {
@@ -313,7 +313,7 @@ func (ss *SQLServer) Version() (version int, dirty bool, err error) {
 }
 
 // Drop all tables from the database.
-func (ss *SQLServer) Drop() error {
+func (ss *SQLServer) Drop(ctx context.Context) error {
 
 	// drop all referential integrity constraints
 	query := `
@@ -347,13 +347,13 @@ func (ss *SQLServer) Drop() error {
 	return nil
 }
 
-func (ss *SQLServer) ensureVersionTable() (err error) {
-	if err = ss.Lock(); err != nil {
+func (ss *SQLServer) ensureVersionTable(ctx context.Context) (err error) {
+	if err = ss.Lock(ctx); err != nil {
 		return err
 	}
 
 	defer func() {
-		if e := ss.Unlock(); e != nil {
+		if e := ss.Unlock(ctx); e != nil {
 			if err == nil {
 				err = e
 			} else {

--- a/database/stub/stub_test.go
+++ b/database/stub/stub_test.go
@@ -1,6 +1,7 @@
 package stub
 
 import (
+	"context"
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/source"
 	"github.com/golang-migrate/migrate/v4/source/stub"
@@ -10,8 +11,9 @@ import (
 )
 
 func Test(t *testing.T) {
+	ctx := context.Background()
 	s := &Stub{}
-	d, err := s.Open("")
+	d, err := s.Open(ctx, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -19,8 +21,9 @@ func Test(t *testing.T) {
 }
 
 func TestMigrate(t *testing.T) {
+	ctx := context.Background()
 	s := &Stub{}
-	d, err := s.Open("")
+	d, err := s.Open(ctx, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +32,7 @@ func TestMigrate(t *testing.T) {
 	stubMigrations.Append(&source.Migration{Version: 1, Direction: source.Up, Identifier: "CREATE 1"})
 	stubMigrations.Append(&source.Migration{Version: 1, Direction: source.Down, Identifier: "DROP 1"})
 	src := &stub.Stub{}
-	srcDrv, err := src.Open("")
+	srcDrv, err := src.Open(ctx, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/database/testing/migrate_testing.go
+++ b/database/testing/migrate_testing.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"context"
 	"testing"
 )
 
@@ -21,14 +22,14 @@ func TestMigrate(t *testing.T, m *migrate.Migrate) {
 // Similar to TestDrop(), but tests the dropping mechanism through the Migrate logic instead, to check for
 // double-locking during the Drop logic.
 func TestMigrateDrop(t *testing.T, m *migrate.Migrate) {
-	if err := m.Drop(); err != nil {
+	if err := m.Drop(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestMigrateUp(t *testing.T, m *migrate.Migrate) {
 	t.Log("UP")
-	if err := m.Up(); err != nil {
+	if err := m.Up(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/database/yugabytedb/yugabytedb_test.go
+++ b/database/yugabytedb/yugabytedb_test.go
@@ -110,6 +110,7 @@ func test(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, ci dktest.ContainerInfo) {
 		createDB(t, ci)
 
+		ctx := context.Background()
 		ip, port, err := ci.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
@@ -117,7 +118,7 @@ func test(t *testing.T) {
 
 		addr := getConnectionString(ip, port)
 		c := &YugabyteDB{}
-		d, err := c.Open(addr)
+		d, err := c.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -129,6 +130,7 @@ func testMigrate(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, ci dktest.ContainerInfo) {
 		createDB(t, ci)
 
+		ctx := context.Background()
 		ip, port, err := ci.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
@@ -136,12 +138,12 @@ func testMigrate(t *testing.T) {
 
 		addr := getConnectionString(ip, port)
 		c := &YugabyteDB{}
-		d, err := c.Open(addr)
+		d, err := c.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		m, err := migrate.NewWithDatabaseInstance("file://./examples/migrations", "migrate", d)
+		m, err := migrate.NewWithDatabaseInstance(ctx, "file://./examples/migrations", "migrate", d)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -153,6 +155,7 @@ func testMultiStatement(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, ci dktest.ContainerInfo) {
 		createDB(t, ci)
 
+		ctx := context.Background()
 		ip, port, err := ci.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
@@ -160,11 +163,11 @@ func testMultiStatement(t *testing.T) {
 
 		addr := getConnectionString(ip, port)
 		c := &YugabyteDB{}
-		d, err := c.Open(addr)
+		d, err := c.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := d.Run(strings.NewReader("CREATE TABLE foo (foo text); CREATE TABLE bar (bar text);")); err != nil {
+		if err := d.Run(ctx, strings.NewReader("CREATE TABLE foo (foo text); CREATE TABLE bar (bar text);")); err != nil {
 			t.Fatalf("expected err to be nil, got %v", err)
 		}
 
@@ -183,6 +186,7 @@ func testFilterCustomQuery(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, ci dktest.ContainerInfo) {
 		createDB(t, ci)
 
+		ctx := context.Background()
 		ip, port, err := ci.Port(defaultPort)
 		if err != nil {
 			t.Fatal(err)
@@ -190,7 +194,7 @@ func testFilterCustomQuery(t *testing.T) {
 
 		addr := getConnectionString(ip, port, "x-custom=foobar")
 		c := &YugabyteDB{}
-		d, err := c.Open(addr)
+		d, err := c.Open(ctx, addr)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -147,8 +148,8 @@ func createFile(filename string) error {
 	return f.Close()
 }
 
-func gotoCmd(m *migrate.Migrate, v uint) error {
-	if err := m.Migrate(v); err != nil {
+func gotoCmd(ctx context.Context, m *migrate.Migrate, v uint) error {
+	if err := m.Migrate(ctx, v); err != nil {
 		if err != migrate.ErrNoChange {
 			return err
 		}
@@ -157,16 +158,16 @@ func gotoCmd(m *migrate.Migrate, v uint) error {
 	return nil
 }
 
-func upCmd(m *migrate.Migrate, limit int) error {
+func upCmd(ctx context.Context, m *migrate.Migrate, limit int) error {
 	if limit >= 0 {
-		if err := m.Steps(limit); err != nil {
+		if err := m.Steps(ctx, limit); err != nil {
 			if err != migrate.ErrNoChange {
 				return err
 			}
 			log.Println(err)
 		}
 	} else {
-		if err := m.Up(); err != nil {
+		if err := m.Up(ctx); err != nil {
 			if err != migrate.ErrNoChange {
 				return err
 			}
@@ -176,16 +177,16 @@ func upCmd(m *migrate.Migrate, limit int) error {
 	return nil
 }
 
-func downCmd(m *migrate.Migrate, limit int) error {
+func downCmd(ctx context.Context, m *migrate.Migrate, limit int) error {
 	if limit >= 0 {
-		if err := m.Steps(-limit); err != nil {
+		if err := m.Steps(ctx, -limit); err != nil {
 			if err != migrate.ErrNoChange {
 				return err
 			}
 			log.Println(err)
 		}
 	} else {
-		if err := m.Down(); err != nil {
+		if err := m.Down(ctx); err != nil {
 			if err != migrate.ErrNoChange {
 				return err
 			}
@@ -195,22 +196,22 @@ func downCmd(m *migrate.Migrate, limit int) error {
 	return nil
 }
 
-func dropCmd(m *migrate.Migrate) error {
-	if err := m.Drop(); err != nil {
+func dropCmd(ctx context.Context, m *migrate.Migrate) error {
+	if err := m.Drop(ctx); err != nil {
 		return err
 	}
 	return nil
 }
 
-func forceCmd(m *migrate.Migrate, v int) error {
-	if err := m.Force(v); err != nil {
+func forceCmd(ctx context.Context, m *migrate.Migrate, v int) error {
+	if err := m.Force(ctx, v); err != nil {
 		return err
 	}
 	return nil
 }
 
-func versionCmd(m *migrate.Migrate) error {
-	v, dirty, err := m.Version()
+func versionCmd(ctx context.Context, m *migrate.Migrate) error {
+	v, dirty, err := m.Version(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -122,10 +123,11 @@ Database drivers: `+strings.Join(database.List(), ", ")+"\n", createUsage, gotoU
 	// initialize migrate
 	// don't catch migraterErr here and let each command decide
 	// how it wants to handle the error
-	migrater, migraterErr := migrate.New(*sourcePtr, *databasePtr)
+	ctx := context.Background()
+	migrater, migraterErr := migrate.New(ctx, *sourcePtr, *databasePtr)
 	defer func() {
 		if migraterErr == nil {
-			if _, err := migrater.Close(); err != nil {
+			if _, err := migrater.Close(ctx); err != nil {
 				log.Println(err)
 			}
 		}
@@ -215,7 +217,7 @@ Database drivers: `+strings.Join(database.List(), ", ")+"\n", createUsage, gotoU
 			log.fatal("error: can't read version argument V")
 		}
 
-		if err := gotoCmd(migrater, uint(v)); err != nil {
+		if err := gotoCmd(ctx, migrater, uint(v)); err != nil {
 			log.fatalErr(err)
 		}
 
@@ -245,7 +247,7 @@ Database drivers: `+strings.Join(database.List(), ", ")+"\n", createUsage, gotoU
 			limit = int(n)
 		}
 
-		if err := upCmd(migrater, limit); err != nil {
+		if err := upCmd(ctx, migrater, limit); err != nil {
 			log.fatalErr(err)
 		}
 
@@ -285,7 +287,7 @@ Database drivers: `+strings.Join(database.List(), ", ")+"\n", createUsage, gotoU
 			}
 		}
 
-		if err := downCmd(migrater, num); err != nil {
+		if err := downCmd(ctx, migrater, num); err != nil {
 			log.fatalErr(err)
 		}
 
@@ -320,7 +322,7 @@ Database drivers: `+strings.Join(database.List(), ", ")+"\n", createUsage, gotoU
 			log.fatalErr(migraterErr)
 		}
 
-		if err := dropCmd(migrater); err != nil {
+		if err := dropCmd(ctx, migrater); err != nil {
 			log.fatalErr(err)
 		}
 
@@ -354,7 +356,7 @@ Database drivers: `+strings.Join(database.List(), ", ")+"\n", createUsage, gotoU
 			log.fatal("error: argument V must be >= -1")
 		}
 
-		if err := forceCmd(migrater, int(v)); err != nil {
+		if err := forceCmd(ctx, migrater, int(v)); err != nil {
 			log.fatalErr(err)
 		}
 
@@ -367,7 +369,7 @@ Database drivers: `+strings.Join(database.List(), ", ")+"\n", createUsage, gotoU
 			log.fatalErr(migraterErr)
 		}
 
-		if err := versionCmd(migrater); err != nil {
+		if err := versionCmd(ctx, migrater); err != nil {
 			log.fatalErr(err)
 		}
 

--- a/migrate.go
+++ b/migrate.go
@@ -5,6 +5,7 @@
 package migrate
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -84,7 +85,7 @@ type Migrate struct {
 
 // New returns a new Migrate instance from a source URL and a database URL.
 // The URL scheme is defined by each driver.
-func New(sourceURL, databaseURL string) (*Migrate, error) {
+func New(ctx context.Context, sourceURL, databaseURL string) (*Migrate, error) {
 	m := newCommon()
 
 	sourceName, err := iurl.SchemeFromURL(sourceURL)
@@ -99,13 +100,13 @@ func New(sourceURL, databaseURL string) (*Migrate, error) {
 	}
 	m.databaseName = databaseName
 
-	sourceDrv, err := source.Open(sourceURL)
+	sourceDrv, err := source.Open(ctx, sourceURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open source, %q: %w", sourceURL, err)
 	}
 	m.sourceDrv = sourceDrv
 
-	databaseDrv, err := database.Open(databaseURL)
+	databaseDrv, err := database.Open(ctx, databaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database, %q: %w", databaseURL, err)
 	}
@@ -118,7 +119,7 @@ func New(sourceURL, databaseURL string) (*Migrate, error) {
 // and an existing database instance. The source URL scheme is defined by each driver.
 // Use any string that can serve as an identifier during logging as databaseName.
 // You are responsible for closing the underlying database client if necessary.
-func NewWithDatabaseInstance(sourceURL string, databaseName string, databaseInstance database.Driver) (*Migrate, error) {
+func NewWithDatabaseInstance(ctx context.Context, sourceURL string, databaseName string, databaseInstance database.Driver) (*Migrate, error) {
 	m := newCommon()
 
 	sourceName, err := iurl.SchemeFromURL(sourceURL)
@@ -129,7 +130,7 @@ func NewWithDatabaseInstance(sourceURL string, databaseName string, databaseInst
 
 	m.databaseName = databaseName
 
-	sourceDrv, err := source.Open(sourceURL)
+	sourceDrv, err := source.Open(ctx, sourceURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open source, %q: %w", sourceURL, err)
 	}
@@ -144,7 +145,7 @@ func NewWithDatabaseInstance(sourceURL string, databaseName string, databaseInst
 // and a database URL. The database URL scheme is defined by each driver.
 // Use any string that can serve as an identifier during logging as sourceName.
 // You are responsible for closing the underlying source client if necessary.
-func NewWithSourceInstance(sourceName string, sourceInstance source.Driver, databaseURL string) (*Migrate, error) {
+func NewWithSourceInstance(ctx context.Context, sourceName string, sourceInstance source.Driver, databaseURL string) (*Migrate, error) {
 	m := newCommon()
 
 	databaseName, err := iurl.SchemeFromURL(databaseURL)
@@ -155,7 +156,7 @@ func NewWithSourceInstance(sourceName string, sourceInstance source.Driver, data
 
 	m.sourceName = sourceName
 
-	databaseDrv, err := database.Open(databaseURL)
+	databaseDrv, err := database.Open(ctx, databaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database, %q: %w", databaseURL, err)
 	}
@@ -192,18 +193,18 @@ func newCommon() *Migrate {
 }
 
 // Close closes the source and the database.
-func (m *Migrate) Close() (source error, database error) {
+func (m *Migrate) Close(ctx context.Context) (source error, database error) {
 	databaseSrvClose := make(chan error)
 	sourceSrvClose := make(chan error)
 
 	m.logVerbosePrintf("Closing source and database\n")
 
 	go func() {
-		databaseSrvClose <- m.databaseDrv.Close()
+		databaseSrvClose <- m.databaseDrv.Close(ctx)
 	}()
 
 	go func() {
-		sourceSrvClose <- m.sourceDrv.Close()
+		sourceSrvClose <- m.sourceDrv.Close(ctx)
 	}()
 
 	return <-sourceSrvClose, <-databaseSrvClose
@@ -211,131 +212,131 @@ func (m *Migrate) Close() (source error, database error) {
 
 // Migrate looks at the currently active migration version,
 // then migrates either up or down to the specified version.
-func (m *Migrate) Migrate(version uint) error {
-	if err := m.lock(); err != nil {
+func (m *Migrate) Migrate(ctx context.Context, version uint) error {
+	if err := m.lock(ctx); err != nil {
 		return err
 	}
 
-	curVersion, dirty, err := m.databaseDrv.Version()
+	curVersion, dirty, err := m.databaseDrv.Version(ctx)
 	if err != nil {
-		return m.unlockErr(err)
+		return m.unlockErr(ctx, err)
 	}
 
 	if dirty {
-		return m.unlockErr(ErrDirty{curVersion})
+		return m.unlockErr(ctx, ErrDirty{curVersion})
 	}
 
 	ret := make(chan interface{}, m.PrefetchMigrations)
-	go m.read(curVersion, int(version), ret)
+	go m.read(ctx, curVersion, int(version), ret)
 
-	return m.unlockErr(m.runMigrations(ret))
+	return m.unlockErr(ctx, m.runMigrations(ctx, ret))
 }
 
 // Steps looks at the currently active migration version.
 // It will migrate up if n > 0, and down if n < 0.
-func (m *Migrate) Steps(n int) error {
+func (m *Migrate) Steps(ctx context.Context, n int) error {
 	if n == 0 {
 		return ErrNoChange
 	}
 
-	if err := m.lock(); err != nil {
+	if err := m.lock(ctx); err != nil {
 		return err
 	}
 
-	curVersion, dirty, err := m.databaseDrv.Version()
+	curVersion, dirty, err := m.databaseDrv.Version(ctx)
 	if err != nil {
-		return m.unlockErr(err)
+		return m.unlockErr(ctx, err)
 	}
 
 	if dirty {
-		return m.unlockErr(ErrDirty{curVersion})
+		return m.unlockErr(ctx, ErrDirty{curVersion})
 	}
 
 	ret := make(chan interface{}, m.PrefetchMigrations)
 
 	if n > 0 {
-		go m.readUp(curVersion, n, ret)
+		go m.readUp(ctx, curVersion, n, ret)
 	} else {
-		go m.readDown(curVersion, -n, ret)
+		go m.readDown(ctx, curVersion, -n, ret)
 	}
 
-	return m.unlockErr(m.runMigrations(ret))
+	return m.unlockErr(ctx, m.runMigrations(ctx, ret))
 }
 
 // Up looks at the currently active migration version
 // and will migrate all the way up (applying all up migrations).
-func (m *Migrate) Up() error {
-	if err := m.lock(); err != nil {
+func (m *Migrate) Up(ctx context.Context) error {
+	if err := m.lock(ctx); err != nil {
 		return err
 	}
 
-	curVersion, dirty, err := m.databaseDrv.Version()
+	curVersion, dirty, err := m.databaseDrv.Version(ctx)
 	if err != nil {
-		return m.unlockErr(err)
+		return m.unlockErr(ctx, err)
 	}
 
 	if dirty {
-		return m.unlockErr(ErrDirty{curVersion})
+		return m.unlockErr(ctx, ErrDirty{curVersion})
 	}
 
 	ret := make(chan interface{}, m.PrefetchMigrations)
 
-	go m.readUp(curVersion, -1, ret)
-	return m.unlockErr(m.runMigrations(ret))
+	go m.readUp(ctx, curVersion, -1, ret)
+	return m.unlockErr(ctx, m.runMigrations(ctx, ret))
 }
 
 // Down looks at the currently active migration version
 // and will migrate all the way down (applying all down migrations).
-func (m *Migrate) Down() error {
-	if err := m.lock(); err != nil {
+func (m *Migrate) Down(ctx context.Context) error {
+	if err := m.lock(ctx); err != nil {
 		return err
 	}
 
-	curVersion, dirty, err := m.databaseDrv.Version()
+	curVersion, dirty, err := m.databaseDrv.Version(ctx)
 	if err != nil {
-		return m.unlockErr(err)
+		return m.unlockErr(ctx, err)
 	}
 
 	if dirty {
-		return m.unlockErr(ErrDirty{curVersion})
+		return m.unlockErr(ctx, ErrDirty{curVersion})
 	}
 
 	ret := make(chan interface{}, m.PrefetchMigrations)
-	go m.readDown(curVersion, -1, ret)
-	return m.unlockErr(m.runMigrations(ret))
+	go m.readDown(ctx, curVersion, -1, ret)
+	return m.unlockErr(ctx, m.runMigrations(ctx, ret))
 }
 
 // Drop deletes everything in the database.
-func (m *Migrate) Drop() error {
-	if err := m.lock(); err != nil {
+func (m *Migrate) Drop(ctx context.Context) error {
+	if err := m.lock(ctx); err != nil {
 		return err
 	}
-	if err := m.databaseDrv.Drop(); err != nil {
-		return m.unlockErr(err)
+	if err := m.databaseDrv.Drop(ctx); err != nil {
+		return m.unlockErr(ctx, err)
 	}
-	return m.unlock()
+	return m.unlock(ctx)
 }
 
 // Run runs any migration provided by you against the database.
 // It does not check any currently active version in database.
 // Usually you don't need this function at all. Use Migrate,
 // Steps, Up or Down instead.
-func (m *Migrate) Run(migration ...*Migration) error {
+func (m *Migrate) Run(ctx context.Context, migration ...*Migration) error {
 	if len(migration) == 0 {
 		return ErrNoChange
 	}
 
-	if err := m.lock(); err != nil {
+	if err := m.lock(ctx); err != nil {
 		return err
 	}
 
-	curVersion, dirty, err := m.databaseDrv.Version()
+	curVersion, dirty, err := m.databaseDrv.Version(ctx)
 	if err != nil {
-		return m.unlockErr(err)
+		return m.unlockErr(ctx, err)
 	}
 
 	if dirty {
-		return m.unlockErr(ErrDirty{curVersion})
+		return m.unlockErr(ctx, ErrDirty{curVersion})
 	}
 
 	ret := make(chan interface{}, m.PrefetchMigrations)
@@ -358,32 +359,32 @@ func (m *Migrate) Run(migration ...*Migration) error {
 		}
 	}()
 
-	return m.unlockErr(m.runMigrations(ret))
+	return m.unlockErr(ctx, m.runMigrations(ctx, ret))
 }
 
 // Force sets a migration version.
 // It does not check any currently active version in database.
 // It resets the dirty state to false.
-func (m *Migrate) Force(version int) error {
+func (m *Migrate) Force(ctx context.Context, version int) error {
 	if version < -1 {
 		return ErrInvalidVersion
 	}
 
-	if err := m.lock(); err != nil {
+	if err := m.lock(ctx); err != nil {
 		return err
 	}
 
-	if err := m.databaseDrv.SetVersion(version, false); err != nil {
-		return m.unlockErr(err)
+	if err := m.databaseDrv.SetVersion(ctx, version, false); err != nil {
+		return m.unlockErr(ctx, err)
 	}
 
-	return m.unlock()
+	return m.unlock(ctx)
 }
 
 // Version returns the currently active migration version.
 // If no migration has been applied, yet, it will return ErrNilVersion.
-func (m *Migrate) Version() (version uint, dirty bool, err error) {
-	v, d, err := m.databaseDrv.Version()
+func (m *Migrate) Version(ctx context.Context) (version uint, dirty bool, err error) {
+	v, d, err := m.databaseDrv.Version(ctx)
 	if err != nil {
 		return 0, false, err
 	}
@@ -399,12 +400,12 @@ func (m *Migrate) Version() (version uint, dirty bool, err error) {
 // Each migration is then written to the ret channel.
 // If an error occurs during reading, that error is written to the ret channel, too.
 // Once read is done reading it will close the ret channel.
-func (m *Migrate) read(from int, to int, ret chan<- interface{}) {
+func (m *Migrate) read(ctx context.Context, from int, to int, ret chan<- interface{}) {
 	defer close(ret)
 
 	// check if from version exists
 	if from >= 0 {
-		if err := m.versionExists(suint(from)); err != nil {
+		if err := m.versionExists(ctx, suint(from)); err != nil {
 			ret <- err
 			return
 		}
@@ -412,7 +413,7 @@ func (m *Migrate) read(from int, to int, ret chan<- interface{}) {
 
 	// check if to version exists
 	if to >= 0 {
-		if err := m.versionExists(suint(to)); err != nil {
+		if err := m.versionExists(ctx, suint(to)); err != nil {
 			ret <- err
 			return
 		}
@@ -428,13 +429,13 @@ func (m *Migrate) read(from int, to int, ret chan<- interface{}) {
 		// it's going up
 		// apply first migration if from is nil version
 		if from == -1 {
-			firstVersion, err := m.sourceDrv.First()
+			firstVersion, err := m.sourceDrv.First(ctx)
 			if err != nil {
 				ret <- err
 				return
 			}
 
-			migr, err := m.newMigration(firstVersion, int(firstVersion))
+			migr, err := m.newMigration(ctx, firstVersion, int(firstVersion))
 			if err != nil {
 				ret <- err
 				return
@@ -456,13 +457,13 @@ func (m *Migrate) read(from int, to int, ret chan<- interface{}) {
 				return
 			}
 
-			next, err := m.sourceDrv.Next(suint(from))
+			next, err := m.sourceDrv.Next(ctx, suint(from))
 			if err != nil {
 				ret <- err
 				return
 			}
 
-			migr, err := m.newMigration(next, int(next))
+			migr, err := m.newMigration(ctx, next, int(next))
 			if err != nil {
 				ret <- err
 				return
@@ -486,10 +487,10 @@ func (m *Migrate) read(from int, to int, ret chan<- interface{}) {
 				return
 			}
 
-			prev, err := m.sourceDrv.Prev(suint(from))
+			prev, err := m.sourceDrv.Prev(ctx, suint(from))
 			if errors.Is(err, os.ErrNotExist) && to == -1 {
 				// apply nil migration
-				migr, err := m.newMigration(suint(from), -1)
+				migr, err := m.newMigration(ctx, suint(from), -1)
 				if err != nil {
 					ret <- err
 					return
@@ -508,7 +509,7 @@ func (m *Migrate) read(from int, to int, ret chan<- interface{}) {
 				return
 			}
 
-			migr, err := m.newMigration(suint(from), int(prev))
+			migr, err := m.newMigration(ctx, suint(from), int(prev))
 			if err != nil {
 				ret <- err
 				return
@@ -531,12 +532,12 @@ func (m *Migrate) read(from int, to int, ret chan<- interface{}) {
 // Each migration is then written to the ret channel.
 // If an error occurs during reading, that error is written to the ret channel, too.
 // Once readUp is done reading it will close the ret channel.
-func (m *Migrate) readUp(from int, limit int, ret chan<- interface{}) {
+func (m *Migrate) readUp(ctx context.Context, from int, limit int, ret chan<- interface{}) {
 	defer close(ret)
 
 	// check if from version exists
 	if from >= 0 {
-		if err := m.versionExists(suint(from)); err != nil {
+		if err := m.versionExists(ctx, suint(from)); err != nil {
 			ret <- err
 			return
 		}
@@ -555,13 +556,13 @@ func (m *Migrate) readUp(from int, limit int, ret chan<- interface{}) {
 
 		// apply first migration if from is nil version
 		if from == -1 {
-			firstVersion, err := m.sourceDrv.First()
+			firstVersion, err := m.sourceDrv.First(ctx)
 			if err != nil {
 				ret <- err
 				return
 			}
 
-			migr, err := m.newMigration(firstVersion, int(firstVersion))
+			migr, err := m.newMigration(ctx, firstVersion, int(firstVersion))
 			if err != nil {
 				ret <- err
 				return
@@ -579,7 +580,7 @@ func (m *Migrate) readUp(from int, limit int, ret chan<- interface{}) {
 		}
 
 		// apply next migration
-		next, err := m.sourceDrv.Next(suint(from))
+		next, err := m.sourceDrv.Next(ctx, suint(from))
 		if errors.Is(err, os.ErrNotExist) {
 			// no limit, but no migrations applied?
 			if limit == -1 && count == 0 {
@@ -609,7 +610,7 @@ func (m *Migrate) readUp(from int, limit int, ret chan<- interface{}) {
 			return
 		}
 
-		migr, err := m.newMigration(next, int(next))
+		migr, err := m.newMigration(ctx, next, int(next))
 		if err != nil {
 			ret <- err
 			return
@@ -631,12 +632,12 @@ func (m *Migrate) readUp(from int, limit int, ret chan<- interface{}) {
 // Each migration is then written to the ret channel.
 // If an error occurs during reading, that error is written to the ret channel, too.
 // Once readDown is done reading it will close the ret channel.
-func (m *Migrate) readDown(from int, limit int, ret chan<- interface{}) {
+func (m *Migrate) readDown(ctx context.Context, from int, limit int, ret chan<- interface{}) {
 	defer close(ret)
 
 	// check if from version exists
 	if from >= 0 {
-		if err := m.versionExists(suint(from)); err != nil {
+		if err := m.versionExists(ctx, suint(from)); err != nil {
 			ret <- err
 			return
 		}
@@ -665,17 +666,17 @@ func (m *Migrate) readDown(from int, limit int, ret chan<- interface{}) {
 			return
 		}
 
-		prev, err := m.sourceDrv.Prev(suint(from))
+		prev, err := m.sourceDrv.Prev(ctx, suint(from))
 		if errors.Is(err, os.ErrNotExist) {
 			// no limit or haven't reached limit, apply "first" migration
 			if limit == -1 || limit-count > 0 {
-				firstVersion, err := m.sourceDrv.First()
+				firstVersion, err := m.sourceDrv.First(ctx)
 				if err != nil {
 					ret <- err
 					return
 				}
 
-				migr, err := m.newMigration(firstVersion, -1)
+				migr, err := m.newMigration(ctx, firstVersion, -1)
 				if err != nil {
 					ret <- err
 					return
@@ -699,7 +700,7 @@ func (m *Migrate) readDown(from int, limit int, ret chan<- interface{}) {
 			return
 		}
 
-		migr, err := m.newMigration(suint(from), int(prev))
+		migr, err := m.newMigration(ctx, suint(from), int(prev))
 		if err != nil {
 			ret <- err
 			return
@@ -722,7 +723,7 @@ func (m *Migrate) readDown(from int, limit int, ret chan<- interface{}) {
 // Before running a newly received migration it will check if it's supposed
 // to stop execution because it might have received a stop signal on the
 // GracefulStop channel.
-func (m *Migrate) runMigrations(ret <-chan interface{}) error {
+func (m *Migrate) runMigrations(ctx context.Context, ret <-chan interface{}) error {
 	for r := range ret {
 
 		if m.stop() {
@@ -737,19 +738,19 @@ func (m *Migrate) runMigrations(ret <-chan interface{}) error {
 			migr := r
 
 			// set version with dirty state
-			if err := m.databaseDrv.SetVersion(migr.TargetVersion, true); err != nil {
+			if err := m.databaseDrv.SetVersion(ctx, migr.TargetVersion, true); err != nil {
 				return err
 			}
 
 			if migr.Body != nil {
 				m.logVerbosePrintf("Read and execute %v\n", migr.LogString())
-				if err := m.databaseDrv.Run(migr.BufferedBody); err != nil {
+				if err := m.databaseDrv.Run(ctx, migr.BufferedBody); err != nil {
 					return err
 				}
 			}
 
 			// set clean state
-			if err := m.databaseDrv.SetVersion(migr.TargetVersion, false); err != nil {
+			if err := m.databaseDrv.SetVersion(ctx, migr.TargetVersion, false); err != nil {
 				return err
 			}
 
@@ -775,9 +776,9 @@ func (m *Migrate) runMigrations(ret <-chan interface{}) error {
 
 // versionExists checks the source if either the up or down migration for
 // the specified migration version exists.
-func (m *Migrate) versionExists(version uint) (result error) {
+func (m *Migrate) versionExists(ctx context.Context, version uint) (result error) {
 	// try up migration first
-	up, _, err := m.sourceDrv.ReadUp(version)
+	up, _, err := m.sourceDrv.ReadUp(ctx, version)
 	if err == nil {
 		defer func() {
 			if errClose := up.Close(); errClose != nil {
@@ -792,7 +793,7 @@ func (m *Migrate) versionExists(version uint) (result error) {
 	}
 
 	// then try down migration
-	down, _, err := m.sourceDrv.ReadDown(version)
+	down, _, err := m.sourceDrv.ReadDown(ctx, version)
 	if err == nil {
 		defer func() {
 			if errClose := down.Close(); errClose != nil {
@@ -831,11 +832,11 @@ func (m *Migrate) stop() bool {
 
 // newMigration is a helper func that returns a *Migration for the
 // specified version and targetVersion.
-func (m *Migrate) newMigration(version uint, targetVersion int) (*Migration, error) {
+func (m *Migrate) newMigration(ctx context.Context, version uint, targetVersion int) (*Migration, error) {
 	var migr *Migration
 
 	if targetVersion >= int(version) {
-		r, identifier, err := m.sourceDrv.ReadUp(version)
+		r, identifier, err := m.sourceDrv.ReadUp(ctx, version)
 		if errors.Is(err, os.ErrNotExist) {
 			// create "empty" migration
 			migr, err = NewMigration(nil, "", version, targetVersion)
@@ -855,7 +856,7 @@ func (m *Migrate) newMigration(version uint, targetVersion int) (*Migration, err
 		}
 
 	} else {
-		r, identifier, err := m.sourceDrv.ReadDown(version)
+		r, identifier, err := m.sourceDrv.ReadDown(ctx, version)
 		if errors.Is(err, os.ErrNotExist) {
 			// create "empty" migration
 			migr, err = NewMigration(nil, "", version, targetVersion)
@@ -886,7 +887,7 @@ func (m *Migrate) newMigration(version uint, targetVersion int) (*Migration, err
 
 // lock is a thread safe helper function to lock the database.
 // It should be called as late as possible when running migrations.
-func (m *Migrate) lock() error {
+func (m *Migrate) lock(ctx context.Context) error {
 	m.isLockedMu.Lock()
 	defer m.isLockedMu.Unlock()
 
@@ -919,7 +920,7 @@ func (m *Migrate) lock() error {
 
 	// now try to acquire the lock
 	go func() {
-		if err := m.databaseDrv.Lock(); err != nil {
+		if err := m.databaseDrv.Lock(ctx); err != nil {
 			errchan <- err
 		} else {
 			errchan <- nil
@@ -937,11 +938,11 @@ func (m *Migrate) lock() error {
 // unlock is a thread safe helper function to unlock the database.
 // It should be called as early as possible when no more migrations are
 // expected to be executed.
-func (m *Migrate) unlock() error {
+func (m *Migrate) unlock(ctx context.Context) error {
 	m.isLockedMu.Lock()
 	defer m.isLockedMu.Unlock()
 
-	if err := m.databaseDrv.Unlock(); err != nil {
+	if err := m.databaseDrv.Unlock(ctx); err != nil {
 		// BUG: Can potentially create a deadlock. Add a timeout.
 		return err
 	}
@@ -952,8 +953,8 @@ func (m *Migrate) unlock() error {
 
 // unlockErr calls unlock and returns a combined error
 // if a prevErr is not nil.
-func (m *Migrate) unlockErr(prevErr error) error {
-	if err := m.unlock(); err != nil {
+func (m *Migrate) unlockErr(ctx context.Context, prevErr error) error {
+	if err := m.unlock(ctx); err != nil {
 		return multierror.Append(prevErr, err)
 	}
 	return prevErr

--- a/source/aws_s3/s3.go
+++ b/source/aws_s3/s3.go
@@ -1,6 +1,7 @@
 package awss3
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/url"
@@ -30,7 +31,7 @@ type Config struct {
 	Prefix string
 }
 
-func (s *s3Driver) Open(folder string) (source.Driver, error) {
+func (s *s3Driver) Open(ctx context.Context, folder string) (source.Driver, error) {
 	config, err := parseURI(folder)
 	if err != nil {
 		return nil, err
@@ -41,10 +42,10 @@ func (s *s3Driver) Open(folder string) (source.Driver, error) {
 		return nil, err
 	}
 
-	return WithInstance(s3.New(sess), config)
+	return WithInstance(ctx, s3.New(sess), config)
 }
 
-func WithInstance(s3client s3iface.S3API, config *Config) (source.Driver, error) {
+func WithInstance(ctx context.Context, s3client s3iface.S3API, config *Config) (source.Driver, error) {
 	driver := &s3Driver{
 		config:     config,
 		s3client:   s3client,
@@ -97,42 +98,42 @@ func (s *s3Driver) loadMigrations() error {
 	return nil
 }
 
-func (s *s3Driver) Close() error {
+func (s *s3Driver) Close(ctx context.Context) error {
 	return nil
 }
 
-func (s *s3Driver) First() (uint, error) {
-	v, ok := s.migrations.First()
+func (s *s3Driver) First(ctx context.Context) (uint, error) {
+	v, ok := s.migrations.First(ctx)
 	if !ok {
 		return 0, os.ErrNotExist
 	}
 	return v, nil
 }
 
-func (s *s3Driver) Prev(version uint) (uint, error) {
-	v, ok := s.migrations.Prev(version)
+func (s *s3Driver) Prev(ctx context.Context, version uint) (uint, error) {
+	v, ok := s.migrations.Prev(ctx, version)
 	if !ok {
 		return 0, os.ErrNotExist
 	}
 	return v, nil
 }
 
-func (s *s3Driver) Next(version uint) (uint, error) {
-	v, ok := s.migrations.Next(version)
+func (s *s3Driver) Next(ctx context.Context, version uint) (uint, error) {
+	v, ok := s.migrations.Next(ctx, version)
 	if !ok {
 		return 0, os.ErrNotExist
 	}
 	return v, nil
 }
 
-func (s *s3Driver) ReadUp(version uint) (io.ReadCloser, string, error) {
+func (s *s3Driver) ReadUp(ctx context.Context, version uint) (io.ReadCloser, string, error) {
 	if m, ok := s.migrations.Up(version); ok {
 		return s.open(m)
 	}
 	return nil, "", os.ErrNotExist
 }
 
-func (s *s3Driver) ReadDown(version uint) (io.ReadCloser, string, error) {
+func (s *s3Driver) ReadDown(ctx context.Context, version uint) (io.ReadCloser, string, error) {
 	if m, ok := s.migrations.Down(version); ok {
 		return s.open(m)
 	}

--- a/source/aws_s3/s3_test.go
+++ b/source/aws_s3/s3_test.go
@@ -1,6 +1,7 @@
 package awss3
 
 import (
+	"context"
 	"errors"
 	"io"
 	"strings"
@@ -30,7 +31,7 @@ func Test(t *testing.T) {
 			"prod/migrations/0-random-stuff/whatever.txt": "",
 		},
 	}
-	driver, err := WithInstance(&s3Client, &Config{
+	driver, err := WithInstance(context.Background(), &s3Client, &Config{
 		Bucket: "some-bucket",
 		Prefix: "prod/migrations/",
 	})

--- a/source/bitbucket/bitbucket_test.go
+++ b/source/bitbucket/bitbucket_test.go
@@ -2,6 +2,7 @@ package bitbucket
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"testing"
 
@@ -24,7 +25,7 @@ func Test(t *testing.T) {
 
 	b := &Bitbucket{}
 
-	d, err := b.Open("bitbucket://" + BitbucketTestSecret + "@abhishekbipp/test-migration/migrations/test#master")
+	d, err := b.Open(context.Background(), "bitbucket://"+BitbucketTestSecret+"@abhishekbipp/test-migration/migrations/test#master")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/source/driver.go
+++ b/source/driver.go
@@ -5,6 +5,7 @@
 package source
 
 import (
+	"context"
 	"fmt"
 	"io"
 	nurl "net/url"
@@ -36,44 +37,44 @@ type Driver interface {
 	// Open returns a new driver instance configured with parameters
 	// coming from the URL string. Migrate will call this function
 	// only once per instance.
-	Open(url string) (Driver, error)
+	Open(ctx context.Context, url string) (Driver, error)
 
 	// Close closes the underlying source instance managed by the driver.
 	// Migrate will call this function only once per instance.
-	Close() error
+	Close(ctx context.Context) error
 
 	// First returns the very first migration version available to the driver.
 	// Migrate will call this function multiple times.
 	// If there is no version available, it must return os.ErrNotExist.
-	First() (version uint, err error)
+	First(ctx context.Context) (version uint, err error)
 
 	// Prev returns the previous version for a given version available to the driver.
 	// Migrate will call this function multiple times.
 	// If there is no previous version available, it must return os.ErrNotExist.
-	Prev(version uint) (prevVersion uint, err error)
+	Prev(ctx context.Context, version uint) (prevVersion uint, err error)
 
 	// Next returns the next version for a given version available to the driver.
 	// Migrate will call this function multiple times.
 	// If there is no next version available, it must return os.ErrNotExist.
-	Next(version uint) (nextVersion uint, err error)
+	Next(ctx context.Context, version uint) (nextVersion uint, err error)
 
 	// ReadUp returns the UP migration body and an identifier that helps
 	// finding this migration in the source for a given version.
 	// If there is no up migration available for this version,
 	// it must return os.ErrNotExist.
 	// Do not start reading, just return the ReadCloser!
-	ReadUp(version uint) (r io.ReadCloser, identifier string, err error)
+	ReadUp(ctx context.Context, version uint) (r io.ReadCloser, identifier string, err error)
 
 	// ReadDown returns the DOWN migration body and an identifier that helps
 	// finding this migration in the source for a given version.
 	// If there is no down migration available for this version,
 	// it must return os.ErrNotExist.
 	// Do not start reading, just return the ReadCloser!
-	ReadDown(version uint) (r io.ReadCloser, identifier string, err error)
+	ReadDown(ctx context.Context, version uint) (r io.ReadCloser, identifier string, err error)
 }
 
 // Open returns a new driver instance.
-func Open(url string) (Driver, error) {
+func Open(ctx context.Context, url string) (Driver, error) {
 	u, err := nurl.Parse(url)
 	if err != nil {
 		return nil, err
@@ -90,7 +91,7 @@ func Open(url string) (Driver, error) {
 		return nil, fmt.Errorf("source driver: unknown driver '%s' (forgotten import?)", u.Scheme)
 	}
 
-	return d.Open(url)
+	return d.Open(ctx, url)
 }
 
 // Register globally registers a driver.

--- a/source/file/file.go
+++ b/source/file/file.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"context"
 	nurl "net/url"
 	"os"
 	"path/filepath"
@@ -19,7 +20,7 @@ type File struct {
 	path string
 }
 
-func (f *File) Open(url string) (source.Driver, error) {
+func (f *File) Open(ctx context.Context, url string) (source.Driver, error) {
 	p, err := parseURL(url)
 	if err != nil {
 		return nil, err

--- a/source/github/github.go
+++ b/source/github/github.go
@@ -42,7 +42,7 @@ type Config struct {
 	Ref   string
 }
 
-func (g *Github) Open(url string) (source.Driver, error) {
+func (g *Github) Open(ctx context.Context, url string) (source.Driver, error) {
 	u, err := nurl.Parse(url)
 	if err != nil {
 		return nil, err
@@ -88,7 +88,7 @@ func (g *Github) Open(url string) (source.Driver, error) {
 	return gn, nil
 }
 
-func WithInstance(client *github.Client, config *Config) (source.Driver, error) {
+func WithInstance(ctx context.Context, client *github.Client, config *Config) (source.Driver, error) {
 	gn := &Github{
 		client:     client,
 		config:     config,
@@ -140,41 +140,41 @@ func (g *Github) ensureFields() {
 	}
 }
 
-func (g *Github) Close() error {
+func (g *Github) Close(ctx context.Context) error {
 	return nil
 }
 
-func (g *Github) First() (version uint, err error) {
+func (g *Github) First(ctx context.Context) (version uint, err error) {
 	g.ensureFields()
 
-	if v, ok := g.migrations.First(); !ok {
+	if v, ok := g.migrations.First(ctx); !ok {
 		return 0, &os.PathError{Op: "first", Path: g.config.Path, Err: os.ErrNotExist}
 	} else {
 		return v, nil
 	}
 }
 
-func (g *Github) Prev(version uint) (prevVersion uint, err error) {
+func (g *Github) Prev(ctx context.Context, version uint) (prevVersion uint, err error) {
 	g.ensureFields()
 
-	if v, ok := g.migrations.Prev(version); !ok {
+	if v, ok := g.migrations.Prev(ctx, version); !ok {
 		return 0, &os.PathError{Op: fmt.Sprintf("prev for version %v", version), Path: g.config.Path, Err: os.ErrNotExist}
 	} else {
 		return v, nil
 	}
 }
 
-func (g *Github) Next(version uint) (nextVersion uint, err error) {
+func (g *Github) Next(ctx context.Context, version uint) (nextVersion uint, err error) {
 	g.ensureFields()
 
-	if v, ok := g.migrations.Next(version); !ok {
+	if v, ok := g.migrations.Next(ctx, version); !ok {
 		return 0, &os.PathError{Op: fmt.Sprintf("next for version %v", version), Path: g.config.Path, Err: os.ErrNotExist}
 	} else {
 		return v, nil
 	}
 }
 
-func (g *Github) ReadUp(version uint) (r io.ReadCloser, identifier string, err error) {
+func (g *Github) ReadUp(ctx context.Context, version uint) (r io.ReadCloser, identifier string, err error) {
 	g.ensureFields()
 
 	if m, ok := g.migrations.Up(version); ok {
@@ -194,7 +194,7 @@ func (g *Github) ReadUp(version uint) (r io.ReadCloser, identifier string, err e
 	return nil, "", &os.PathError{Op: fmt.Sprintf("read version %v", version), Path: g.config.Path, Err: os.ErrNotExist}
 }
 
-func (g *Github) ReadDown(version uint) (r io.ReadCloser, identifier string, err error) {
+func (g *Github) ReadDown(ctx context.Context, version uint) (r io.ReadCloser, identifier string, err error) {
 	g.ensureFields()
 
 	if m, ok := g.migrations.Down(version); ok {

--- a/source/github/github_test.go
+++ b/source/github/github_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -25,7 +26,7 @@ func Test(t *testing.T) {
 	}
 
 	g := &Github{}
-	d, err := g.Open("github://" + GithubTestSecret + "@mattes/migrate_test_tmp/test#452b8003e7")
+	d, err := g.Open(context.Background(), "github://"+GithubTestSecret+"@mattes/migrate_test_tmp/test#452b8003e7")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,24 +35,25 @@ func Test(t *testing.T) {
 }
 
 func TestDefaultClient(t *testing.T) {
+	ctx := context.Background()
 	g := &Github{}
 	owner := "golang-migrate"
 	repo := "migrate"
 	path := "source/github/examples/migrations"
 
 	url := fmt.Sprintf("github://%s/%s/%s", owner, repo, path)
-	d, err := g.Open(url)
+	d, err := g.Open(ctx, url)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	ver, err := d.First()
+	ver, err := d.First(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, uint(1085649617), ver)
 
-	ver, err = d.Next(ver)
+	ver, err = d.Next(ctx, ver)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/source/github_ee/github_ee.go
+++ b/source/github_ee/github_ee.go
@@ -1,6 +1,7 @@
 package github_ee
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
@@ -22,7 +23,7 @@ type GithubEE struct {
 	source.Driver
 }
 
-func (g *GithubEE) Open(url string) (source.Driver, error) {
+func (g *GithubEE) Open(ctx context.Context, url string) (source.Driver, error) {
 	verifyTLS := true
 
 	u, err := nurl.Parse(url)
@@ -64,7 +65,7 @@ func (g *GithubEE) Open(url string) (source.Driver, error) {
 		cfg.Path = strings.Join(pe[2:], "/")
 	}
 
-	i, err := gh.WithInstance(ghc, cfg)
+	i, err := gh.WithInstance(ctx, ghc, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/source/github_ee/github_ee_test.go
+++ b/source/github_ee/github_ee_test.go
@@ -1,6 +1,7 @@
 package github_ee
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	nurl "net/url"
@@ -36,7 +37,7 @@ func Test(t *testing.T) {
 	}
 
 	g := &GithubEE{}
-	_, err = g.Open("github-ee://foo:bar@" + u.Host + "/mattes/migrate_test_tmp/test?verify-tls=false#452b8003e7")
+	_, err = g.Open(context.Background(), "github-ee://foo:bar@"+u.Host+"/mattes/migrate_test_tmp/test?verify-tls=false#452b8003e7")
 
 	if err != nil {
 		t.Fatal(err)

--- a/source/gitlab/gitlab_test.go
+++ b/source/gitlab/gitlab_test.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"testing"
 
@@ -23,7 +24,7 @@ func Test(t *testing.T) {
 	}
 
 	g := &Gitlab{}
-	d, err := g.Open("gitlab://" + GitlabTestSecret + "@gitlab.com/11197284/migrations")
+	d, err := g.Open(context.Background(), "gitlab://"+GitlabTestSecret+"@gitlab.com/11197284/migrations")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/source/go_bindata/go-bindata_test.go
+++ b/source/go_bindata/go-bindata_test.go
@@ -1,6 +1,7 @@
 package bindata
 
 import (
+	"context"
 	"testing"
 
 	"github.com/golang-migrate/migrate/v4/source/go_bindata/testdata"
@@ -14,7 +15,7 @@ func Test(t *testing.T) {
 			return testdata.Asset(name)
 		})
 
-	d, err := WithInstance(s)
+	d, err := WithInstance(context.Background(), s)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +29,7 @@ func TestWithInstance(t *testing.T) {
 			return testdata.Asset(name)
 		})
 
-	_, err := WithInstance(s)
+	_, err := WithInstance(context.Background(), s)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +37,7 @@ func TestWithInstance(t *testing.T) {
 
 func TestOpen(t *testing.T) {
 	b := &Bindata{}
-	_, err := b.Open("")
+	_, err := b.Open(context.Background(), "")
 	if err == nil {
 		t.Fatal("expected err, because it's not implemented yet")
 	}

--- a/source/godoc_vfs/vfs.go
+++ b/source/godoc_vfs/vfs.go
@@ -7,6 +7,7 @@
 package godoc_vfs
 
 import (
+	"context"
 	"github.com/golang-migrate/migrate/v4/source"
 	"github.com/golang-migrate/migrate/v4/source/httpfs"
 
@@ -30,7 +31,7 @@ type VFS struct {
 //
 // Calling this function panics, instead use the WithInstance function.
 // See the package level documentation for an example.
-func (b *VFS) Open(url string) (source.Driver, error) {
+func (b *VFS) Open(ctx context.Context, url string) (source.Driver, error) {
 	panic("not implemented")
 }
 
@@ -38,7 +39,7 @@ func (b *VFS) Open(url string) (source.Driver, error) {
 // If a tree named searchPath exists in the virtual filesystem, WithInstance
 // searches for migration files there.
 // It defaults to "/".
-func WithInstance(fs vfs.FileSystem, searchPath string) (source.Driver, error) {
+func WithInstance(ctx context.Context, fs vfs.FileSystem, searchPath string) (source.Driver, error) {
 	if searchPath == "" {
 		searchPath = "/"
 	}

--- a/source/godoc_vfs/vfs_example_test.go
+++ b/source/godoc_vfs/vfs_example_test.go
@@ -1,6 +1,7 @@
 package godoc_vfs_test
 
 import (
+	"context"
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/source/godoc_vfs"
 	"golang.org/x/tools/godoc/vfs/mapfs"
@@ -18,15 +19,16 @@ func Example_mapfs() {
 		"7_foobar.down.sql": "7 down",
 	})
 
-	d, err := godoc_vfs.WithInstance(fs, "")
+	ctx := context.Background()
+	d, err := godoc_vfs.WithInstance(ctx, fs, "")
 	if err != nil {
 		panic("bad migrations found!")
 	}
-	m, err := migrate.NewWithSourceInstance("godoc-vfs", d, "database://foobar")
+	m, err := migrate.NewWithSourceInstance(ctx, "godoc-vfs", d, "database://foobar")
 	if err != nil {
 		panic("error creating the migrations")
 	}
-	err = m.Up()
+	err = m.Up(ctx)
 	if err != nil {
 		panic("up failed")
 	}

--- a/source/godoc_vfs/vfs_test.go
+++ b/source/godoc_vfs/vfs_test.go
@@ -1,6 +1,7 @@
 package godoc_vfs_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/golang-migrate/migrate/v4/source/godoc_vfs"
@@ -20,7 +21,7 @@ func TestVFS(t *testing.T) {
 		"7_foobar.down.sql": "7 down",
 	})
 
-	d, err := godoc_vfs.WithInstance(fs, "")
+	d, err := godoc_vfs.WithInstance(context.Background(), fs, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +35,7 @@ func TestOpen(t *testing.T) {
 		}
 	}()
 	b := &godoc_vfs.VFS{}
-	if _, err := b.Open(""); err != nil {
+	if _, err := b.Open(context.Background(), ""); err != nil {
 		t.Error(err)
 	}
 }

--- a/source/google_cloud_storage/storage.go
+++ b/source/google_cloud_storage/storage.go
@@ -24,7 +24,7 @@ type gcs struct {
 	migrations *source.Migrations
 }
 
-func (g *gcs) Open(folder string) (source.Driver, error) {
+func (g *gcs) Open(ctx context.Context, folder string) (source.Driver, error) {
 	u, err := url.Parse(folder)
 	if err != nil {
 		return nil, err
@@ -67,42 +67,42 @@ func (g *gcs) loadMigrations() error {
 	return nil
 }
 
-func (g *gcs) Close() error {
+func (g *gcs) Close(ctx context.Context) error {
 	return nil
 }
 
-func (g *gcs) First() (uint, error) {
-	v, ok := g.migrations.First()
+func (g *gcs) First(ctx context.Context) (uint, error) {
+	v, ok := g.migrations.First(ctx)
 	if !ok {
 		return 0, os.ErrNotExist
 	}
 	return v, nil
 }
 
-func (g *gcs) Prev(version uint) (uint, error) {
-	v, ok := g.migrations.Prev(version)
+func (g *gcs) Prev(ctx context.Context, version uint) (uint, error) {
+	v, ok := g.migrations.Prev(ctx, version)
 	if !ok {
 		return 0, os.ErrNotExist
 	}
 	return v, nil
 }
 
-func (g *gcs) Next(version uint) (uint, error) {
-	v, ok := g.migrations.Next(version)
+func (g *gcs) Next(ctx context.Context, version uint) (uint, error) {
+	v, ok := g.migrations.Next(ctx, version)
 	if !ok {
 		return 0, os.ErrNotExist
 	}
 	return v, nil
 }
 
-func (g *gcs) ReadUp(version uint) (io.ReadCloser, string, error) {
+func (g *gcs) ReadUp(ctx context.Context, version uint) (io.ReadCloser, string, error) {
 	if m, ok := g.migrations.Up(version); ok {
 		return g.open(m)
 	}
 	return nil, "", os.ErrNotExist
 }
 
-func (g *gcs) ReadDown(version uint) (io.ReadCloser, string, error) {
+func (g *gcs) ReadDown(ctx context.Context, version uint) (io.ReadCloser, string, error) {
 	if m, ok := g.migrations.Down(version); ok {
 		return g.open(m)
 	}

--- a/source/httpfs/driver.go
+++ b/source/httpfs/driver.go
@@ -1,6 +1,7 @@
 package httpfs
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -26,6 +27,6 @@ func New(fs http.FileSystem, path string) (source.Driver, error) {
 
 // Open completes the implementetion of source.Driver interface. Other methods
 // are implemented by the embedded PartialDriver struct.
-func (d *driver) Open(url string) (source.Driver, error) {
+func (d *driver) Open(ctx context.Context, url string) (source.Driver, error) {
 	return nil, errors.New("Open() cannot be called on the httpfs passthrough driver")
 }

--- a/source/httpfs/driver_test.go
+++ b/source/httpfs/driver_test.go
@@ -1,6 +1,7 @@
 package httpfs_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -32,7 +33,7 @@ func TestOpen(t *testing.T) {
 		t.Error("New() expected no error")
 		return
 	}
-	d, err = d.Open("")
+	d, err = d.Open(context.Background(), "")
 	if d != nil {
 		t.Error("Open() expected to return nil driver")
 	}

--- a/source/httpfs/partial_driver.go
+++ b/source/httpfs/partial_driver.go
@@ -1,6 +1,7 @@
 package httpfs
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -66,13 +67,13 @@ func (p *PartialDriver) Init(fs http.FileSystem, path string) error {
 }
 
 // Close is part of source.Driver interface implementation. This is a no-op.
-func (p *PartialDriver) Close() error {
+func (p *PartialDriver) Close(ctx context.Context) error {
 	return nil
 }
 
 // First is part of source.Driver interface implementation.
-func (p *PartialDriver) First() (version uint, err error) {
-	if version, ok := p.migrations.First(); ok {
+func (p *PartialDriver) First(ctx context.Context) (version uint, err error) {
+	if version, ok := p.migrations.First(ctx); ok {
 		return version, nil
 	}
 	return 0, &os.PathError{
@@ -83,8 +84,8 @@ func (p *PartialDriver) First() (version uint, err error) {
 }
 
 // Prev is part of source.Driver interface implementation.
-func (p *PartialDriver) Prev(version uint) (prevVersion uint, err error) {
-	if version, ok := p.migrations.Prev(version); ok {
+func (p *PartialDriver) Prev(ctx context.Context, version uint) (prevVersion uint, err error) {
+	if version, ok := p.migrations.Prev(ctx, version); ok {
 		return version, nil
 	}
 	return 0, &os.PathError{
@@ -95,8 +96,8 @@ func (p *PartialDriver) Prev(version uint) (prevVersion uint, err error) {
 }
 
 // Next is part of source.Driver interface implementation.
-func (p *PartialDriver) Next(version uint) (nextVersion uint, err error) {
-	if version, ok := p.migrations.Next(version); ok {
+func (p *PartialDriver) Next(ctx context.Context, version uint) (nextVersion uint, err error) {
+	if version, ok := p.migrations.Next(ctx, version); ok {
 		return version, nil
 	}
 	return 0, &os.PathError{
@@ -107,7 +108,7 @@ func (p *PartialDriver) Next(version uint) (nextVersion uint, err error) {
 }
 
 // ReadUp is part of source.Driver interface implementation.
-func (p *PartialDriver) ReadUp(version uint) (r io.ReadCloser, identifier string, err error) {
+func (p *PartialDriver) ReadUp(ctx context.Context, version uint) (r io.ReadCloser, identifier string, err error) {
 	if m, ok := p.migrations.Up(version); ok {
 		body, err := p.open(path.Join(p.path, m.Raw))
 		if err != nil {
@@ -123,7 +124,7 @@ func (p *PartialDriver) ReadUp(version uint) (r io.ReadCloser, identifier string
 }
 
 // ReadDown is part of source.Driver interface implementation.
-func (p *PartialDriver) ReadDown(version uint) (r io.ReadCloser, identifier string, err error) {
+func (p *PartialDriver) ReadDown(ctx context.Context, version uint) (r io.ReadCloser, identifier string, err error) {
 	if m, ok := p.migrations.Down(version); ok {
 		body, err := p.open(path.Join(p.path, m.Raw))
 		if err != nil {

--- a/source/httpfs/partial_driver_test.go
+++ b/source/httpfs/partial_driver_test.go
@@ -1,6 +1,7 @@
 package httpfs_test
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strings"
@@ -13,13 +14,15 @@ import (
 
 type driver struct{ httpfs.PartialDriver }
 
-func (d *driver) Open(url string) (source.Driver, error) { return nil, errors.New("X") }
+func (d *driver) Open(ctx context.Context, url string) (source.Driver, error) {
+	return nil, errors.New("X")
+}
 
 type driverExample struct {
 	httpfs.PartialDriver
 }
 
-func (d *driverExample) Open(url string) (source.Driver, error) {
+func (d *driverExample) Open(ctx context.Context, url string) (source.Driver, error) {
 	parts := strings.Split(url, ":")
 	dir := parts[0]
 	path := ""
@@ -32,7 +35,7 @@ func (d *driverExample) Open(url string) (source.Driver, error) {
 }
 
 func TestDriverExample(t *testing.T) {
-	d, err := (*driverExample)(nil).Open("testdata:sql")
+	d, err := (*driverExample)(nil).Open(context.Background(), "testdata:sql")
 	if err != nil {
 		t.Errorf("Open() returned error: %s", err)
 	}
@@ -80,7 +83,7 @@ func TestPartialDriverInit(t *testing.T) {
 					t.Errorf("Init() returned error %s", err)
 				}
 				st.Test(t, &d)
-				if err = d.Close(); err != nil {
+				if err = d.Close(context.Background()); err != nil {
 					t.Errorf("Init().Close() returned error %s", err)
 				}
 			} else {
@@ -101,7 +104,7 @@ func TestFirstWithNoMigrations(t *testing.T) {
 		t.Errorf("No error on Init() expected, got: %v", err)
 	}
 
-	if _, err := d.First(); err == nil {
+	if _, err := d.First(context.Background()); err == nil {
 		t.Errorf("Expected error on First(), got: %v", err)
 	}
 }

--- a/source/iofs/example_test.go
+++ b/source/iofs/example_test.go
@@ -4,6 +4,7 @@
 package iofs_test
 
 import (
+	"context"
 	"embed"
 	"log"
 
@@ -16,15 +17,16 @@ import (
 var fs embed.FS
 
 func Example() {
+	ctx := context.Background()
 	d, err := iofs.New(fs, "testdata/migrations")
 	if err != nil {
 		log.Fatal(err)
 	}
-	m, err := migrate.NewWithSourceInstance("iofs", d, "postgres://postgres@localhost/postgres?sslmode=disable")
+	m, err := migrate.NewWithSourceInstance(ctx, "iofs", d, "postgres://postgres@localhost/postgres?sslmode=disable")
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = m.Up()
+	err = m.Up(ctx)
 	if err != nil {
 		// ...
 	}

--- a/source/migration.go
+++ b/source/migration.go
@@ -1,6 +1,7 @@
 package source
 
 import (
+	"context"
 	"sort"
 )
 
@@ -75,14 +76,14 @@ func (i *Migrations) buildIndex() {
 	})
 }
 
-func (i *Migrations) First() (version uint, ok bool) {
+func (i *Migrations) First(ctx context.Context) (version uint, ok bool) {
 	if len(i.index) == 0 {
 		return 0, false
 	}
 	return i.index[0], true
 }
 
-func (i *Migrations) Prev(version uint) (prevVersion uint, ok bool) {
+func (i *Migrations) Prev(ctx context.Context, version uint) (prevVersion uint, ok bool) {
 	pos := i.findPos(version)
 	if pos >= 1 && len(i.index) > pos-1 {
 		return i.index[pos-1], true
@@ -90,7 +91,7 @@ func (i *Migrations) Prev(version uint) (prevVersion uint, ok bool) {
 	return 0, false
 }
 
-func (i *Migrations) Next(version uint) (nextVersion uint, ok bool) {
+func (i *Migrations) Next(ctx context.Context, version uint) (nextVersion uint, ok bool) {
 	pos := i.findPos(version)
 	if pos >= 0 && len(i.index) > pos+1 {
 		return i.index[pos+1], true

--- a/source/pkger/pkger.go
+++ b/source/pkger/pkger.go
@@ -1,14 +1,15 @@
 package pkger
 
 import (
+	"context"
 	"fmt"
+	"github.com/markbates/pkger/pkging"
 	"net/http"
 	stdurl "net/url"
 
 	"github.com/golang-migrate/migrate/v4/source"
 	"github.com/golang-migrate/migrate/v4/source/httpfs"
 	"github.com/markbates/pkger"
-	"github.com/markbates/pkger/pkging"
 )
 
 func init() {
@@ -26,7 +27,7 @@ type Pkger struct {
 // scoped pkger.Open to access migrations.  The relative root and any
 // migrations must be added to the global pkger.Pkger instance by calling
 // pkger.Apply. Refer to Pkger documentation for more information.
-func (p *Pkger) Open(url string) (source.Driver, error) {
+func (p *Pkger) Open(ctx context.Context, url string) (source.Driver, error) {
 	u, err := stdurl.Parse(url)
 	if err != nil {
 		return nil, err
@@ -52,7 +53,7 @@ func (p *Pkger) Open(url string) (source.Driver, error) {
 // pkging.Pkger. The relative location of migrations is indicated by path. The
 // path must exist on the pkging.Pkger instance for the driver to initialize
 // successfully.
-func WithInstance(instance pkging.Pkger, path string) (source.Driver, error) {
+func WithInstance(ctx context.Context, instance pkging.Pkger, path string) (source.Driver, error) {
 	if instance == nil {
 		return nil, fmt.Errorf("expected instance of pkging.Pkger")
 	}

--- a/source/pkger/pkger_test.go
+++ b/source/pkger/pkger_test.go
@@ -1,6 +1,7 @@
 package pkger
 
 import (
+	"context"
 	"errors"
 	"os"
 	"testing"
@@ -14,6 +15,7 @@ import (
 
 func Test(t *testing.T) {
 	t.Run("WithInstance", func(t *testing.T) {
+		ctx := context.Background()
 		i := testInstance(t)
 
 		createPkgerFile(t, i, "/1_foobar.up.sql")
@@ -25,7 +27,7 @@ func Test(t *testing.T) {
 		createPkgerFile(t, i, "/7_foobar.up.sql")
 		createPkgerFile(t, i, "/7_foobar.down.sql")
 
-		d, err := WithInstance(i, "/")
+		d, err := WithInstance(ctx, i, "/")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -34,6 +36,7 @@ func Test(t *testing.T) {
 	})
 
 	t.Run("Open", func(t *testing.T) {
+		ctx := context.Background()
 		i := testInstance(t)
 
 		createPkgerFile(t, i, "/1_foobar.up.sql")
@@ -47,7 +50,7 @@ func Test(t *testing.T) {
 
 		registerPackageLevelInstance(t, i)
 
-		d, err := (&Pkger{}).Open("pkger:///")
+		d, err := (&Pkger{}).Open(ctx, "pkger:///")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -58,6 +61,7 @@ func Test(t *testing.T) {
 }
 
 func TestWithInstance(t *testing.T) {
+	ctx := context.Background()
 	t.Run("Subdir", func(t *testing.T) {
 		i := testInstance(t)
 
@@ -65,14 +69,14 @@ func TestWithInstance(t *testing.T) {
 		// initialize.
 		createPkgerSubdir(t, i, "/subdir")
 
-		_, err := WithInstance(i, "/subdir")
+		_, err := WithInstance(ctx, i, "/subdir")
 		if err != nil {
 			t.Fatal("")
 		}
 	})
 
 	t.Run("NilInstance", func(t *testing.T) {
-		_, err := WithInstance(nil, "")
+		_, err := WithInstance(ctx, nil, "")
 		if err == nil {
 			t.Fatal(err)
 		}
@@ -81,7 +85,7 @@ func TestWithInstance(t *testing.T) {
 	t.Run("FailInit", func(t *testing.T) {
 		i := testInstance(t)
 
-		_, err := WithInstance(i, "/fail")
+		_, err := WithInstance(ctx, i, "/fail")
 		if err == nil {
 			t.Fatal(err)
 		}
@@ -92,12 +96,12 @@ func TestWithInstance(t *testing.T) {
 
 		createPkgerSubdir(t, i, "/")
 
-		d, err := WithInstance(i, "/")
+		d, err := WithInstance(ctx, i, "/")
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if _, err := d.First(); !errors.Is(err, os.ErrNotExist) {
+		if _, err := d.First(ctx); !errors.Is(err, os.ErrNotExist) {
 			t.Fatal(err)
 		}
 
@@ -105,23 +109,24 @@ func TestWithInstance(t *testing.T) {
 }
 
 func TestOpen(t *testing.T) {
+	ctx := context.Background()
 
 	t.Run("InvalidURL", func(t *testing.T) {
-		_, err := (&Pkger{}).Open(":///")
+		_, err := (&Pkger{}).Open(ctx, ":///")
 		if err == nil {
 			t.Fatal(err)
 		}
 	})
 
 	t.Run("Root", func(t *testing.T) {
-		_, err := (&Pkger{}).Open("pkger:///")
+		_, err := (&Pkger{}).Open(ctx, "pkger:///")
 		if err != nil {
 			t.Fatal(err)
 		}
 	})
 
 	t.Run("FailInit", func(t *testing.T) {
-		_, err := (&Pkger{}).Open("pkger:///subdir")
+		_, err := (&Pkger{}).Open(ctx, "pkger:///subdir")
 		if err == nil {
 			t.Fatal(err)
 		}
@@ -136,7 +141,7 @@ func TestOpen(t *testing.T) {
 	registerPackageLevelInstance(t, i)
 
 	t.Run("Subdir", func(t *testing.T) {
-		_, err := (&Pkger{}).Open("pkger:///subdir")
+		_, err := (&Pkger{}).Open(ctx, "pkger:///subdir")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -144,11 +149,12 @@ func TestOpen(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
-	d, err := (&Pkger{}).Open("pkger:///")
+	ctx := context.Background()
+	d, err := (&Pkger{}).Open(ctx, "pkger:///")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := d.Close(); err != nil {
+	if err := d.Close(ctx); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/source/stub/stub_test.go
+++ b/source/stub/stub_test.go
@@ -1,6 +1,7 @@
 package stub
 
 import (
+	"context"
 	"testing"
 
 	"github.com/golang-migrate/migrate/v4/source"
@@ -9,7 +10,7 @@ import (
 
 func Test(t *testing.T) {
 	s := &Stub{}
-	d, err := s.Open("")
+	d, err := s.Open(context.Background(), "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/source/testing/testing.go
+++ b/source/testing/testing.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"context"
 	"errors"
 	"os"
 	"testing"
@@ -21,15 +22,16 @@ import (
 //
 // See source/stub/stub_test.go or source/file/file_test.go for an example.
 func Test(t *testing.T, d source.Driver) {
-	TestFirst(t, d)
-	TestPrev(t, d)
-	TestNext(t, d)
-	TestReadUp(t, d)
-	TestReadDown(t, d)
+	ctx := context.Background()
+	TestFirst(t, ctx, d)
+	TestPrev(t, ctx, d)
+	TestNext(t, ctx, d)
+	TestReadUp(t, ctx, d)
+	TestReadDown(t, ctx, d)
 }
 
-func TestFirst(t *testing.T, d source.Driver) {
-	version, err := d.First()
+func TestFirst(t *testing.T, ctx context.Context, d source.Driver) {
+	version, err := d.First(ctx)
 	if err != nil {
 		t.Fatalf("First: expected err to be nil, got %v", err)
 	}
@@ -38,7 +40,7 @@ func TestFirst(t *testing.T, d source.Driver) {
 	}
 }
 
-func TestPrev(t *testing.T, d source.Driver) {
+func TestPrev(t *testing.T, ctx context.Context, d source.Driver) {
 	tt := []struct {
 		version           uint
 		expectErr         error
@@ -57,7 +59,7 @@ func TestPrev(t *testing.T, d source.Driver) {
 	}
 
 	for i, v := range tt {
-		pv, err := d.Prev(v.version)
+		pv, err := d.Prev(ctx, v.version)
 		if (v.expectErr == os.ErrNotExist && !errors.Is(err, os.ErrNotExist)) && v.expectErr != err {
 			t.Errorf("Prev: expected %v, got %v, in %v", v.expectErr, err, i)
 		}
@@ -67,7 +69,7 @@ func TestPrev(t *testing.T, d source.Driver) {
 	}
 }
 
-func TestNext(t *testing.T, d source.Driver) {
+func TestNext(t *testing.T, ctx context.Context, d source.Driver) {
 	tt := []struct {
 		version           uint
 		expectErr         error
@@ -86,7 +88,7 @@ func TestNext(t *testing.T, d source.Driver) {
 	}
 
 	for i, v := range tt {
-		nv, err := d.Next(v.version)
+		nv, err := d.Next(ctx, v.version)
 		if (v.expectErr == os.ErrNotExist && !errors.Is(err, os.ErrNotExist)) && v.expectErr != err {
 			t.Errorf("Next: expected %v, got %v, in %v", v.expectErr, err, i)
 		}
@@ -96,7 +98,7 @@ func TestNext(t *testing.T, d source.Driver) {
 	}
 }
 
-func TestReadUp(t *testing.T, d source.Driver) {
+func TestReadUp(t *testing.T, ctx context.Context, d source.Driver) {
 	tt := []struct {
 		version   uint
 		expectErr error
@@ -114,7 +116,7 @@ func TestReadUp(t *testing.T, d source.Driver) {
 	}
 
 	for i, v := range tt {
-		up, identifier, err := d.ReadUp(v.version)
+		up, identifier, err := d.ReadUp(ctx, v.version)
 		if (v.expectErr == os.ErrNotExist && !errors.Is(err, os.ErrNotExist)) ||
 			(v.expectErr != os.ErrNotExist && err != v.expectErr) {
 			t.Errorf("expected %v, got %v, in %v", v.expectErr, err, i)
@@ -138,7 +140,7 @@ func TestReadUp(t *testing.T, d source.Driver) {
 	}
 }
 
-func TestReadDown(t *testing.T, d source.Driver) {
+func TestReadDown(t *testing.T, ctx context.Context, d source.Driver) {
 	tt := []struct {
 		version    uint
 		expectErr  error
@@ -156,7 +158,7 @@ func TestReadDown(t *testing.T, d source.Driver) {
 	}
 
 	for i, v := range tt {
-		down, identifier, err := d.ReadDown(v.version)
+		down, identifier, err := d.ReadDown(ctx, v.version)
 		if (v.expectErr == os.ErrNotExist && !errors.Is(err, os.ErrNotExist)) ||
 			(v.expectErr != os.ErrNotExist && err != v.expectErr) {
 			t.Errorf("expected %v, got %v, in %v", v.expectErr, err, i)


### PR DESCRIPTION
This PR changes the internal API of the `database.Driver` and `source.Driver` interfaces so that every function accepts a `context.Context` to enable future use cases which require passing around data between these functions.

There are no other functional changes in this PR.