### PR TITLE
chore: remove deprecated `rand.Seed()` in testing.docker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.21.x", "1.22.x"]
+        go: ["1.22.x"]
     steps:
       - uses: actions/checkout@v4
 

--- a/testing/docker.go
+++ b/testing/docker.go
@@ -15,7 +15,7 @@ import (
 	dockerclient "github.com/docker/docker/client"
 	"github.com/hashicorp/go-multierror"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 	"strings"
 	"testing"
@@ -289,7 +289,7 @@ func pseudoRandStr(n int) string {
 	var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+		b[i] = letterRunes[rand.IntN(len(letterRunes))]
 	}
 	return string(b)
 }

--- a/testing/docker.go
+++ b/testing/docker.go
@@ -19,7 +19,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 )
 
 func NewDockerContainer(t testing.TB, image string, env []string, cmd []string) (*DockerContainer, error) {
@@ -284,10 +283,6 @@ type dockerImagePullOutput struct {
 	} `json:"progressDetail"`
 	Id       string `json:"id"`
 	Progress string `json:"progress"`
-}
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
 }
 
 func pseudoRandStr(n int) string {


### PR DESCRIPTION
golangci-lint complains about the use of `rand.Seed(...)`:

> ```
> Error: testing/docker.go:290:2: SA1019: rand.Seed has been deprecated since Go 1.20 and an alternative has been available since Go 1.0: As of Go 1.20 there is no reason to call Seed with a random value. Programs that call Seed with a known value to get a specific sequence of results should use New(NewSource(seed)) to obtain a local random generator. (staticcheck)
> ```

See also:
- https://go.dev/blog/randv2
- https://tip.golang.org/doc/go1.20#mathrandpkgmathrand