### PR TITLE
docs: fix getting started link in neo4j tutorial

### DIFF
--- a/database/neo4j/TUTORIAL.md
+++ b/database/neo4j/TUTORIAL.md
@@ -19,7 +19,7 @@ And in the `.down.sql` let's delete it:
 ```
 MATCH (u:User) WHERE u.name IN ["Peter", "Paul", "Mary"] DELETE u
 ```
-Ideally your migrations should be idempotent. You can read more about idempotency in [getting started](GETTING_STARTED.md#create-migrations)
+Ideally your migrations should be idempotent. You can read more about idempotency in [getting started](../../GETTING_STARTED.md#create-migrations)
 
 ## Run migrations
 ```


### PR DESCRIPTION
`database/neo4j/TUTORIAL.md` links to `[getting started](GETTING_STARTED.md#create-migrations)`, which resolves to `database/neo4j/GETTING_STARTED.md` — a file that doesn't exist, so the link 404s.

`GETTING_STARTED.md` lives at the repository root. The sibling `database/postgres/TUTORIAL.md` already links it correctly as `../../GETTING_STARTED.md`; this change makes neo4j consistent. Verified the root file exists. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)