### PR TITLE
Remove toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/golang-migrate/migrate/v4
 
 go 1.22.0
 
-toolchain go1.23.1
-
 require (
 	cloud.google.com/go/spanner v1.56.0
 	cloud.google.com/go/storage v1.38.0


### PR DESCRIPTION


With go 1.21 the controversial toolchain directive got introduced which forces downstream consumers of libraries to needlessly change their go compiler version with no way to ignore it on an application level without go mod tidy and various tools and linters silently failing. I am of the opinion that libraries shouldn't really set a toolchain to allow consumers to be not bothered by it.

Depends on https://github.com/dhui/dktest/pull/38