### PR TITLE
test(mongodb): remove old versions of MongoDB in tests

### DIFF
--- a/database/mongodb/mongodb_test.go
+++ b/database/mongodb/mongodb_test.go
@@ -32,10 +32,10 @@ var (
 	opts = dktest.Options{PortRequired: true, ReadyFunc: isReady}
 	// Supported versions: https://www.mongodb.com/support-policy
 	specs = []dktesting.ContainerSpec{
-		{ImageName: "mongo:3.4", Options: opts},
-		{ImageName: "mongo:3.6", Options: opts},
-		{ImageName: "mongo:4.0", Options: opts},
-		{ImageName: "mongo:4.2", Options: opts},
+		{ImageName: "mongo:5.0", Options: opts},
+		{ImageName: "mongo:6.0", Options: opts},
+		{ImageName: "mongo:7.0", Options: opts},
+		{ImageName: "mongo:8.0", Options: opts},
 	}
 )
 


### PR DESCRIPTION
Removed:

| Release     | Release Date  | End of Life Date |
|-------------|---------------|------------------|
| MongoDB 3.4 | November 2016 | January 2020     |
| MongoDB 3.6 | November 2017 | April 2021       |
| MongoDB 4.0 | June 2018     | April 2022       |
| MongoDB 4.2 | August 2019   | April 2023       |

Added:

| Release     | Release Date  | End of Life Date |
|-------------|---------------|------------------|
| MongoDB 5.0 | July 2021     | October 2024     |
| MongoDB 6.0 | July 2022     | July 2025        |
| MongoDB 7.0 | August 2023   | August 2026      |
| MongoDB 8.0 | October 2024  | TBD              |

https://www.mongodb.com/legal/support-policy/lifecycles