### PR TITLE
fix: propagate migration body read errors to the database driver

### DIFF
--- a/migration.go
+++ b/migration.go
@@ -37,9 +37,9 @@ type Migration struct {
 	// BufferSize defaults to DefaultBufferSize
 	BufferSize uint
 
-	// bufferWriter holds an io.WriteCloser and pipes to BufferBody.
+	// bufferWriter holds the write half of the pipe to BufferedBody.
 	// It's an *Closer for flow control.
-	bufferWriter io.WriteCloser
+	bufferWriter *io.PipeWriter
 
 	// Scheduled is the time when the migration was scheduled/ queued.
 	Scheduled time.Time
@@ -131,8 +131,14 @@ func (m *Migration) Buffer() (berr error) {
 	// defer closing buffer writer and body.
 	defer func() {
 		// close bufferWriter so Buffer knows that there is no
-		// more data coming.
-		if err := m.bufferWriter.Close(); err != nil {
+		// more data coming. If reading the body failed, close with that
+		// error instead: a plain Close would signal a clean io.EOF and the
+		// database driver would run a truncated migration and report success.
+		if berr != nil {
+			if err := m.bufferWriter.CloseWithError(berr); err != nil {
+				berr = errors.Join(berr, err)
+			}
+		} else if err := m.bufferWriter.Close(); err != nil {
 			berr = errors.Join(berr, err)
 		}
 

--- a/migration_test.go
+++ b/migration_test.go
@@ -1,10 +1,13 @@
 package migrate
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"strings"
+	"testing"
 )
 
 func ExampleNewMigration() {
@@ -53,4 +56,66 @@ func ExampleNewMigration_nilVersion() {
 	fmt.Print(migr.LogString())
 	// Output:
 	// 1486686016/d drop_users_table
+}
+
+// errReader yields prefix and then fails with err. It simulates a source
+// (S3, GCS, GitHub, ...) that breaks while the migration body is being read.
+type errReader struct {
+	prefix []byte
+	err    error
+	off    int
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	if r.off >= len(r.prefix) {
+		return 0, r.err
+	}
+	n := copy(p, r.prefix[r.off:])
+	r.off += n
+	return n, nil
+}
+
+func (r *errReader) Close() error { return nil }
+
+// TestBufferPropagatesReadError asserts that a failure to read the migration
+// body reaches whoever reads BufferedBody, which is the database driver.
+// Closing the pipe without the error would signal a clean io.EOF and make the
+// driver run a truncated (possibly empty) migration and report success.
+func TestBufferPropagatesReadError(t *testing.T) {
+	errRead := errors.New("source connection reset")
+
+	tests := []struct {
+		name   string
+		prefix []byte
+	}{
+		// Fails inside Buffer's Peek, before anything is written to the pipe.
+		{"fails before any data is read", nil},
+		{"fails after a partial read", []byte("CREATE TABLE users (")},
+		// Larger than the buffer, so Peek succeeds and the read fails later,
+		// inside WriteTo, after bytes have already reached the driver.
+		{"fails after the buffer is filled", bytes.Repeat([]byte("-- sql\n"), int(DefaultBufferSize)/7+1)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := &errReader{prefix: tt.prefix, err: errRead}
+
+			migr, err := NewMigration(body, "create_users_table", 1, 2)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			bufferErr := make(chan error, 1)
+			go func() { bufferErr <- migr.Buffer() }()
+
+			// This is what database.Driver.Run does with BufferedBody.
+			if _, err := io.ReadAll(migr.BufferedBody); !errors.Is(err, errRead) {
+				t.Errorf("reading BufferedBody: got error %v, want %v", err, errRead)
+			}
+
+			if err := <-bufferErr; !errors.Is(err, errRead) {
+				t.Errorf("Buffer(): got error %v, want %v", err, errRead)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Follow-up to #1308.

### Problem

`Migration.bufferWriter` is the write half of an `io.Pipe` and `Migration.BufferedBody` is the read half that `runMigrations` passes to `database.Driver.Run`.

#1308 correctly made `Buffer()` always close `bufferWriter` via a deferred call, which fixed the reported case of a driver blocking forever on `BufferedBody`. However, `io.PipeWriter.Close()` closes with a **nil** error, so the reader observes a clean `io.EOF` — including when reading the migration body actually failed.

Both error returns in `Buffer()` are affected:

```go
if _, err := b.Peek(int(m.BufferSize)); err != nil && err != io.EOF {
    return err          // nothing written to the pipe yet
}
...
n, err := b.WriteTo(m.bufferWriter)
if err != nil {
    return err          // partial body already written to the pipe
}
```

The error returned by `Buffer()` does not compensate for this, because `Buffer()` runs in a goroutine started by `readUp`/`readDown` whose only handling is `m.logErr(err)` — and `logErr` is a no-op when no logger is configured, which is the default for library use:

```go
go func() {
    if err := migr.Buffer(); err != nil {
        m.logErr(err)
    }
}()
```

So when a source fails mid-read (S3, GCS, GitHub and other network-backed sources are the realistic trigger), `runMigrations` does:

```
SetVersion(target, dirty=true)
Run(BufferedBody)   -> reads EOF, executes a truncated or empty body, returns nil
SetVersion(target, dirty=false)
```

The result is that a partially-read migration is executed and then recorded as **fully applied and clean**. Nothing fails and nothing is logged, so the next `up` continues from a schema that was never fully migrated. That is worse than the migration failing outright, where the dirty flag at least stops the next run.

### Fix

Close the pipe with the read error instead of a nil error, so the failure reaches the driver:

```go
if berr != nil {
    if err := m.bufferWriter.CloseWithError(berr); err != nil {
        berr = errors.Join(berr, err)
    }
} else if err := m.bufferWriter.Close(); err != nil {
    berr = errors.Join(berr, err)
}
```

`Run` then returns the error, `runMigrations` propagates it to the caller, and the version row is correctly left dirty. The writer is still closed unconditionally, so the guarantee added in #1308 is preserved.

This required changing the unexported field `bufferWriter` from `io.WriteCloser` to `*io.PipeWriter` to reach `CloseWithError`. The field is private and only referenced inside `migration.go`; `NewMigration` already assigns it from `io.Pipe()`. There is no change to the exported API.

### Tests

`TestBufferPropagatesReadError` covers a body that fails before any data is read, after a partial read, and after the buffer is filled — the last one exercising the `WriteTo` return site rather than `Peek`. Each asserts that the error surfaces to a reader of `BufferedBody`, which is what a database driver does with it.

The test fails on `master` (the read returns `<nil>`, i.e. a clean EOF with truncated content) and passes with this change. No Docker required.
