### PR TITLE
fix: handle host query parameter for unix socket connections

### DIFF
--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -155,7 +155,22 @@ func (p *Postgres) Open(url string) (database.Driver, error) {
 		return nil, err
 	}
 
-	db, err := sql.Open("postgres", migrate.FilterCustomQuery(purl).String())
+	filteredURL := migrate.FilterCustomQuery(purl)
+	connStr := filteredURL.String()
+
+	// When host is specified as a query parameter (e.g., for unix socket
+	// connections via ?host=/var/run/postgresql) and the URL has no host in
+	// the authority section, convert to a key-value connection string so
+	// lib/pq reliably uses the host parameter. Without this, the driver
+	// may silently connect to localhost:5432 instead of the specified host.
+	if purl.Host == "" && purl.Query().Get("host") != "" {
+		connStr, err = pq.ParseURL(connStr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	db, err := sql.Open("postgres", connStr)
 	if err != nil {
 		return nil, err
 	}

--- a/database/postgres/postgres_test.go
+++ b/database/postgres/postgres_test.go
@@ -91,6 +91,7 @@ func Test(t *testing.T) {
 	t.Run("testMultipleStatementsInMultiStatementMode", testMultipleStatementsInMultiStatementMode)
 	t.Run("testErrorParsing", testErrorParsing)
 	t.Run("testFilterCustomQuery", testFilterCustomQuery)
+	t.Run("testHostQueryParam", testHostQueryParam)
 	t.Run("testWithSchema", testWithSchema)
 	t.Run("testMigrationTableOption", testMigrationTableOption)
 	t.Run("testFailToCreateTableWithoutPermissions", testFailToCreateTableWithoutPermissions)
@@ -272,6 +273,32 @@ func testFilterCustomQuery(t *testing.T) {
 				t.Error(err)
 			}
 		}()
+	})
+}
+
+func testHostQueryParam(t *testing.T) {
+	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ip, port, err := c.FirstPort()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Test that host specified as a query parameter (instead of in the URL
+		// authority) is correctly used for the connection. This is the pattern
+		// used for unix socket connections: postgres:///db?host=/var/run/postgresql
+		addr := fmt.Sprintf("postgres://postgres:%s@/postgres?host=%s&port=%s&sslmode=disable",
+			pgPassword, ip, port)
+		p := &Postgres{}
+		d, err := p.Open(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := d.Close(); err != nil {
+				t.Error(err)
+			}
+		}()
+		dt.Test(t, d, []byte("SELECT 1"))
 	})
 }
 


### PR DESCRIPTION
## Summary
- When `host` is specified as a query parameter (e.g., `?host=/var/run/postgresql` for unix socket connections) and the URL has no host in the authority section, `lib/pq` silently connects to `localhost:5432` instead of the specified socket path
- This converts to a key-value connection string when a query-param host is detected so `lib/pq` reliably uses it
- Adds test coverage for the host-as-query-param pattern

## Test plan
- [x] Added `testHostQueryParam` test that connects using `postgres:///db?host=<ip>&port=<port>` format
- [ ] Existing postgres driver tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)