### PR TITLE
perf(source): build migrations index lazily to avoid quadratic startup

### DIFF
--- a/source/migration.go
+++ b/source/migration.go
@@ -35,6 +35,7 @@ type Migration struct {
 // to keep track of Migration order.
 type Migrations struct {
 	index      uintSlice
+	dirty      bool
 	migrations map[uint]map[Direction]*Migration
 }
 
@@ -60,7 +61,7 @@ func (i *Migrations) Append(m *Migration) (ok bool) {
 	}
 
 	i.migrations[m.Version][m.Direction] = m
-	i.buildIndex()
+	i.dirty = true
 
 	return true
 }
@@ -73,9 +74,17 @@ func (i *Migrations) buildIndex() {
 	sort.Slice(i.index, func(x, y int) bool {
 		return i.index[x] < i.index[y]
 	})
+	i.dirty = false
+}
+
+func (i *Migrations) ensureIndex() {
+	if i.dirty {
+		i.buildIndex()
+	}
 }
 
 func (i *Migrations) First() (version uint, ok bool) {
+	i.ensureIndex()
 	if len(i.index) == 0 {
 		return 0, false
 	}
@@ -117,6 +126,7 @@ func (i *Migrations) Down(version uint) (m *Migration, ok bool) {
 }
 
 func (i *Migrations) findPos(version uint) int {
+	i.ensureIndex()
 	if len(i.index) > 0 {
 		ix := i.index.Search(version)
 		if ix < len(i.index) && i.index[ix] == version {

--- a/source/migration_test.go
+++ b/source/migration_test.go
@@ -12,6 +12,53 @@ func TestAppend(t *testing.T) {
 	// TODO
 }
 
+func TestInterleavedAppendReads(t *testing.T) {
+	m := NewMigrations()
+
+	if !m.Append(&Migration{Version: 10, Direction: Up}) {
+		t.Fatal("expected append version 10 up to succeed")
+	}
+	if !m.Append(&Migration{Version: 10, Direction: Down}) {
+		t.Fatal("expected append version 10 down to succeed")
+	}
+	if !m.Append(&Migration{Version: 30, Direction: Up}) {
+		t.Fatal("expected append version 30 up to succeed")
+	}
+
+	if v, ok := m.First(); !ok || v != 10 {
+		t.Fatalf("expected first version 10, got %v, %v", v, ok)
+	}
+	if v, ok := m.Next(10); !ok || v != 30 {
+		t.Fatalf("expected next version after 10 to be 30, got %v, %v", v, ok)
+	}
+	if v, ok := m.Prev(30); !ok || v != 10 {
+		t.Fatalf("expected previous version before 30 to be 10, got %v, %v", v, ok)
+	}
+
+	if !m.Append(&Migration{Version: 20, Direction: Up}) {
+		t.Fatal("expected append version 20 up to succeed")
+	}
+	if !m.Append(&Migration{Version: 20, Direction: Down}) {
+		t.Fatal("expected append version 20 down to succeed")
+	}
+	if !m.Append(&Migration{Version: 5, Direction: Up}) {
+		t.Fatal("expected append version 5 up to succeed")
+	}
+
+	if v, ok := m.First(); !ok || v != 5 {
+		t.Fatalf("expected first version 5, got %v, %v", v, ok)
+	}
+	if v, ok := m.Next(10); !ok || v != 20 {
+		t.Fatalf("expected next version after 10 to be 20, got %v, %v", v, ok)
+	}
+	if v, ok := m.Next(20); !ok || v != 30 {
+		t.Fatalf("expected next version after 20 to be 30, got %v, %v", v, ok)
+	}
+	if v, ok := m.Prev(20); !ok || v != 10 {
+		t.Fatalf("expected previous version before 20 to be 10, got %v, %v", v, ok)
+	}
+}
+
 func TestBuildIndex(t *testing.T) {
 	// TODO
 }
@@ -42,5 +89,35 @@ func TestFindPos(t *testing.T) {
 	}
 	if p := m.findPos(3); p != 2 {
 		t.Errorf("expected 2, got %v", p)
+	}
+}
+
+func BenchmarkAppend100(b *testing.B) {
+	benchmarkAppend(b, 100)
+}
+
+func BenchmarkAppend1000(b *testing.B) {
+	benchmarkAppend(b, 1000)
+}
+
+func BenchmarkAppend5000(b *testing.B) {
+	benchmarkAppend(b, 5000)
+}
+
+func benchmarkAppend(b *testing.B, n int) {
+	for i := 0; i < b.N; i++ {
+		m := NewMigrations()
+		for version := 1; version <= n; version++ {
+			v := uint(version)
+			if !m.Append(&Migration{Version: v, Direction: Up}) {
+				b.Fatalf("expected append version %d up to succeed", version)
+			}
+			if !m.Append(&Migration{Version: v, Direction: Down}) {
+				b.Fatalf("expected append version %d down to succeed", version)
+			}
+		}
+		if _, ok := m.First(); !ok {
+			b.Fatal("expected first version")
+		}
 	}
 }


### PR DESCRIPTION
# Problem

`source.Migrations.Append` calls `buildIndex()` on every append, which rebuilds and re-sorts the entire version index each time. Since every in-memory source driver (`file`, `iofs`, `aws_s3`, `github`, `bitbucket`, `go_bindata`, ...) calls `Append` in a loop when the driver is opened/initialized, loading n migration files costs O(n² log n).

For long-lived projects this makes startup noticeably slow before any migration is even executed. Large migration counts are a real use case (see e.g. #1412, which fixes S3 listing for >1000 migrations).

# Fix

`Append` now only marks the index as dirty. The index is rebuilt at most once, lazily, on the first read access (`First`, or `Prev`/`Next` via `findPos`). This keeps the total cost at O(n log n) regardless of how many files are appended.

- No exported API changes; `Append`'s duplicate-rejection behavior is unchanged.
- No change to the (already non-)thread-safety contract of `Migrations`: drivers build it once at init and read afterwards, same as before.

# Benchmarks

Added `BenchmarkAppend{100,1000,5000}` (append n up/down pairs, then one read so the index build is included). Same benchmark code against both implementations (i9-9900K, Windows, go1.25; the n=10,000 row was measured with an equivalent out-of-tree benchmark):

| n (versions) | before | after |
|---|---|---|
| 100 | 0.69 ms/op | 0.05 ms/op |
| 1,000 | 70.4 ms/op | 0.41 ms/op |
| 5,000 | 2.12 s/op | 2.0 ms/op |
| 10,000 | 11.3 s/op | 7.0 ms/op |

Before scales ~quadratically (4x files → ~16x time); after is linearithmic.

# Verification

- `go test ./source/` — passes (existing tests + new interleaved append/read regression test)
- `go vet ./source/` — clean
- `golangci-lint run ./source/` — no new issues
