### PR TITLE
build: bump alpine docker image to 3.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine3.21 AS builder
+FROM golang:1.26-alpine3.24 AS builder
 ARG VERSION
 
 RUN apk add --no-cache git gcc musl-dev make
@@ -15,7 +15,7 @@ COPY . ./
 
 RUN make build-docker
 
-FROM alpine:3.21
+FROM alpine:3.24
 
 RUN apk add --no-cache ca-certificates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN make build-docker
 
 FROM alpine:3.24
 
-RUN apk add --no-cache ca-certificates
+RUN apk upgrade --no-cache \
+    && apk add --no-cache ca-certificates
 
 COPY --from=builder /go/src/github.com/golang-migrate/migrate/build/migrate.linux-386 /usr/local/bin/migrate
 RUN ln -s /usr/local/bin/migrate /migrate

--- a/Dockerfile.github-actions
+++ b/Dockerfile.github-actions
@@ -1,6 +1,7 @@
 FROM alpine:3.24
 
-RUN apk add --no-cache ca-certificates
+RUN apk upgrade --no-cache \
+    && apk add --no-cache ca-certificates
 
 COPY migrate /usr/local/bin/migrate
 

--- a/Dockerfile.github-actions
+++ b/Dockerfile.github-actions
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM alpine:3.24
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
## Summary

Update the Docker images to supported Go and Alpine versions:

- update the regular Docker builder from Go 1.25 / Alpine 3.21 to Go 1.26 / Alpine 3.24;
- update both runtime images to Alpine 3.24;
- upgrade Alpine packages during image construction before installing CA certificates.

The official Docker Hub images are produced through
`Dockerfile.github-actions`, which previously used the unsupported Alpine
3.19 release.

Running `apk upgrade` is necessary because the current Alpine 3.24 base
image contains OpenSSL 3.5.7-r0, while the fixed 3.5.8-r0 packages are
available from the Alpine repositories.

## Verification

- built and smoke-tested the regular Docker image on `linux/arm64`;
- cross-built and smoke-tested the regular image on `linux/amd64`;
- built and smoke-tested the GoReleaser-style image using
  `Dockerfile.github-actions`;
- confirmed Alpine 3.24.1 and Go 1.26.7;
- scanned the release-style image with Trivy 0.69.3.

The resulting image has no HIGH or CRITICAL Alpine OS-package findings.
Existing Go dependency findings are unchanged and outside the scope of
this PR.

Addresses #1362.
Addresses the Alpine portion of #1381.