### PR TITLE
ci: update golangci-lint to v2.13.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,10 +26,10 @@ jobs:
       #    version: 19.03.13
           # docker_layer_caching: true
       - run: curl -sL -o ~/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
-      - run: curl -sfL -o ~/bin/golangci-lint.sh https://install.goreleaser.com/github.com/golangci/golangci-lint.sh
+      - run: curl -sfL -o ~/bin/golangci-lint.sh https://golangci-lint.run/install.sh
       - run: chmod +x ~/bin/gimme ~/bin/golangci-lint.sh
       - run: eval "$(gimme $GO_VERSION)"
-      - run: golangci-lint.sh -b ~/bin v1.37.0
+      - run: golangci-lint.sh -b ~/bin v2.13.1
       - checkout
       - restore_cache:
           keys:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.11.4
+          version: v2.13.1
 
   test:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,9 @@ linters:
     - unconvert
     - unparam
   settings:
+    goconst:
+      # Ignore tests to match goconst's default behavior.
+      ignore-tests: true
     misspell:
       locale: US
     revive:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   # Install golangci-lint
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0
+  - curl -sfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.13.1
   - echo "TRAVIS_GO_VERSION=${TRAVIS_GO_VERSION}"
 
 install:


### PR DESCRIPTION
## Summary

- update all pinned golangci-lint versions to v2.13.1
- update legacy CI jobs to use the current official installer
- ignore test files in goconst to match goconst's default behavior

## Testing

- ran golangci-lint v2.13.1 with the repository configuration
- 0 issues reported