### PR TITLE
Remove redundant build tags

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,10 +13,14 @@ linters:
     - unparam
     - nakedret
     - prealloc
+    - revive
     #- gosec
 linters-settings:
   misspell:
     locale: US
+  revive:
+    rules:
+      - name: redundant-build-tag
 issues:
   max-same-issues: 0
   max-issues-per-linter: 0

--- a/database/firebird/firebird.go
+++ b/database/firebird/firebird.go
@@ -1,5 +1,4 @@
 //go:build go1.9
-// +build go1.9
 
 package firebird
 

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -1,5 +1,4 @@
 //go:build go1.9
-// +build go1.9
 
 package mysql
 

--- a/database/pgx/pgx.go
+++ b/database/pgx/pgx.go
@@ -1,5 +1,4 @@
 //go:build go1.9
-// +build go1.9
 
 package pgx
 

--- a/database/pgx/v5/pgx.go
+++ b/database/pgx/v5/pgx.go
@@ -1,5 +1,4 @@
 //go:build go1.9
-// +build go1.9
 
 package pgx
 

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -1,5 +1,4 @@
 //go:build go1.9
-// +build go1.9
 
 package postgres
 

--- a/database/redshift/redshift.go
+++ b/database/redshift/redshift.go
@@ -1,5 +1,4 @@
 //go:build go1.9
-// +build go1.9
 
 package redshift
 

--- a/internal/cli/build_aws-s3.go
+++ b/internal/cli/build_aws-s3.go
@@ -1,5 +1,4 @@
 //go:build aws_s3
-// +build aws_s3
 
 package cli
 

--- a/internal/cli/build_bitbucket.go
+++ b/internal/cli/build_bitbucket.go
@@ -1,5 +1,4 @@
 //go:build bitbucket
-// +build bitbucket
 
 package cli
 

--- a/internal/cli/build_cassandra.go
+++ b/internal/cli/build_cassandra.go
@@ -1,5 +1,4 @@
 //go:build cassandra
-// +build cassandra
 
 package cli
 

--- a/internal/cli/build_clickhouse.go
+++ b/internal/cli/build_clickhouse.go
@@ -1,5 +1,4 @@
 //go:build clickhouse
-// +build clickhouse
 
 package cli
 

--- a/internal/cli/build_cockroachdb.go
+++ b/internal/cli/build_cockroachdb.go
@@ -1,5 +1,4 @@
 //go:build cockroachdb
-// +build cockroachdb
 
 package cli
 

--- a/internal/cli/build_firebird.go
+++ b/internal/cli/build_firebird.go
@@ -1,5 +1,4 @@
 //go:build firebird
-// +build firebird
 
 package cli
 

--- a/internal/cli/build_github.go
+++ b/internal/cli/build_github.go
@@ -1,5 +1,4 @@
 //go:build github
-// +build github
 
 package cli
 

--- a/internal/cli/build_github_ee.go
+++ b/internal/cli/build_github_ee.go
@@ -1,5 +1,4 @@
 //go:build github
-// +build github
 
 package cli
 

--- a/internal/cli/build_gitlab.go
+++ b/internal/cli/build_gitlab.go
@@ -1,5 +1,4 @@
 //go:build gitlab
-// +build gitlab
 
 package cli
 

--- a/internal/cli/build_go-bindata.go
+++ b/internal/cli/build_go-bindata.go
@@ -1,5 +1,4 @@
 //go:build go_bindata
-// +build go_bindata
 
 package cli
 

--- a/internal/cli/build_godoc-vfs.go
+++ b/internal/cli/build_godoc-vfs.go
@@ -1,5 +1,4 @@
 //go:build godoc_vfs
-// +build godoc_vfs
 
 package cli
 

--- a/internal/cli/build_google-cloud-storage.go
+++ b/internal/cli/build_google-cloud-storage.go
@@ -1,5 +1,4 @@
 //go:build google_cloud_storage
-// +build google_cloud_storage
 
 package cli
 

--- a/internal/cli/build_mongodb.go
+++ b/internal/cli/build_mongodb.go
@@ -1,5 +1,4 @@
 //go:build mongodb
-// +build mongodb
 
 package cli
 

