### PR TITLE
Default transaction level in MySQL when `NoLock` is set

### DIFF
--- a/database/mysql/README.md
+++ b/database/mysql/README.md
@@ -5,7 +5,7 @@
 | URL Query  | WithInstance Config | Description |
 |------------|---------------------|-------------|
 | `x-migrations-table` | `MigrationsTable` | Name of the migrations table |
-| `x-no-lock` | `NoLock` | Set to `true` to skip `GET_LOCK`/`RELEASE_LOCK` statements. Useful for [multi-master MySQL flavors](https://www.percona.com/doc/percona-xtradb-cluster/LATEST/features/pxc-strict-mode.html#explicit-table-locking). Only run migrations from one host when this is enabled. |
+| `x-no-lock` | `NoLock` | Set to `true` to skip `GET_LOCK`/`RELEASE_LOCK` statements and `SERIALIZABLE` transaction level. Useful for [multi-master MySQL flavors](https://docs.percona.com/percona-xtradb-cluster/latest/strict-mode.html#explicit-table-locking). Only run migrations from one host when this is enabled. |
 | `x-statement-timeout` | `StatementTimeout` | Abort any statement that takes more than the specified number of milliseconds, functionally similar to [Server-side SELECT statement timeouts](https://dev.mysql.com/blog-archive/server-side-select-statement-timeouts/) but enforced by the client. Available for all versions of MySQL, not just >=5.7. | 
 | `dbname` | `DatabaseName` | The name of the database to connect to |
 | `user` | | The user to sign in as |

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -356,7 +356,14 @@ func (m *Mysql) Run(migration io.Reader) error {
 }
 
 func (m *Mysql) SetVersion(version int, dirty bool) error {
-	tx, err := m.conn.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable})
+	opts := sql.TxOptions{
+		Isolation: sql.LevelSerializable,
+	}
+	if m.config.NoLock {
+		opts.Isolation = 0 // driver default
+	}
+
+	tx, err := m.conn.BeginTx(context.Background(), &opts)
 	if err != nil {
 		return &database.Error{OrigErr: err, Err: "transaction start failed"}
 	}


### PR DESCRIPTION
The Percona Xtra Cluster does not allow `SERIALIZABLE` in strict mode which initiated these changes.

`SERIALIZABLE` can perhaps be considered a sort of locking so using the existing `NoLock` setting to control the transaction level as well.