### PR TITLE
postgres: Drop() also drops custom types

### DIFF
--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -446,13 +446,21 @@ func (p *Postgres) Drop() (err error) {
 
 	// select all custom types (enums, domains, and standalone composite types) in the current schema.
 	// Excludes the row type Postgres automatically creates for every table (already gone via DROP TABLE
-	// above, or never a real user type to begin with) and the array type Postgres automatically creates
-	// alongside every type.
+	// above, or never a real user type to begin with), the array type Postgres automatically creates
+	// alongside every type, and any type an extension or the system installed (an internal or
+	// extension pg_depend entry) -- those can't be dropped without dropping the extension itself,
+	// which is outside Drop()'s remit, and a range type's auto-generated multirange has an internal
+	// dependency on its range type that trips a plain DROP regardless of statement order.
 	query = `SELECT t.typname FROM pg_catalog.pg_type t
 		LEFT JOIN pg_catalog.pg_class c ON c.oid = t.typrelid
 		WHERE t.typnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = current_schema())
 		AND (t.typrelid = 0 OR c.relkind = 'c')
-		AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_type el WHERE el.typarray = t.oid)`
+		AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_type el WHERE el.typarray = t.oid)
+		AND NOT EXISTS (
+			SELECT 1 FROM pg_catalog.pg_depend d
+			WHERE d.classid = 'pg_catalog.pg_type'::regclass AND d.objid = t.oid
+			AND d.deptype IN ('e', 'i')
+		)`
 	types, err := p.conn.QueryContext(context.Background(), query)
 	if err != nil {
 		return &database.Error{OrigErr: err, Query: []byte(query)}

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -444,6 +444,49 @@ func (p *Postgres) Drop() (err error) {
 		}
 	}
 
+	// select all custom types (enums, domains, and standalone composite types) in the current schema.
+	// Excludes the row type Postgres automatically creates for every table (already gone via DROP TABLE
+	// above, or never a real user type to begin with) and the array type Postgres automatically creates
+	// alongside every type.
+	query = `SELECT t.typname FROM pg_catalog.pg_type t
+		LEFT JOIN pg_catalog.pg_class c ON c.oid = t.typrelid
+		WHERE t.typnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = current_schema())
+		AND (t.typrelid = 0 OR c.relkind = 'c')
+		AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_type el WHERE el.typarray = t.oid)`
+	types, err := p.conn.QueryContext(context.Background(), query)
+	if err != nil {
+		return &database.Error{OrigErr: err, Query: []byte(query)}
+	}
+	defer func() {
+		if errClose := types.Close(); errClose != nil {
+			err = errors.Join(err, errClose)
+		}
+	}()
+
+	typeNames := make([]string, 0)
+	for types.Next() {
+		var typeName string
+		if err := types.Scan(&typeName); err != nil {
+			return err
+		}
+		if len(typeName) > 0 {
+			typeNames = append(typeNames, typeName)
+		}
+	}
+	if err := types.Err(); err != nil {
+		return &database.Error{OrigErr: err, Query: []byte(query)}
+	}
+
+	if len(typeNames) > 0 {
+		// delete one by one ...
+		for _, t := range typeNames {
+			query = `DROP TYPE IF EXISTS ` + pq.QuoteIdentifier(t) + ` CASCADE`
+			if _, err := p.conn.ExecContext(context.Background(), query); err != nil {
+				return &database.Error{OrigErr: err, Query: []byte(query)}
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/database/postgres/postgres_test.go
+++ b/database/postgres/postgres_test.go
@@ -100,6 +100,7 @@ func Test(t *testing.T) {
 	t.Run("testWithInstanceConcurrent", testWithInstanceConcurrent)
 	t.Run("testWithConnection", testWithConnection)
 	t.Run("testDropWithCustomTypes", testDropWithCustomTypes)
+	t.Run("testDropWithExtensionAndRangeTypes", testDropWithExtensionAndRangeTypes)
 
 	t.Cleanup(func() {
 		for _, spec := range specs {
@@ -188,6 +189,71 @@ func testDropWithCustomTypes(t *testing.T) {
 			if _, err := db.Exec(s); err != nil {
 				t.Fatalf("re-creating type after Drop() failed (Drop() left it behind): %v", err)
 			}
+		}
+	})
+}
+
+// testDropWithExtensionAndRangeTypes is a regression test for two ways the
+// type-selection query in Drop() can pick up a type it must not try to drop:
+// a type an extension installed (dropping it fails -- only dropping the
+// extension itself can remove it), and a range type, whose auto-generated
+// multirange type has an internal dependency on it that a plain DROP TYPE
+// (even with CASCADE) cannot satisfy regardless of statement order.
+func testDropWithExtensionAndRangeTypes(t *testing.T) {
+	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ip, port, err := c.FirstPort()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		addr := pgConnectionString(ip, port)
+		p := &Postgres{}
+		d, err := p.Open(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := d.Close(); err != nil {
+				t.Error(err)
+			}
+		}()
+
+		db, err := sql.Open("postgres", addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := db.Close(); err != nil {
+				t.Error(err)
+			}
+		}()
+
+		statements := []string{
+			`CREATE EXTENSION IF NOT EXISTS citext`,
+			`CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')`,
+			`CREATE TYPE floatrange AS RANGE (subtype = float8)`,
+		}
+		for _, s := range statements {
+			if _, err := db.Exec(s); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if err := d.Drop(); err != nil {
+			t.Fatalf("Drop() failed on a database with an extension-owned type and a range type: %v", err)
+		}
+
+		var extant string
+		err = db.QueryRow(`SELECT typname FROM pg_type WHERE typname = 'citext'`).Scan(&extant)
+		if err != nil {
+			t.Fatalf("expected the extension-owned citext type to survive Drop(), got: %v", err)
+		}
+
+		if _, err := db.Exec(`CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')`); err != nil {
+			t.Fatalf("re-creating mood after Drop() failed: %v", err)
+		}
+		if _, err := db.Exec(`CREATE TYPE floatrange AS RANGE (subtype = float8)`); err != nil {
+			t.Fatalf("re-creating floatrange after Drop() failed: %v", err)
 		}
 	})
 }

