### PR TITLE
Redact passwords

### DIFF
--- a/database/error_test.go
+++ b/database/error_test.go
@@ -1,0 +1,71 @@
+package database
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestRedactPassword(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    error
+		expected string
+	}{
+		{
+			name:     "quoted password in key-value format",
+			input:    errors.New("connection failed: password='secret123' invalid"),
+			expected: "connection failed: password=xxxxx invalid",
+		},
+		{
+			name:     "plain password in key-value format",
+			input:    errors.New("connection failed: password=secret123 invalid"),
+			expected: "connection failed: password=xxxxx invalid",
+		},
+		{
+			name:     "password in URL format",
+			input:    errors.New("connection failed: postgres://user:secret123@localhost/db"),
+			expected: "connection failed: postgres://user:xxxxxx@localhost/db",
+		},
+		{
+			name:     "multiple password formats",
+			input:    errors.New("connection failed: password='secret' and url postgres://user:pass@host"),
+			expected: "connection failed: password=xxxxx and url postgres://user:xxxxxx@host",
+		},
+		{
+			name:     "no password in error",
+			input:    errors.New("connection failed: invalid host"),
+			expected: "connection failed: invalid host",
+		},
+		{
+			name:     "empty error",
+			input:    errors.New(""),
+			expected: "",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := RedactPassword(tc.input)
+			if result.Error() != tc.expected {
+				t.Errorf("Expected %q, got %q", tc.expected, result.Error())
+			}
+		})
+	}
+}
+
+type SpecialError struct {
+	msg string
+}
+
+func (e SpecialError) Error() string {
+	return e.msg
+}
+
+func TestRedactPasswordPreservesOriginalWhenNoPassword(t *testing.T) {
+	originalErr := SpecialError{msg: "no password here"}
+	result := RedactPassword(originalErr)
+
+	if !errors.Is(result, originalErr) {
+		t.Error("Expected original error to be returned when no password found")
+	}
+}

--- a/migrate.go
+++ b/migrate.go
@@ -107,7 +107,7 @@ func New(sourceURL, databaseURL string) (*Migrate, error) {
 
 	databaseDrv, err := database.Open(databaseURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open database: %w", err)
+		return nil, fmt.Errorf("failed to open database: %w", database.RedactPassword(err))
 	}
 	m.databaseDrv = databaseDrv
 


### PR DESCRIPTION
Found the following problem today with this package:

When sending an invalid URL as a database URL to the package, the entire URL, including any kind of secrets, is included in the errors.

I made the following change to address this. Let me know what you think 👍

It was mentioned [here](https://github.com/golang-migrate/migrate/issues/1278) and [here](https://github.com/golang-migrate/migrate/issues/1242) too.