### PR TITLE
fix(mysql): correct error message for x-statement-timeout parsing

### DIFF
--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -247,7 +247,7 @@ func (m *Mysql) Open(url string) (database.Driver, error) {
 	if statementTimeoutParam != "" {
 		statementTimeout, err = strconv.Atoi(statementTimeoutParam)
 		if err != nil {
-			return nil, fmt.Errorf("could not parse x-statement-timeout as float: %w", err)
+			return nil, fmt.Errorf("could not parse x-statement-timeout as integer: %w", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fix incorrect error message for `x-statement-timeout` parsing.

## Problem

`strconv.Atoi` is used to parse `x-statement-timeout`, but the error message incorrectly referred to the value as `float`.

```go
// Before
return nil, fmt.Errorf("could not parse x-statement-timeout as float: %w", err)
```

## Fix

```go
// After
return nil, fmt.Errorf("could not parse x-statement-timeout as integer: %w", err)
```

## Notes

- Logic is unchanged
- No tests required as this is a string-only fix