### PR TITLE
docs: add sslnegotiation parameter for PostgreSQL 17 support

### DIFF
--- a/database/pgx/v5/README.md
+++ b/database/pgx/v5/README.md
@@ -23,6 +23,7 @@ This package is for [pgx/v5](https://pkg.go.dev/github.com/jackc/pgx/v5). A back
 | `sslkey` | | Key file location. The file must contain PEM encoded data. |
 | `sslrootcert` | | The location of the root certificate file. The file must contain PEM encoded data. |
 | `sslmode` | | Whether or not to use SSL (disable\|require\|verify-ca\|verify-full) |
+| `sslnegotiation` | | How to negotiate SSL (postgres\|direct). Use `direct` to skip PostgreSQL's SSL negotiation and go directly to TLS handshake. Requires PostgreSQL 17+ or a proxy that supports direct SSL. (default: postgres) |
 
 
 ## Upgrading from v1

--- a/database/postgres/README.md
+++ b/database/postgres/README.md
@@ -21,6 +21,7 @@
 | `sslkey` | | Key file location. The file must contain PEM encoded data. |
 | `sslrootcert` | | The location of the root certificate file. The file must contain PEM encoded data. | 
 | `sslmode` | | Whether or not to use SSL (disable\|require\|verify-ca\|verify-full) |
+| `sslnegotiation` | | How to negotiate SSL (postgres\|direct). Use `direct` to skip PostgreSQL's SSL negotiation and go directly to TLS handshake. Requires PostgreSQL 17+ or a proxy that supports direct SSL. (default: postgres) |
 
 
 ## Upgrading from v1


### PR DESCRIPTION
Fixes #1347

## Changes
- Document sslnegotiation parameter in pgx/v5 README
- Document sslnegotiation parameter in postgres README

The underlying drivers (pgx/v5 v5.7.6 and lib/pq v1.10.9) already support the sslnegotiation parameter. This PR adds documentation to inform users that they can use sslnegotiation=direct for PostgreSQL 17+ or proxies that support direct SSL.