### PR TITLE
test: update PostgreSQL test matrix

### DIFF
--- a/database/pgx/pgx_test.go
+++ b/database/pgx/pgx_test.go
@@ -39,6 +39,7 @@ var (
 		{ImageName: "postgres:15", Options: opts},
 		{ImageName: "postgres:16", Options: opts},
 		{ImageName: "postgres:17", Options: opts},
+		{ImageName: "postgres:18", Options: opts},
 	}
 )
 

--- a/database/pgx/pgx_test.go
+++ b/database/pgx/pgx_test.go
@@ -34,7 +34,6 @@ var (
 		PortRequired: true, ReadyFunc: isReady}
 	// Supported versions: https://www.postgresql.org/support/versioning/
 	specs = []dktesting.ContainerSpec{
-		{ImageName: "postgres:13", Options: opts},
 		{ImageName: "postgres:14", Options: opts},
 		{ImageName: "postgres:15", Options: opts},
 		{ImageName: "postgres:16", Options: opts},

--- a/database/pgx/v5/pgx_test.go
+++ b/database/pgx/v5/pgx_test.go
@@ -40,6 +40,7 @@ var (
 		{ImageName: "postgres:15", Options: opts},
 		{ImageName: "postgres:16", Options: opts},
 		{ImageName: "postgres:17", Options: opts},
+		{ImageName: "postgres:18", Options: opts},
 	}
 )
 

--- a/database/pgx/v5/pgx_test.go
+++ b/database/pgx/v5/pgx_test.go
@@ -35,7 +35,6 @@ var (
 		PortRequired: true, ReadyFunc: isReady}
 	// Supported versions: https://www.postgresql.org/support/versioning/
 	specs = []dktesting.ContainerSpec{
-		{ImageName: "postgres:13", Options: opts},
 		{ImageName: "postgres:14", Options: opts},
 		{ImageName: "postgres:15", Options: opts},
 		{ImageName: "postgres:16", Options: opts},

--- a/database/postgres/postgres_test.go
+++ b/database/postgres/postgres_test.go
@@ -40,6 +40,7 @@ var (
 		{ImageName: "postgres:15", Options: opts},
 		{ImageName: "postgres:16", Options: opts},
 		{ImageName: "postgres:17", Options: opts},
+		{ImageName: "postgres:18", Options: opts},
 	}
 )
 

--- a/database/postgres/postgres_test.go
+++ b/database/postgres/postgres_test.go
@@ -35,7 +35,6 @@ var (
 		PortRequired: true, ReadyFunc: isReady}
 	// Supported versions: https://www.postgresql.org/support/versioning/
 	specs = []dktesting.ContainerSpec{
-		{ImageName: "postgres:13", Options: opts},
 		{ImageName: "postgres:14", Options: opts},
 		{ImageName: "postgres:15", Options: opts},
 		{ImageName: "postgres:16", Options: opts},


### PR DESCRIPTION
Remove PostgreSQL 13 from and add PostgreSQL 18 to test matrix.

https://www.postgresql.org/support/versioning/