### PR TITLE
fix(source/aws_s3): paginate ListObjects to load >1000 migrations

### DIFF
--- a/source/aws_s3/s3.go
+++ b/source/aws_s3/s3.go
@@ -76,25 +76,33 @@ func parseURI(uri string) (*Config, error) {
 }
 
 func (s *s3Driver) loadMigrations() error {
-	output, err := s.s3client.ListObjects(&s3.ListObjectsInput{
+	input := &s3.ListObjectsInput{
 		Bucket:    aws.String(s.config.Bucket),
 		Prefix:    aws.String(s.config.Prefix),
 		Delimiter: aws.String("/"),
+	}
+	// ListObjects returns at most 1000 keys per response, so paginate over
+	// every page; otherwise migrations beyond the first 1000 objects are
+	// silently dropped and never applied.
+	var appendErr error
+	err := s.s3client.ListObjectsPages(input, func(output *s3.ListObjectsOutput, _ bool) bool {
+		for _, object := range output.Contents {
+			_, fileName := path.Split(aws.StringValue(object.Key))
+			m, err := source.DefaultParse(fileName)
+			if err != nil {
+				continue
+			}
+			if !s.migrations.Append(m) {
+				appendErr = fmt.Errorf("unable to parse file %v", aws.StringValue(object.Key))
+				return false
+			}
+		}
+		return true
 	})
 	if err != nil {
 		return err
 	}
-	for _, object := range output.Contents {
-		_, fileName := path.Split(aws.StringValue(object.Key))
-		m, err := source.DefaultParse(fileName)
-		if err != nil {
-			continue
-		}
-		if !s.migrations.Append(m) {
-			return fmt.Errorf("unable to parse file %v", aws.StringValue(object.Key))
-		}
-	}
-	return nil
+	return appendErr
 }
 
 func (s *s3Driver) Close() error {

--- a/source/aws_s3/s3_test.go
+++ b/source/aws_s3/s3_test.go
@@ -2,7 +2,9 @@ package awss3
 
 import (
 	"errors"
+	"fmt"
 	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -38,6 +40,64 @@ func Test(t *testing.T) {
 		t.Fatal(err)
 	}
 	st.Test(t, driver)
+}
+
+func TestLoadMigrationsPaginates(t *testing.T) {
+	// A single ListObjects response is capped at 1000 keys by S3. Spread the
+	// migrations across several pages (via pageSize) to ensure loadMigrations
+	// walks every page instead of silently stopping after the first one.
+	const migrationCount = 300
+	objects := make(map[string]string, migrationCount*2)
+	for i := 1; i <= migrationCount; i++ {
+		objects[fmt.Sprintf("prod/migrations/%d_foobar.up.sql", i)] = fmt.Sprintf("%d up", i)
+		objects[fmt.Sprintf("prod/migrations/%d_foobar.down.sql", i)] = fmt.Sprintf("%d down", i)
+	}
+	s3Client := fakeS3{
+		bucket:   "some-bucket",
+		pageSize: 50,
+		objects:  objects,
+	}
+	driver, err := WithInstance(&s3Client, &Config{
+		Bucket: "some-bucket",
+		Prefix: "prod/migrations/",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := driver.First()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, uint(1), first)
+
+	version := first
+	count := 1
+	for {
+		next, err := driver.Next(version)
+		if errors.Is(err, os.ErrNotExist) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		version = next
+		count++
+	}
+	assert.Equal(t, migrationCount, count, "every migration across all pages should be loaded")
+	assert.Equal(t, uint(migrationCount), version, "the highest-numbered migration should be loaded")
+
+	r, identifier, err := driver.ReadUp(uint(migrationCount))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = r.Close() }()
+	assert.Equal(t, "foobar", identifier)
+	body, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, fmt.Sprintf("%d up", migrationCount), string(body))
 }
 
 func TestParseURI(t *testing.T) {
@@ -90,8 +150,11 @@ func TestParseURI(t *testing.T) {
 
 type fakeS3 struct {
 	s3.S3
-	bucket  string
-	objects map[string]string
+	bucket string
+	// pageSize caps how many objects each ListObjectsPages page returns so
+	// tests can exercise the multi-page path; 0 means a single page.
+	pageSize int
+	objects  map[string]string
 }
 
 func (s *fakeS3) ListObjects(input *s3.ListObjectsInput) (*s3.ListObjectsOutput, error) {
@@ -112,6 +175,29 @@ func (s *fakeS3) ListObjects(input *s3.ListObjectsInput) (*s3.ListObjectsOutput,
 		}
 	}
 	return &output, nil
+}
+
+func (s *fakeS3) ListObjectsPages(input *s3.ListObjectsInput, fn func(*s3.ListObjectsOutput, bool) bool) error {
+	output, err := s.ListObjects(input)
+	if err != nil {
+		return err
+	}
+	contents := output.Contents
+	pageSize := s.pageSize
+	if pageSize <= 0 {
+		pageSize = len(contents)
+	}
+	for start := 0; start < len(contents); start += pageSize {
+		end := start + pageSize
+		if end > len(contents) {
+			end = len(contents)
+		}
+		lastPage := end == len(contents)
+		if !fn(&s3.ListObjectsOutput{Contents: contents[start:end]}, lastPage) {
+			break
+		}
+	}
+	return nil
 }
 
 func (s *fakeS3) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {


### PR DESCRIPTION
### What

`source/aws_s3` loads migrations with a single, non-paginated `ListObjects` call:

```go
output, err := s.s3client.ListObjects(&s3.ListObjectsInput{ Bucket, Prefix, Delimiter })
for _, object := range output.Contents { ... } // no IsTruncated / pagination
```

The S3 `ListObjects` API returns **at most 1000 keys** per response and sets `IsTruncated=true` when more exist. The driver never checks `IsTruncated` and never continues past the first page, so any bucket/prefix holding more than 1000 objects has its remaining keys silently dropped from the migration listing.

### Why it matters

A migrations directory with ~500 migrations (an `.up.sql` + `.down.sql` per version = ~1000 files) crosses the 1000-key boundary. Once it does, the highest-numbered migration files are the ones truncated away (they sort last lexicographically). The migrator then never sees the newest migrations: `Up()` returns `ErrNoChange` and callers get a false "database is up to date" while migrations silently fail to apply.

### Fix

Replace the single `ListObjects` call with `ListObjectsPages`, accumulating `Contents` from every page. `ListObjectsPages` is already part of the `s3iface.S3API` interface the driver depends on, so there is no interface or signature change. The diff is minimal — the per-object parsing loop is unchanged, just moved into the page callback, and an append error is propagated out after pagination completes.

### Test

Added `TestLoadMigrationsPaginates`, which registers 300 versions (600 objects) behind a fake S3 client that serves them in 50-object pages, then asserts every version — including the highest-numbered one that falls well beyond the first page — is loaded and readable. The fake gains a `ListObjectsPages` implementation (reusing its existing `ListObjects` filtering) and a `pageSize` knob to force the multi-page path. Before this fix the driver would have only seen the first page.

```
$ go build ./source/aws_s3/... && go vet ./source/aws_s3/... && go test ./source/aws_s3/...
ok  github.com/golang-migrate/migrate/v4/source/aws_s3
```

`golangci-lint run ./source/aws_s3/...` reports 0 issues.
