### PR TITLE
Update docker base image to alpine 3.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine3.21 AS builder
+FROM golang:1.25-alpine3.23 AS builder
 ARG VERSION
 
 RUN apk add --no-cache git gcc musl-dev make
@@ -15,7 +15,7 @@ COPY . ./
 
 RUN make build-docker
 
-FROM alpine:3.21
+FROM alpine:3.23
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
Alpine 3.23 is out and stable!
This removes some outstanding Medium/Low CVEs on the Docker image for migrate. 

Previous Trivy scan results:
```
Report Summary

┌─────────────────────────────────┬──────────┬─────────────────┬─────────┐
│             Target              │   Type   │ Vulnerabilities │ Secrets │
├─────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ 56dd845b88fa2f2 (alpine 3.21.5) │  alpine  │        6        │    -    │
├─────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/migrate           │ gobinary │        2        │    -    │
└─────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


56dd845b88fa2f2 (alpine 3.21.5)

Total: 6 (UNKNOWN: 0, LOW: 3, MEDIUM: 3, HIGH: 0, CRITICAL: 0)

┌───────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│    Library    │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                             │
├───────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ busybox       │ CVE-2024-58251 │ MEDIUM   │ fixed  │ 1.37.0-r13        │ 1.37.0-r14    │ In netstat in BusyBox through 1.37.0, local users can launch │
│               │                │          │        │                   │               │ of networ...                                                 │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-58251                   │
│               ├────────────────┼──────────┤        │                   │               ├──────────────────────────────────────────────────────────────┤
│               │ CVE-2025-46394 │ LOW      │        │                   │               │ In tar in BusyBox through 1.37.0, a TAR archive can have     │
│               │                │          │        │                   │               │ filenames...                                                 │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-46394                   │
├───────────────┼────────────────┼──────────┤        │                   │               ├──────────────────────────────────────────────────────────────┤
│ busybox-binsh │ CVE-2024-58251 │ MEDIUM   │        │                   │               │ In netstat in BusyBox through 1.37.0, local users can launch │
│               │                │          │        │                   │               │ of networ...                                                 │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-58251                   │
│               ├────────────────┼──────────┤        │                   │               ├──────────────────────────────────────────────────────────────┤
│               │ CVE-2025-46394 │ LOW      │        │                   │               │ In tar in BusyBox through 1.37.0, a TAR archive can have     │
│               │                │          │        │                   │               │ filenames...                                                 │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-46394                   │
├───────────────┼────────────────┼──────────┤        │                   │               ├──────────────────────────────────────────────────────────────┤
│ ssl_client    │ CVE-2024-58251 │ MEDIUM   │        │                   │               │ In netstat in BusyBox through 1.37.0, local users can launch │
│               │                │          │        │                   │               │ of networ...                                                 │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-58251                   │
│               ├────────────────┼──────────┤        │                   │               ├──────────────────────────────────────────────────────────────┤
│               │ CVE-2025-46394 │ LOW      │        │                   │               │ In tar in BusyBox through 1.37.0, a TAR archive can have     │
│               │                │          │        │                   │               │ filenames...                                                 │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-46394                   │
└───────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────────────┘

usr/local/bin/migrate (gobinary)

Total: 2 (UNKNOWN: 0, LOW: 0, MEDIUM: 2, HIGH: 0, CRITICAL: 0)

┌─────────────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────────┐
│       Library       │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                           │
├─────────────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ golang.org/x/crypto │ CVE-2025-47914 │ MEDIUM   │ fixed  │ v0.36.0           │ 0.45.0        │ golang.org/x/crypto/ssh/agent: in                         │
│                     │                │          │        │                   │               │ golang.org/x/crypto/ssh/agent                             │
│                     │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-47914                │
│                     ├────────────────┤          │        │                   │               ├───────────────────────────────────────────────────────────┤
│                     │ CVE-2025-58181 │          │        │                   │               │ SSH servers parsing GSSAPI authentication requests do not │
│                     │                │          │        │                   │               │ validate the ...                                          │
│                     │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-58181                │
└─────────────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────────────┘


```

Post-upgrade Trivy scan results:
```
Report Summary

┌──────────────────────────────────┬──────────┬─────────────────┬─────────┐
│              Target              │   Type   │ Vulnerabilities │ Secrets │
├──────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ 66c850a349926a26 (alpine 3.23.2) │  alpine  │        0        │    -    │
├──────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/migrate            │ gobinary │        2        │    -    │
└──────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


usr/local/bin/migrate (gobinary)

Total: 2 (UNKNOWN: 0, LOW: 0, MEDIUM: 2, HIGH: 0, CRITICAL: 0)

┌─────────────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────────┐
│       Library       │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                           │
├─────────────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ golang.org/x/crypto │ CVE-2025-47914 │ MEDIUM   │ fixed  │ v0.36.0           │ 0.45.0        │ golang.org/x/crypto/ssh/agent: in                         │
│                     │                │          │        │                   │               │ golang.org/x/crypto/ssh/agent                             │
│                     │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-47914                │
│                     ├────────────────┤          │        │                   │               ├───────────────────────────────────────────────────────────┤
│                     │ CVE-2025-58181 │          │        │                   │               │ SSH servers parsing GSSAPI authentication requests do not │
│                     │                │          │        │                   │               │ validate the ...                                          │
│                     │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-58181                │
└─────────────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────────────┘

```