### PR TITLE
Upgrade Golang base image to 1.25.5 to fix crypto/x509 security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine3.21 AS builder
+FROM golang:1.25.5-alpine3.21 AS builder
 ARG VERSION
 
 RUN apk add --no-cache git gcc musl-dev make


### PR DESCRIPTION
**Updated Dockerfile builder image:** #1351 

- Before: golang:1.25-alpine3.21
- After: golang:1.25.5-alpine3.21

No application code changes required
Runtime image remains unchanged