### PR TITLE
cassandra: parse port from url to set cluster’s port

### DIFF
--- a/database/cassandra/cassandra.go
+++ b/database/cassandra/cassandra.go
@@ -125,6 +125,14 @@ func (c *Cassandra) Open(url string) (database.Driver, error) {
 		}
 		cluster.ProtoVersion = protoversion
 	}
+	if len(u.Query().Get("port")) > 0 {
+		var port int
+		port, err = strconv.Atoi(u.Query().Get("port"))
+		if err != nil {
+			return nil, err
+		}
+		cluster.Port = port
+	}
 	if len(u.Query().Get("timeout")) > 0 {
 		var timeout time.Duration
 		timeout, err = time.ParseDuration(u.Query().Get("timeout"))


### PR DESCRIPTION
There is a valid parameter, "port", in the [docs](https://github.com/golang-migrate/migrate/tree/master/database/cassandra) for the Cassandra driver. However, there is no parsing of this parameter in the source code, so it's impossible to set the cluster's parameters.
I've executed this command:
```
migrate -path ./migrations/ -database "cassandra://{node_host_0}:9142/{keyspace}?
port=9142&protocol=4&sslcert=certificate.pem&sslkey=private_key.pem&sslrootcert=ca_chain.pem&sslmode=require&disable-host-lookup=true" -verbose up

```

and got errors:

```
2024/12/02 15:04:16 error: failed to connect to {node_host_1}:9042 due to error: tls: first record does not look like a TLS handshake
2024/12/02 15:04:16 error: failed to connect to {node_host_2}:9042 due to error: tls: first record does not look like a TLS handshake
2024/12/02 15:04:16 error: failed to connect to {node_host_3}:9042 due to error: tls: first record does not look like a TLS handshake

```

({node_host_[n]} is valid host)

After my fix, the migration went smoothly.

I may be wrong, so please correct me if I use it incorrectly.