### PR TITLE
test(postgres): run tests with PostgreSQL 17

### DIFF
--- a/database/pgx/pgx_test.go
+++ b/database/pgx/pgx_test.go
@@ -34,11 +34,11 @@ var (
 		PortRequired: true, ReadyFunc: isReady}
 	// Supported versions: https://www.postgresql.org/support/versioning/
 	specs = []dktesting.ContainerSpec{
-		{ImageName: "postgres:12", Options: opts},
 		{ImageName: "postgres:13", Options: opts},
 		{ImageName: "postgres:14", Options: opts},
 		{ImageName: "postgres:15", Options: opts},
 		{ImageName: "postgres:16", Options: opts},
+		{ImageName: "postgres:17", Options: opts},
 	}
 )
 

--- a/database/pgx/v5/pgx_test.go
+++ b/database/pgx/v5/pgx_test.go
@@ -35,11 +35,11 @@ var (
 		PortRequired: true, ReadyFunc: isReady}
 	// Supported versions: https://www.postgresql.org/support/versioning/
 	specs = []dktesting.ContainerSpec{
-		{ImageName: "postgres:12", Options: opts},
 		{ImageName: "postgres:13", Options: opts},
 		{ImageName: "postgres:14", Options: opts},
 		{ImageName: "postgres:15", Options: opts},
 		{ImageName: "postgres:16", Options: opts},
+		{ImageName: "postgres:17", Options: opts},
 	}
 )
 

--- a/database/postgres/postgres_test.go
+++ b/database/postgres/postgres_test.go
@@ -35,11 +35,11 @@ var (
 		PortRequired: true, ReadyFunc: isReady}
 	// Supported versions: https://www.postgresql.org/support/versioning/
 	specs = []dktesting.ContainerSpec{
-		{ImageName: "postgres:12", Options: opts},
 		{ImageName: "postgres:13", Options: opts},
 		{ImageName: "postgres:14", Options: opts},
 		{ImageName: "postgres:15", Options: opts},
 		{ImageName: "postgres:16", Options: opts},
+		{ImageName: "postgres:17", Options: opts},
 	}
 )
 


### PR DESCRIPTION
Add PostgreSQL 17, remove PostgreSQL 12 (EOL since November 21, 2024).

https://www.postgresql.org/support/versioning/