### PR TITLE
fix: bump alpine in Dockerfile.github-actions from 3.19 to 3.21

### DIFF
--- a/Dockerfile.github-actions
+++ b/Dockerfile.github-actions
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM alpine:3.21
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
Syncs with the main Dockerfile which already uses alpine:3.21. Fixes #1362