### PR TITLE
WIP: Fix sqlserver tests.

### DIFF
--- a/database/sqlserver/sqlserver_test.go
+++ b/database/sqlserver/sqlserver_test.go
@@ -35,11 +35,11 @@ var (
 				},
 			},
 		},
-		PortRequired: true, ReadyFunc: isReady, PullTimeout: 2 * time.Minute,
+		PortRequired: true, ReadyFunc: isReady, PullTimeout: 3 * time.Minute,
 	}
 	sqlServerOpts = dktest.Options{
 		Env:          map[string]string{"ACCEPT_EULA": "Y", "MSSQL_SA_PASSWORD": saPassword, "MSSQL_PID": "Express"},
-		PortRequired: true, ReadyFunc: isReady, PullTimeout: 2 * time.Minute,
+		PortRequired: true, ReadyFunc: isReady, PullTimeout: 3 * time.Minute,
 	}
 	// Container versions: https://mcr.microsoft.com/v2/mssql/server/tags/list
 	specs = []dktesting.ContainerSpec{


### PR DESCRIPTION
We have an issue with `sqlserver` `mcr.microsoft.com/azure-sql-edge:latest` on running `make test`.

```
dktest.go:185: Failed: timed out waiting for container to get ready: dktest.ContainerInfo{ID:"be9269d838e9d978e57396c001346251609d1551c89f899ee48579adb545648a", Name:"dktest_kyiOTeoPAF", ImageName:"mcr.microsoft.com/azure-sql-edge:latest", Ports:[1433/tcp -> 0.0.0.0:55011 1401/tcp -> 0.0.0.0:55010]}
```