### PR TITLE
fix: clearer error when the migrations source has no files

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -32,6 +32,10 @@ var (
 	ErrInvalidVersion = errors.New("version must be >= -1")
 	ErrLocked         = errors.New("database locked")
 	ErrLockTimeout    = errors.New("timeout: can't acquire database lock")
+	// ErrNoMigrationFiles is returned when the source contains no migration
+	// files, which usually means the source path is wrong or the directory is
+	// empty. It wraps os.ErrNotExist for backwards compatibility.
+	ErrNoMigrationFiles = fmt.Errorf("no migration files found in source: %w", os.ErrNotExist)
 )
 
 // ErrShortLimit is an error returned when not enough migrations
@@ -428,7 +432,11 @@ func (m *Migrate) read(from int, to int, ret chan<- interface{}) {
 		if from == -1 {
 			firstVersion, err := m.sourceDrv.First()
 			if err != nil {
-				ret <- err
+				if errors.Is(err, os.ErrNotExist) {
+					ret <- ErrNoMigrationFiles
+				} else {
+					ret <- err
+				}
 				return
 			}
 
@@ -555,7 +563,11 @@ func (m *Migrate) readUp(from int, limit int, ret chan<- interface{}) {
 		if from == -1 {
 			firstVersion, err := m.sourceDrv.First()
 			if err != nil {
-				ret <- err
+				if errors.Is(err, os.ErrNotExist) {
+					ret <- ErrNoMigrationFiles
+				} else {
+					ret <- err
+				}
 				return
 			}
 

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -232,6 +232,24 @@ func TestClose(t *testing.T) {
 	}
 }
 
+func TestUpWithNoMigrationFiles(t *testing.T) {
+	// A fresh database with an empty source used to fail with the cryptic
+	// "first .: file does not exist". It should now report that no migration
+	// files were found, while still satisfying errors.Is(os.ErrNotExist).
+	m, err := New("stub://", "stub://")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = m.Up()
+	if !errors.Is(err, ErrNoMigrationFiles) {
+		t.Fatalf("expected ErrNoMigrationFiles, got %v", err)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected error to wrap os.ErrNotExist, got %v", err)
+	}
+}
+
 func TestMigrate(t *testing.T) {
 	m, _ := New("stub://", "stub://")
 	m.sourceDrv.(*sStub.Stub).Migrations = sourceStubMigrations


### PR DESCRIPTION
Closes #1314.

An empty or mistyped migrations directory currently fails with `first .: file does not exist`, which gives no hint about the real cause. This returns a new `ErrNoMigrationFiles` instead. It still wraps `os.ErrNotExist`, so existing `errors.Is` checks keep working.

The same cryptic error came up via `Up()` and `Migrate()`/`Steps()` since they share the code path, so both are covered. Added a test.