### PR TITLE
Fixed sqlserver not actually getting a lock if lock is already set

### DIFF
--- a/database/sqlserver/sqlserver.go
+++ b/database/sqlserver/sqlserver.go
@@ -33,7 +33,7 @@ var (
 	ErrMultipleAuthOptionsPassed = fmt.Errorf("both password and useMsi=true were passed.")
 )
 
-var lockErrorMap = map[mssql.ReturnStatus]string{
+var lockErrorMap = map[int]string{
 	-1:   "The lock request timed out.",
 	-2:   "The lock request was canceled.",
 	-3:   "The lock request was chosen as a deadlock victim.",
@@ -198,18 +198,24 @@ func (ss *SQLServer) Lock() error {
 			return err
 		}
 
-		// This will either obtain the lock immediately and return true,
-		// or return false if the lock cannot be acquired immediately.
+		// This will block until the lock is acquired.
 		// MS Docs: sp_getapplock: https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-getapplock-transact-sql?view=sql-server-2017
-		query := `EXEC sp_getapplock @Resource = @p1, @LockMode = 'Update', @LockOwner = 'Session', @LockTimeout = 0`
+		query := `
+		DECLARE @lockResult int;
+		EXEC @lockResult = sp_getapplock @Resource = @p1, @LockMode = 'Exclusive', @LockOwner = 'Session', @LockTimeout = -1;
+		SELECT @lockResult;`
 
-		var status mssql.ReturnStatus
-		if _, err = ss.conn.ExecContext(context.Background(), query, aid, &status); err == nil && status > -1 {
+		var status int
+		if err = ss.conn.QueryRowContext(context.Background(), query, aid).Scan(&status); err == nil && status > -1 {
 			return nil
 		} else if err != nil {
 			return &database.Error{OrigErr: err, Err: "try lock failed", Query: []byte(query)}
 		} else {
-			return &database.Error{Err: fmt.Sprintf("try lock failed with error %v: %v", status, lockErrorMap[status]), Query: []byte(query)}
+			errorDescription, ok := lockErrorMap[status]
+			if !ok {
+				errorDescription = "Unknown error"
+			}
+			return &database.Error{Err: fmt.Sprintf("try lock failed with error %v: %v", status, errorDescription), Query: []byte(query)}
 		}
 	})
 }


### PR DESCRIPTION
This PR fixes the SQL Server not actually getting a lock if lock is already set (e.g. by another instance).

As mentioned in [this comment](https://github.com/golang-migrate/migrate/issues/253#issuecomment-514900578) by @dhui, the SQL statement for `sp_getapplock` is not correct.

I tested the locking with [this script](https://gist.github.com/urbim/6bfa8e8f5f5453666a7b5b75df02e156) and added some debugging logging as seen in [this commit](https://github.com/urbim/migrate/commit/31000afbb169f98494c0a22154717c05d06e85d3) (debug log is not actually part of this PR, I only used it for testing).

The result before applying the fixes was:

```
=== Lock 0xc000080400
=== Unlock 0xc000080400
=== Lock 0xc000080400
Locked
=== Lock 0xc0001440a0
=== Unlock 0xc0001440a0
panic: mssql: Cannot release the application lock (Database Principal: 'public', Resource: '983082799') because it is not currently held. in line 0: EXEC sp_releaseapplock @Resource = @p1, @LockOwner = 'Session'

goroutine 1 [running]:
main.main()
        /path/to/golang-migrate-test/golang-migrate-test.go:49 +0x254
```

The first two lines are from `d1, err := p.Open(connectionString)`. Then `d1` acquires the lock (line 3). Then `_, err = p.Open(connectionString) // d2` should fail when trying to acquire the second lock, but it does not - the code succeeds but the lock is actually not acquired (line 5). The code actually fails when `d2` tries to unlock - it can't because it hasn't acquired the lock in the first place (line 6+).

> I'd expect a SELECT statement after the EXEC sp_getapplock statement to be used with sql.Conn.QueryRowContext instead of with sql.Conn.ExecContext().

This is exactly right, the SELECT statement is missing and this PR fixes this, along with some other improvements to the locking:

> It's unclear to me what @<!-- -->LockMode (update vs exclusive)

From the [documentation](https://learn.microsoft.com/en-us/sql/relational-databases/sql-server-transaction-locking-and-row-versioning-guide?view=sql-server-2017#lock_modes) the `Update` should be used when updating resources, which is not the case here. The documentation is not entirely clear to me, but from what I can tell, this is the same as `Exclusive` with added mechanism, that prevents deadlocks from read-lock-update pattern. I think the `Exclusive` is the right choice here, so the PR also changes that.

> and @LockOwner (transaction vs session) we should be using.

From the [documentation](https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-getapplock-transact-sql?view=sql-server-2017):

> Locks associated with the current transaction are released when the transaction commits or rolls back. Locks associated with the session are released when the session is logged out.

Since we are acquiring lock outside the transaction, the `Session` is the correct option to use. I actually tried using the `Transaction` value as the LockOwner and the result was `-999`, which "Indicates a parameter validation or other call error".

I also set the timeout of the `sp_getapplock` to infinite, similar to what is used in the postgres implementation. Since migrations can take a long time (e.g. updating an index on a large database), I think that the only good options for timeout are either infinite or somehow configurable by the user. Since the second option is probably not feasible in the current architecture of this library, I opted for the first one. [One PR](https://github.com/golang-migrate/migrate/pull/1123) is already open addressing this timeout, but it would still incorrectly obtain the lock if another instance was holding the lock for more than 10 seconds.

This PR should close #1123 and #253.

I didn't manage to get the tests working locally, but I'm hoping the tests will pass in CI.

Lastly, the result of the above script with fixes applied (and non-infinite timeout for testing):

```
=== Lock 0xc00043a0a0
=== Unlock 0xc00043a0a0
=== Lock 0xc00043a0a0
Locked
=== Lock 0xc0000800c0
panic: try lock failed with error -1: The lock request timed out. in line 0: DECLARE @lockResult int; EXEC @lockResult = sp_getapplock @Resource = @p1, @LockMode = 'Exclusive', @LockOwner = 'Session', @LockTimeout = 1000; SELECT @lockResult; (details: <nil>)

goroutine 1 [running]:
main.main()
        /path/to/golang-migrate-test.go:42 +0x13c
```

When `d2` tries to acquire the lock, it fails with `-1: The lock request timed out` after timeout as expected.
