### PR TITLE
Update migrate -help output for the readme file

### DIFF
--- a/cmd/migrate/README.md
+++ b/cmd/migrate/README.md
@@ -86,14 +86,18 @@ Options:
   -help            Print usage
 
 Commands:
-  create [-ext E] [-dir D] [-seq] [-digits N] [-format] NAME
-               Create a set of timestamped up/down migrations titled NAME, in directory D with extension E.
-               Use -seq option to generate sequential up/down migrations with N digits.
-               Use -format option to specify a Go time format string.
+  create [-ext E] [-dir D] [-seq] [-digits N] [-format] [-tz] NAME
+           Create a set of timestamped up/down migrations titled NAME, in directory D with extension E.
+           Use -seq option to generate sequential up/down migrations with N digits.
+           Use -format option to specify a Go time format string. Note: migrations with the same time cause "duplicate migration version" error.
+           Use -tz option to specify the timezone that will be used when generating non-sequential migrations (defaults: UTC).
+
   goto V       Migrate to version V
   up [N]       Apply all or N up migrations
-  down [N]     Apply all or N down migrations
-  drop         Drop everything inside database
+  down [N] [-all]    Apply all or N down migrations
+        Use -all to apply all down migrations
+  drop [-f]    Drop everything inside database
+        Use -f to bypass confirmation
   force V      Set version V but don't run migration (ignores dirty state)
   version      Print current migration version
 ```


### PR DESCRIPTION
I copied the output of `migrate -help` at version 4.18.1

I am opening this pull request, because I original missed the `-all` option which was not in the readme file. I had to google search and found a few topics ([Add an option to assume "yes" to all prompts](https://github.com/golang-migrate/migrate/issues/370), [Add help statement for cli](https://github.com/golang-migrate/migrate/pull/460)) discussing this very feature. Then I discovered it was all there in the help output of the most recent version of the app. So I decided to update