### PR TITLE
test(firebird): remove old versions of Firebird in tests

### DIFF
--- a/database/firebird/firebird_test.go
+++ b/database/firebird/firebird_test.go
@@ -38,8 +38,9 @@ var (
 		},
 	}
 	specs = []dktesting.ContainerSpec{
-		{ImageName: "jacobalberty/firebird:2.5-ss", Options: opts},
-		{ImageName: "jacobalberty/firebird:3.0", Options: opts},
+		{ImageName: "jacobalberty/firebird:v3.0", Options: opts},
+		{ImageName: "jacobalberty/firebird:v4.0", Options: opts},
+		{ImageName: "jacobalberty/firebird:v5.0", Options: opts},
 	}
 )
 


### PR DESCRIPTION
Removed: Firebird 2.5, see https://firebirdsql.org/en/discontinued-versions/

Added:
- Firebird 4.0 (https://firebirdsql.org/en/firebird-4-0-5/)
- Firebird 5.0 (https://firebirdsql.org/en/firebird-5-0-1/)