### PR TITLE
test(mssql): add MS SQLServer 2022 for tests

### DIFF
--- a/database/sqlserver/sqlserver_test.go
+++ b/database/sqlserver/sqlserver_test.go
@@ -44,8 +44,8 @@ var (
 	// Container versions: https://mcr.microsoft.com/v2/mssql/server/tags/list
 	specs = []dktesting.ContainerSpec{
 		{ImageName: "mcr.microsoft.com/azure-sql-edge:latest", Options: sqlEdgeOpts},
-		{ImageName: "mcr.microsoft.com/mssql/server:2017-latest", Options: sqlServerOpts},
 		{ImageName: "mcr.microsoft.com/mssql/server:2019-latest", Options: sqlServerOpts},
+		{ImageName: "mcr.microsoft.com/mssql/server:2022-latest", Options: sqlServerOpts},
 	}
 )
 


### PR DESCRIPTION
Add Microsoft SQL Server 2022 to test matrix and remove SQL Server 2017, which still gets security updates (see https://endoflife.date/mssqlserver) but causes some issues with the tests lately.

Refs https://github.com/golang-migrate/migrate/issues/1174