### PR TITLE
fix: remove init function to clear lint error

### DIFF
--- a/testing/docker.go
+++ b/testing/docker.go
@@ -9,17 +9,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	dockertypes "github.com/docker/docker/api/types"
-	dockercontainer "github.com/docker/docker/api/types/container"
-	dockernetwork "github.com/docker/docker/api/types/network"
-	dockerclient "github.com/docker/docker/client"
-	"github.com/hashicorp/go-multierror"
 	"io"
 	"math/rand"
 	"strconv"
 	"strings"
 	"testing"
-	"time"
+
+	dockertypes "github.com/docker/docker/api/types"
+	dockercontainer "github.com/docker/docker/api/types/container"
+	dockernetwork "github.com/docker/docker/api/types/network"
+	dockerclient "github.com/docker/docker/client"
+	"github.com/hashicorp/go-multierror"
 )
 
 func NewDockerContainer(t testing.TB, image string, env []string, cmd []string) (*DockerContainer, error) {
@@ -284,10 +284,6 @@ type dockerImagePullOutput struct {
 	} `json:"progressDetail"`
 	Id       string `json:"id"`
 	Progress string `json:"progress"`
-}
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
 }
 
 func pseudoRandStr(n int) string {


### PR DESCRIPTION
The init function only called rand.Seed which is no longer necessary.

Fixes lint error:
```
testing/docker.go:290:2: SA1019: rand.Seed has been deprecated since Go 1.20 and an alternative has been available since Go 1.0: As of Go 1.20 there is no reason to call Seed with a random value. Programs that call Seed with a known value to get a specific sequence of results should use New(NewSource(seed)) to obtain a local random generator. (staticcheck)
```