### PR TITLE
Add no lock parameter for Postgres

### DIFF
--- a/database/postgres/README.md
+++ b/database/postgres/README.md
@@ -9,6 +9,7 @@
 | `x-statement-timeout` | `StatementTimeout` | Abort any statement that takes more than the specified number of milliseconds |
 | `x-multi-statement` | `MultiStatementEnabled` | Enable multi-statement execution (default: false) |
 | `x-multi-statement-max-size` | `MultiStatementMaxSize` | Maximum size of single statement in bytes (default: 10MB) |
+| `x-no-lock` | `NoLock` | Prevent acquiring advisory lock (default: false) |
 | `dbname` | `DatabaseName` | The name of the database to connect to |
 | `search_path` | | This variable specifies the order in which schemas are searched when an object is referenced by a simple name with no schema specified. |
 | `user` | | The user to sign in as |

--- a/database/postgres/postgres_test.go
+++ b/database/postgres/postgres_test.go
@@ -668,6 +668,57 @@ func testPostgresLock(t *testing.T) {
 	})
 }
 
+func TestNoLockParamValidation(t *testing.T) {
+	ip := "127.0.0.1"
+	port := 5432
+	addr := fmt.Sprintf("postgres://root:root@%v:%v/public", ip, port)
+	p := &Postgres{}
+	_, err := p.Open(addr + "?x-no-lock=not-a-bool")
+	if !errors.Is(err, strconv.ErrSyntax) {
+		t.Fatal("Expected syntax error when passing a non-bool as x-no-lock parameter")
+	}
+}
+
+func TestNoLockWorks(t *testing.T) {
+	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ip, port, err := c.FirstPort()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		addr := pgConnectionString(ip, port)
+		p := &Postgres{}
+		d, err := p.Open(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		lock := d.(*Postgres)
+
+		p = &Postgres{}
+		d, err = p.Open(addr + "&x-no-lock=true")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		noLock := d.(*Postgres)
+
+		// Should be possible to take real lock and no-lock at the same time
+		if err = lock.Lock(); err != nil {
+			t.Fatal(err)
+		}
+		if err = noLock.Lock(); err != nil {
+			t.Fatal(err)
+		}
+		if err = lock.Unlock(); err != nil {
+			t.Fatal(err)
+		}
+		if err = noLock.Unlock(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
 func testWithInstanceConcurrent(t *testing.T) {
 	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
 		ip, port, err := c.FirstPort()


### PR DESCRIPTION
Essentially a copy of Mysql no-lock parameter, but for Postgres.
Opened issue addressing this: https://github.com/golang-migrate/migrate/issues/1001

Most changes were found in abandoned PR: https://github.com/golang-migrate/migrate/pull/1030