### PR TITLE
fix: decode percent-encoded path in sqlite database URL

### DIFF
--- a/database/sqlite/sqlite.go
+++ b/database/sqlite/sqlite.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	nurl "net/url"
 	"strconv"
-	"strings"
 	"sync/atomic"
 
 	"github.com/golang-migrate/migrate/v4"
@@ -92,7 +91,14 @@ func (m *Sqlite) Open(url string) (database.Driver, error) {
 	if err != nil {
 		return nil, err
 	}
-	dbfile := strings.Replace(migrate.FilterCustomQuery(purl).String(), "sqlite://", "", 1)
+	// Build the DSN from the decoded path so percent-encoded characters (e.g.
+	// spaces as %20) resolve to the real file name. Using purl.String() here
+	// would re-encode the path and sql.Open would look for a literal "%20".
+	filtered := migrate.FilterCustomQuery(purl)
+	dbfile := filtered.Host + filtered.Path
+	if filtered.RawQuery != "" {
+		dbfile += "?" + filtered.RawQuery
+	}
 	db, err := sql.Open("sqlite", dbfile)
 	if err != nil {
 		return nil, err

--- a/database/sqlite/sqlite_test.go
+++ b/database/sqlite/sqlite_test.go
@@ -3,6 +3,8 @@ package sqlite
 import (
 	"database/sql"
 	"fmt"
+	nurl "net/url"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -22,6 +24,34 @@ func Test(t *testing.T) {
 	d, err := p.Open(addr)
 	if err != nil {
 		t.Fatal(err)
+	}
+	dt.Test(t, d, []byte("CREATE TABLE t (Qty int, Name string);"))
+}
+
+func TestOpenWithPercentEncodedPath(t *testing.T) {
+	// Regression for https://github.com/golang-migrate/migrate/issues/1256:
+	// a percent-encoded path (a space encoded as %20) must resolve to the real
+	// file name instead of a literal "%20".
+	dir := filepath.Join(t.TempDir(), "Magic Data")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(dir, "sqlite.db")
+
+	addr := (&nurl.URL{Scheme: "sqlite", Path: dbPath}).String()
+	p := &Sqlite{}
+	d, err := p.Open(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := d.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Fatalf("expected database file at %q: %v", dbPath, err)
 	}
 	dt.Test(t, d, []byte("CREATE TABLE t (Qty int, Name string);"))
 }


### PR DESCRIPTION
Closes #1256.

The sqlite driver built its DSN from `purl.String()`, which re-encodes the URL path. A database URL like `sqlite:///Magic%20Data/db.sqlite` was passed to `sql.Open` with the `%20` intact, so it looked for a literal `Magic%20Data` file and failed to connect.

Now the DSN is built from the decoded path (still keeping any non-custom query params, e.g. sqlite pragmas). Added a test that opens a DB under a directory with a space in the name.