### PR TITLE
postgres/pgx: don't leak the conn from WithInstance when init fails

### DIFF
--- a/database/pgx/pgx.go
+++ b/database/pgx/pgx.go
@@ -150,10 +150,12 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 	}
 
 	if err := px.ensureLockTable(); err != nil {
+		_ = conn.Close()
 		return nil, err
 	}
 
 	if err := px.ensureVersionTable(); err != nil {
+		_ = conn.Close()
 		return nil, err
 	}
 

--- a/database/pgx/v5/pgx.go
+++ b/database/pgx/v5/pgx.go
@@ -130,6 +130,9 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 	}
 
 	if err := px.ensureVersionTable(); err != nil {
+		// Release the connection back to the pool so we don't leak
+		// it when WithInstance returns the error.
+		_ = conn.Close()
 		return nil, err
 	}
 

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -143,6 +143,7 @@ func WithInstance(instance *sql.DB, config *Config) (database.Driver, error) {
 
 	px, err := WithConnection(ctx, conn, config)
 	if err != nil {
+		_ = conn.Close()
 		return nil, err
 	}
 	px.db = instance


### PR DESCRIPTION
Fixes #1366.

\`WithInstance\` pulls a connection out of the \`*sql.DB\` pool and then runs \`ensureLockTable\` / \`ensureVersionTable\`. If either of those fails the connection was never returned to the pool, so a caller that retried (or just expected \`WithInstance\` failures to be recoverable) leaked one conn per attempt until the pool ran out.

\`Close\` the conn on every error path between \`Conn()\` and a successful return. Same fix applied to \`database/postgres\`, \`database/pgx\`, and \`database/pgx/v5\` since they all share the pattern.