### PR TITLE
fix: Postgres Drop() also removes custom enum types

### DIFF
--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -444,6 +444,32 @@ func (p *Postgres) Drop() (err error) {
 		}
 	}
 
+	// Drop all custom enum types in current schema
+	query = `SELECT typname FROM pg_type t JOIN pg_namespace n ON t.typnamespace = n.oid WHERE n.nspname = (SELECT current_schema()) AND t.typtype = 'e'`
+	types, err := p.conn.QueryContext(context.Background(), query)
+	if err != nil {
+		return &database.Error{OrigErr: err, Query: []byte(query)}
+	}
+	defer func() {
+		if errClose := types.Close(); errClose != nil {
+			err = errors.Join(err, errClose)
+		}
+	}()
+
+	for types.Next() {
+		var typeName string
+		if err := types.Scan(&typeName); err != nil {
+			return err
+		}
+		query = `DROP TYPE IF EXISTS ` + pq.QuoteIdentifier(typeName) + ` CASCADE`
+		if _, err := p.conn.ExecContext(context.Background(), query); err != nil {
+			return &database.Error{OrigErr: err, Query: []byte(query)}
+		}
+	}
+	if err := types.Err(); err != nil {
+		return &database.Error{OrigErr: err, Query: []byte(query)}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Fixes #626

## Problem

`Drop()` only drops tables but leaves custom types (enums, etc.) behind. When a migration creates a custom type:

```sql
CREATE TYPE mytype AS ENUM('a', 'b');
```

Running `Drop()` followed by `Up()` fails:
```
pq: type "mytype" already exists
```

## Fix

After dropping tables, query `pg_type` for enum types (`typtype = 'e'`) in the current schema and drop them with `CASCADE`. This follows the same pattern used for table dropping (iterate + `DROP IF EXISTS`).

Previous PR #477 was closed without merge. This implementation uses a simpler approach querying `pg_type` directly.