### PR TITLE
Don't output sensitive information on error

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -107,7 +107,7 @@ func New(sourceURL, databaseURL string) (*Migrate, error) {
 
 	databaseDrv, err := database.Open(databaseURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open database, %q: %w", databaseURL, err)
+		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
 	m.databaseDrv = databaseDrv
 
@@ -157,7 +157,7 @@ func NewWithSourceInstance(sourceName string, sourceInstance source.Driver, data
 
 	databaseDrv, err := database.Open(databaseURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open database, %q: %w", databaseURL, err)
+		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
 	m.databaseDrv = databaseDrv
 


### PR DESCRIPTION
A recent change introduced a situation where potentially sensitive information in the form of connection strings (which can often contain usernames and passwords) can end up in logs. Please consider applying.

This PR resolves https://github.com/golang-migrate/migrate/issues/1161