--- a/internal/cli/build_mysql.go
+++ b/internal/cli/build_mysql.go
@@ -1,5 +1,4 @@
 //go:build mysql
-// +build mysql
 
 package cli
 

--- a/internal/cli/build_neo4j.go
+++ b/internal/cli/build_neo4j.go
@@ -1,5 +1,4 @@
 //go:build neo4j
-// +build neo4j
 
 package cli
 

--- a/internal/cli/build_pgx.go
+++ b/internal/cli/build_pgx.go
@@ -1,5 +1,4 @@
 //go:build pgx
-// +build pgx
 
 package cli
 

--- a/internal/cli/build_pgxv5.go
+++ b/internal/cli/build_pgxv5.go
@@ -1,5 +1,4 @@
 //go:build pgx5
-// +build pgx5
 
 package cli
 

--- a/internal/cli/build_postgres.go
+++ b/internal/cli/build_postgres.go
@@ -1,5 +1,4 @@
 //go:build postgres
-// +build postgres
 
 package cli
 

--- a/internal/cli/build_ql.go
+++ b/internal/cli/build_ql.go
@@ -1,5 +1,4 @@
 //go:build ql
-// +build ql
 
 package cli
 

--- a/internal/cli/build_redshift.go
+++ b/internal/cli/build_redshift.go
@@ -1,5 +1,4 @@
 //go:build redshift
-// +build redshift
 
 package cli
 

--- a/internal/cli/build_rqlite.go
+++ b/internal/cli/build_rqlite.go
@@ -1,5 +1,4 @@
 //go:build rqlite
-// +build rqlite
 
 package cli
 

--- a/internal/cli/build_snowflake.go
+++ b/internal/cli/build_snowflake.go
@@ -1,5 +1,4 @@
 //go:build snowflake
-// +build snowflake
 
 package cli
 

--- a/internal/cli/build_spanner.go
+++ b/internal/cli/build_spanner.go
@@ -1,5 +1,4 @@
 //go:build spanner
-// +build spanner
 
 package cli
 

--- a/internal/cli/build_sqlcipher.go
+++ b/internal/cli/build_sqlcipher.go
@@ -1,5 +1,4 @@
 //go:build sqlcipher
-// +build sqlcipher
 
 package cli
 

--- a/internal/cli/build_sqlite.go
+++ b/internal/cli/build_sqlite.go
@@ -1,5 +1,4 @@
 //go:build sqlite
-// +build sqlite
 
 package cli
 

--- a/internal/cli/build_sqlite3.go
+++ b/internal/cli/build_sqlite3.go
@@ -1,5 +1,4 @@
 //go:build sqlite3
-// +build sqlite3
 
 package cli
 

--- a/internal/cli/build_sqlserver.go
+++ b/internal/cli/build_sqlserver.go
@@ -1,5 +1,4 @@
 //go:build sqlserver
-// +build sqlserver
 
 package cli
 

--- a/internal/cli/build_yugabytedb.go
+++ b/internal/cli/build_yugabytedb.go
@@ -1,5 +1,4 @@
 //go:build yugabytedb
-// +build yugabytedb
 
 package cli
 

--- a/source/iofs/example_test.go
+++ b/source/iofs/example_test.go
@@ -1,5 +1,4 @@
 //go:build go1.16
-// +build go1.16
 
 package iofs_test
 

--- a/source/iofs/iofs.go
+++ b/source/iofs/iofs.go
@@ -1,5 +1,4 @@
 //go:build go1.16
-// +build go1.16
 
 package iofs
 

--- a/source/iofs/iofs_test.go
+++ b/source/iofs/iofs_test.go
@@ -1,5 +1,4 @@
 //go:build go1.16
-// +build go1.16
 
 package iofs_test
 


### PR DESCRIPTION
This PR removes outdated in Go 1.22 `// +build` comments by running the command:
```
go fix -fix buildtag ./...
```

Additionally, enables [`revive.redundant-build-tag`](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#redundant-build-tag) to detect redundant build tags in the future. This rule introduced by the newest golangci-lint, so I need to update it's version as well.

From https://pkg.go.dev/cmd/go#hdr-Build_constraints:

> Go versions 1.16 and earlier used a different syntax for build constraints, with a "// +build" prefix. The gofmt command will add an equivalent //go:build constraint when encountering the older syntax.