### PR TITLE
fix(github): upgrade go-github to v89 to remove unmaintained openpgp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/gobuffalo/here v0.6.0
 	github.com/gocql/gocql v0.0.0-20210515062232-b7ef815b4556
-	github.com/google/go-github/v39 v39.2.0
+	github.com/google/go-github/v89 v89.0.0
 	github.com/jackc/pgconn v1.14.3
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v4 v4.18.2
@@ -35,7 +35,6 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/xanzy/go-gitlab v0.15.0
 	go.mongodb.org/mongo-driver v1.7.5
-	golang.org/x/oauth2 v0.34.0
 	golang.org/x/tools/godoc v0.1.0-deprecated
 	google.golang.org/api v0.247.0
 	modernc.org/ql v1.0.0
@@ -76,6 +75,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/trace v1.40.0 // indirect
+	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/telemetry v0.0.0-20251111182119-bc8e575c7b54 // indirect
 	golang.org/x/tools v0.39.0 // indirect
 )
@@ -133,7 +133,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/flatbuffers v2.0.8+incompatible // indirect
-	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -954,13 +954,14 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v39 v39.2.0 h1:rNNM311XtPOz5rDdsJXAp2o8F67X9FnROXTvto3aSnQ=
-github.com/google/go-github/v39 v39.2.0/go.mod h1:C1s8C5aCC9L+JXIYpJM5GYytdX52vC1bLvHEF1IhBrE=
+github.com/google/go-github/v89 v89.0.0 h1:35bEK5XoEcF3PZrlVbl9XN63f5BcJRA/UGkxeC9xPg0=
+github.com/google/go-github/v89 v89.0.0/go.mod h1:QLcbU0ipeAqQuR5KSg8c2lql4Qk1EwJ2dWz/0rP4Nho=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
-github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
-github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
+github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -1413,7 +1414,6 @@ golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220511200225-c6db032c6c88/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/source/github/github.go
+++ b/source/github/github.go
@@ -4,16 +4,13 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/http"
 	nurl "net/url"
 	"os"
 	"path"
 	"strings"
 
-	"golang.org/x/oauth2"
-
 	"github.com/golang-migrate/migrate/v4/source"
-	"github.com/google/go-github/v39/github"
+	"github.com/google/go-github/v89/github"
 )
 
 func init() {
@@ -48,22 +45,22 @@ func (g *Github) Open(url string) (source.Driver, error) {
 		return nil, err
 	}
 
-	// client defaults to http.DefaultClient
-	var client *http.Client
+	var opts []github.ClientOptionsFunc
 	if u.User != nil {
 		password, ok := u.User.Password()
 		if !ok {
 			return nil, ErrNoUserInfo
 		}
-		ts := oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: password},
-		)
-		client = oauth2.NewClient(context.Background(), ts)
+		opts = append(opts, github.WithAuthToken(password))
+	}
 
+	client, err := github.NewClient(opts...)
+	if err != nil {
+		return nil, err
 	}
 
 	gn := &Github{
-		client:     github.NewClient(client),
+		client:     client,
 		migrations: source.NewMigrations(),
 		options:    &github.RepositoryContentGetOptions{Ref: u.Fragment},
 	}

--- a/source/github_ee/github_ee.go
+++ b/source/github_ee/github_ee.go
@@ -11,7 +11,7 @@ import (
 	"github.com/golang-migrate/migrate/v4/source"
 	gh "github.com/golang-migrate/migrate/v4/source/github"
 
-	"github.com/google/go-github/v39/github"
+	"github.com/google/go-github/v89/github"
 )
 
 func init() {
@@ -84,7 +84,10 @@ func (g *GithubEE) createGithubClient(host, username, password string, verifyTLS
 	apiHost := fmt.Sprintf("https://%s/api/v3", host)
 	uploadHost := fmt.Sprintf("https://uploads.%s", host)
 
-	return github.NewEnterpriseClient(apiHost, uploadHost, tr.Client())
+	return github.NewClient(
+		github.WithHTTPClient(tr.Client()),
+		github.WithEnterpriseURLs(apiHost, uploadHost),
+	)
 }
 
 func parseBool(val string, fallback bool) bool {


### PR DESCRIPTION
Fixes #1410.

Bumps the `github` and `github-ee` source drivers from `go-github/v39` to `v89`, which removes `golang.org/x/crypto/openpgp` from the module graph entirely — `go mod why golang.org/x/crypto/openpgp` now reports the package is not needed.

### Worth highlighting

- **This is an API adaptation, not only a version bump.** v89 reworked client construction:
  - `github`: `NewClient(*http.Client)` → options-based `NewClient(...ClientOptionsFunc) (*Client, error)`. The token path now uses `github.WithAuthToken(...)`, dropping the driver's direct `golang.org/x/oauth2` dependency (now indirect via other sources).
  - `github-ee`: `NewEnterpriseClient(base, upload, httpClient)` was removed → `NewClient(WithHTTPClient(...), WithEnterpriseURLs(base, upload))`. URL normalization is equivalent — `parseURL` appends the trailing slash before the `/api/v3/` check, so `https://host/api/v3` still resolves to `/api/v3/`.
- **No behavior or URL-contract change** for `github://` or `github-ee://`; the content API (`GetContents` / `DownloadContents`) is unchanged.
