### PR TITLE
Rename databaseName to databaseDriverName

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -56,10 +56,10 @@ func (e ErrDirty) Error() string {
 }
 
 type Migrate struct {
-	sourceName   string
-	sourceDrv    source.Driver
-	databaseName string
-	databaseDrv  database.Driver
+	sourceName         string
+	sourceDrv          source.Driver
+	databaseDriverName string
+	databaseDrv        database.Driver
 
 	// Log accepts a Logger interface
 	Log Logger
@@ -93,11 +93,11 @@ func New(sourceURL, databaseURL string) (*Migrate, error) {
 	}
 	m.sourceName = sourceName
 
-	databaseName, err := iurl.SchemeFromURL(databaseURL)
+	databaseDriverName, err := iurl.SchemeFromURL(databaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse scheme from database URL: %w", err)
 	}
-	m.databaseName = databaseName
+	m.databaseDriverName = databaseDriverName
 
 	sourceDrv, err := source.Open(sourceURL)
 	if err != nil {
@@ -116,9 +116,9 @@ func New(sourceURL, databaseURL string) (*Migrate, error) {
 
 // NewWithDatabaseInstance returns a new Migrate instance from a source URL
 // and an existing database instance. The source URL scheme is defined by each driver.
-// Use any string that can serve as an identifier during logging as databaseName.
+// Use any string that can serve as an identifier during logging as databaseDriverName.
 // You are responsible for closing the underlying database client if necessary.
-func NewWithDatabaseInstance(sourceURL string, databaseName string, databaseInstance database.Driver) (*Migrate, error) {
+func NewWithDatabaseInstance(sourceURL string, databaseDriverName string, databaseInstance database.Driver) (*Migrate, error) {
 	m := newCommon()
 
 	sourceName, err := iurl.SchemeFromURL(sourceURL)
@@ -127,7 +127,7 @@ func NewWithDatabaseInstance(sourceURL string, databaseName string, databaseInst
 	}
 	m.sourceName = sourceName
 
-	m.databaseName = databaseName
+	m.databaseDriverName = databaseDriverName
 
 	sourceDrv, err := source.Open(sourceURL)
 	if err != nil {
@@ -147,11 +147,11 @@ func NewWithDatabaseInstance(sourceURL string, databaseName string, databaseInst
 func NewWithSourceInstance(sourceName string, sourceInstance source.Driver, databaseURL string) (*Migrate, error) {
 	m := newCommon()
 
-	databaseName, err := iurl.SchemeFromURL(databaseURL)
+	databaseDriverName, err := iurl.SchemeFromURL(databaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse scheme from database URL: %w", err)
 	}
-	m.databaseName = databaseName
+	m.databaseDriverName = databaseDriverName
 
 	m.sourceName = sourceName
 
@@ -168,13 +168,13 @@ func NewWithSourceInstance(sourceName string, sourceInstance source.Driver, data
 
 // NewWithInstance returns a new Migrate instance from an existing source and
 // database instance. Use any string that can serve as an identifier during logging
-// as sourceName and databaseName. You are responsible for closing down
+// as sourceName and databaseDriverName. You are responsible for closing down
 // the underlying source and database client if necessary.
-func NewWithInstance(sourceName string, sourceInstance source.Driver, databaseName string, databaseInstance database.Driver) (*Migrate, error) {
+func NewWithInstance(sourceName string, sourceInstance source.Driver, databaseDriverName string, databaseInstance database.Driver) (*Migrate, error) {
 	m := newCommon()
 
 	m.sourceName = sourceName
-	m.databaseName = databaseName
+	m.databaseDriverName = databaseDriverName
 
 	m.sourceDrv = sourceInstance
 	m.databaseDrv = databaseInstance

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -54,8 +54,8 @@ func TestNew(t *testing.T) {
 		t.Error("expected sourceDrv not to be nil")
 	}
 
-	if m.databaseName != dbDrvNameStub {
-		t.Errorf("expected stub, got %v", m.databaseName)
+	if m.databaseDriverName != dbDrvNameStub {
+		t.Errorf("expected stub, got %v", m.databaseDriverName)
 	}
 	if m.databaseDrv == nil {
 		t.Error("expected databaseDrv not to be nil")
@@ -94,8 +94,8 @@ func TestNewWithDatabaseInstance(t *testing.T) {
 		t.Error("expected sourceDrv not to be nil")
 	}
 
-	if m.databaseName != dbDrvNameStub {
-		t.Errorf("expected stub, got %v", m.databaseName)
+	if m.databaseDriverName != dbDrvNameStub {
+		t.Errorf("expected stub, got %v", m.databaseDriverName)
 	}
 	if m.databaseDrv == nil {
 		t.Error("expected databaseDrv not to be nil")
@@ -153,8 +153,8 @@ func TestNewWithSourceInstance(t *testing.T) {
 		t.Error("expected sourceDrv not to be nil")
 	}
 
-	if m.databaseName != dbDrvNameStub {
-		t.Errorf("expected stub, got %v", m.databaseName)
+	if m.databaseDriverName != dbDrvNameStub {
+		t.Errorf("expected stub, got %v", m.databaseDriverName)
 	}
 	if m.databaseDrv == nil {
 		t.Error("expected databaseDrv not to be nil")
@@ -209,8 +209,8 @@ func TestNewWithInstance(t *testing.T) {
 		t.Error("expected sourceDrv not to be nil")
 	}
 
-	if m.databaseName != dbDrvNameStub {
-		t.Errorf("expected stub, got %v", m.databaseName)
+	if m.databaseDriverName != dbDrvNameStub {
+		t.Errorf("expected stub, got %v", m.databaseDriverName)
 	}
 	if m.databaseDrv == nil {
 		t.Error("expected databaseDrv not to be nil")


### PR DESCRIPTION
What

Rename parameter `databaseName` to `databaseDriverName` in `NewWithInstance`, `NewWithDatabaseInstance` functions and in the `migrate object` to clarify its purpose.

Why

The current name, `databaseName`, may confuse users into thinking it refers to the _actual name of their database_ (e.g. "bank", "test_db"), when in reality it refers to the **database driver name** (e.g. "postgres", "mysql").

This change improves readability and aligns with the `sourceName` parameter, which correctly indicates that it's the name of the source driver.