### PR TITLE
Bump golang version to 1.24.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golang-migrate/migrate/v4
 
-go 1.23.0
+go 1.24.4
 
 require (
 	cloud.google.com/go/spanner v1.56.0


### PR DESCRIPTION
Remove vulnerabilities in [v4.18.3](https://github.com/golang-migrate/migrate/releases/tag/v4.18.3) related to Go stdlib. 