### PR TITLE
refactor: replace github.com/pkg/errors with stdlib

### DIFF
--- a/database/rqlite/rqlite.go
+++ b/database/rqlite/rqlite.go
@@ -12,7 +12,6 @@ import (
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database"
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"github.com/rqlite/gorqlite"
 )
 
@@ -292,7 +291,7 @@ func parseUrl(url string) (*nurl.URL, *Config, error) {
 	}
 
 	if parsedUrl.Scheme != "rqlite" {
-		return nil, nil, errors.Wrap(ErrBadConfig, "bad scheme")
+		return nil, nil, fmt.Errorf("bad scheme: %w", ErrBadConfig)
 	}
 
 	// adapt from rqlite to http/https schemes
@@ -316,7 +315,7 @@ func parseConfigFromQuery(queryVals nurl.Values) (*Config, error) {
 	migrationsTable := queryVals.Get("x-migrations-table")
 	if migrationsTable != "" {
 		if strings.HasPrefix(migrationsTable, "sqlite_") {
-			return nil, errors.Wrap(ErrBadConfig, "invalid value for x-migrations-table")
+			return nil, fmt.Errorf("invalid value for x-migrations-table: %w", ErrBadConfig)
 		}
 		c.MigrationsTable = migrationsTable
 	}
@@ -325,7 +324,7 @@ func parseConfigFromQuery(queryVals nurl.Values) (*Config, error) {
 	if connectInsecureStr != "" {
 		connectInsecure, err := strconv.ParseBool(connectInsecureStr)
 		if err != nil {
-			return nil, errors.Wrap(ErrBadConfig, "invalid value for x-connect-insecure")
+			return nil, fmt.Errorf("invalid value for x-connect-insecure: %w", ErrBadConfig)
 		}
 		c.ConnectInsecure = connectInsecure
 	}

--- a/go.mod
+++ b/go.mod
@@ -163,7 +163,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.16 // indirect
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/rqlite/gorqlite v0.0.0-20230708021416-2acd02b70b79


### PR DESCRIPTION
The package was deprecated since at least 2021.