### PR TITLE
Update docker image to use go 1.25, addressing vulnerabilities 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine3.21 AS builder
+FROM golang:1.25-alpine3.21 AS builder
 ARG VERSION
 
 RUN apk add --no-cache git gcc musl-dev make


### PR DESCRIPTION
Addresses: 
https://github.com/golang-migrate/migrate/issues/1332
https://github.com/golang-migrate/migrate/issues/1327

From local build and trivy check after this change:
```

Report Summary

┌──────────────────────────────┬──────────┬─────────────────┬─────────┐
│            Target            │   Type   │ Vulnerabilities │ Secrets │
├──────────────────────────────┼──────────┼─────────────────┼─────────┤
│ 71a588e905d0 (alpine 3.21.5) │  alpine  │        0        │    -    │
├──────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/migrate        │ gobinary │        0        │    -    │
└──────────────────────────────┴──────────┴─────────────────┴─────────┘
```