### PR TITLE
fix: strip UTF-8 BOM from migrations

### DIFF
--- a/migration.go
+++ b/migration.go
@@ -2,6 +2,7 @@ package migrate
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -142,6 +143,13 @@ func (m *Migration) Buffer() (berr error) {
 		}
 
 	}()
+
+	utf8BOM := []byte{0xEF, 0xBB, 0xBF}
+	if prefix, err := b.Peek(len(utf8BOM)); err == nil && bytes.Equal(prefix, utf8BOM) {
+		if _, err := b.Discard(len(utf8BOM)); err != nil {
+			return err
+		}
+	}
 
 	// start reading from body, peek won't move the read pointer though
 	// poor man's solution?

--- a/migration_test.go
+++ b/migration_test.go
@@ -5,7 +5,41 @@ import (
 	"io"
 	"log"
 	"strings"
+	"testing"
 )
+
+func TestMigrationBufferStripsUTF8BOM(t *testing.T) {
+	const migrationBody = "CREATE TABLE users (id INT);"
+	migration, err := NewMigration(
+		io.NopCloser(strings.NewReader("\xEF\xBB\xBF"+migrationBody)),
+		"create_users_table",
+		1,
+		2,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bufferErr := make(chan error, 1)
+	go func() {
+		bufferErr <- migration.Buffer()
+	}()
+
+	buffered, err := io.ReadAll(migration.BufferedBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := <-bufferErr; err != nil {
+		t.Fatal(err)
+	}
+
+	if got := string(buffered); got != migrationBody {
+		t.Fatalf("buffered migration = %q, want %q", got, migrationBody)
+	}
+	if migration.BytesRead != int64(len(migrationBody)) {
+		t.Fatalf("bytes read = %d, want %d", migration.BytesRead, len(migrationBody))
+	}
+}
 
 func ExampleNewMigration() {
 	// Create a dummy migration body, this is coming from the source usually.


### PR DESCRIPTION
## Motivation

Migration files saved as UTF-8 with a byte order mark currently pass the BOM to the database driver. PostgreSQL and other databases then reject the first statement because the BOM is not valid SQL syntax.

Fixes #1136.

## Changes

- Detect and discard an exact UTF-8 BOM at the start of the central migration buffer.
- Preserve all other migration bytes unchanged.
- Add a regression test that exercises the asynchronous buffer path and verifies the resulting byte count.

Handling this in `Migration.Buffer` makes the behavior consistent across source and database drivers.

## Testing

- `go test . -run TestMigrationBufferStripsUTF8BOM`
- `go test .`
- `go vet .`
- `git diff --check`

`go test -short ./...` was also run. Packages not requiring external services passed; database integration suites failed because Docker is unavailable locally, and several existing driver tests assume Unix-style temporary paths.