--- a/database/postgres/postgres_test.go
+++ b/database/postgres/postgres_test.go
@@ -99,6 +99,7 @@ func Test(t *testing.T) {
 	t.Run("testPostgresLock", testPostgresLock)
 	t.Run("testWithInstanceConcurrent", testWithInstanceConcurrent)
 	t.Run("testWithConnection", testWithConnection)
+	t.Run("testDropWithCustomTypes", testDropWithCustomTypes)
 
 	t.Cleanup(func() {
 		for _, spec := range specs {
@@ -129,6 +130,65 @@ func test(t *testing.T) {
 			}
 		}()
 		dt.Test(t, d, []byte("SELECT 1"))
+	})
+}
+
+// testDropWithCustomTypes is a regression test for Drop() not removing custom
+// types (enums, domains, standalone composite types), which left a database
+// unable to re-run a migration that (re-)creates one of those types. See
+// https://github.com/golang-migrate/migrate/issues/626.
+func testDropWithCustomTypes(t *testing.T) {
+	dktesting.ParallelTest(t, specs, func(t *testing.T, c dktest.ContainerInfo) {
+		ip, port, err := c.FirstPort()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		addr := pgConnectionString(ip, port)
+		p := &Postgres{}
+		d, err := p.Open(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := d.Close(); err != nil {
+				t.Error(err)
+			}
+		}()
+
+		db, err := sql.Open("postgres", addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := db.Close(); err != nil {
+				t.Error(err)
+			}
+		}()
+
+		statements := []string{
+			`CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')`,
+			`CREATE TYPE point2d AS (x int, y int)`,
+			`CREATE DOMAIN posint AS int CHECK (VALUE > 0)`,
+			`CREATE TABLE widgets (id serial primary key, m mood, p point2d, n posint)`,
+		}
+		for _, s := range statements {
+			if _, err := db.Exec(s); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if err := d.Drop(); err != nil {
+			t.Fatal(err)
+		}
+
+		// A truly clean database can re-create every type Drop() should have
+		// removed. Before the fix this failed with "type ... already exists".
+		for _, s := range statements[:3] {
+			if _, err := db.Exec(s); err != nil {
+				t.Fatalf("re-creating type after Drop() failed (Drop() left it behind): %v", err)
+			}
+		}
 	})
 }
 


### PR DESCRIPTION
Fixes #626.

## Problem

\`Drop()\` deletes every table in the current schema but leaves custom types (enums, domains, standalone composite types) behind. If a migration creates one of those types, dropping and re-running fails because the type already exists — even though every table is gone.

## Root cause

Confirmed empirically against a real local Postgres 16 instance, not just by reading the code:

\`\`\`
CREATE TYPE mood AS ENUM ('sad','ok','happy');
CREATE TABLE widgets (id serial primary key, m mood);
DROP TABLE widgets CASCADE;
\dT+   -- mood is still there
\`\`\`

\`DROP TABLE ... CASCADE\` cascades to things that depend *on* the table (views, FKs), not to types the table's columns merely reference — the dependency runs the other way. So a type used as a column type always survives a table drop.

## Fix

After dropping tables, the same pattern for types: query, then drop one by one, \`IF EXISTS ... CASCADE\`.

The query mirrors the existing table query's schema-scoping (\`current_schema()\`) and adds two exclusions, verified against real catalog data:
- **Table row types**: every table gets an implicit composite type; joining to \`pg_class\` and requiring \`relkind = 'c'\` (or no backing relation at all, \`typrelid = 0\`) excludes those while still catching real standalone composite types created via \`CREATE TYPE ... AS (...)\`.
- **Array types**: every type gets an implicit array type (e.g. \`_mood\` alongside \`mood\`); the \`NOT EXISTS (... el.typarray = t.oid)\` check excludes those.

Tested against enums, domains, and standalone composite types together in the same schema, plus a second schema and a table with columns of all three custom types, to confirm the query returns exactly the 3 real user types and nothing else — not the table's row type, not any array type, not the other schema's type.

## Testing

- Ran the exact scenario from the issue end-to-end through the real \`postgres.WithInstance\` driver (not just the raw SQL) against a local Postgres 16: create the enum, create a table using it, \`Drop()\`, then re-run the exact \`CREATE TYPE\` from the issue. Before the fix this reproduces \`type "mood" already exists\`; after the fix it succeeds.
- Added \`testDropWithCustomTypes\` to \`postgres_test.go\`, following the existing \`dktesting\`/\`dktest\` pattern used by the rest of this file (registered in the top-level \`Test\` alongside the others) — creates an enum, a domain, and a standalone composite type, uses all three as column types in a table, calls \`Drop()\`, then asserts all three types can be re-created without error.
- \`go build ./...\` and \`go vet ./...\` clean on \`database/postgres\`.

I don't have Docker in this environment, so I could not run the \`dktest\`-based container suite that \`testDropWithCustomTypes\` is written for — the direct-driver run above against a real (non-containerized) Postgres 16 is what actually verifies the fix, and the added test is written to match how this repo's CI will run it.