### PR TITLE
fix: don't leak conn when returning error in pgxv5.WithInstance() fixes #1366

### DIFF
--- a/database/pgx/v5/pgx.go
+++ b/database/pgx/v5/pgx.go
@@ -130,6 +130,8 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 	}
 
 	if err := px.ensureVersionTable(); err != nil {
+		conn.Close()
+
 		return nil, err
 	}
 

--- a/database/pgx/v5/pgx.go
+++ b/database/pgx/v5/pgx.go
@@ -130,7 +130,9 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 	}
 
 	if err := px.ensureVersionTable(); err != nil {
-		conn.Close()
+		if errC := conn.Close(); err != nil {
+			err = errors.Join(err, errC)
+		}
 
 		return nil, err
 	}


### PR DESCRIPTION
fixing https://github.com/golang-migrate/migrate/issues/1366 leaked conn when error return in pgx/v5.WithInstance()