### PR TITLE
fix(mongodb): replace deprecated DecodeBytes

### DIFF
--- a/database/mongodb/mongodb_test.go
+++ b/database/mongodb/mongodb_test.go
@@ -411,12 +411,7 @@ func waitForReplicaInit(client *mongo.Client) error {
 			//during replica set initialization, the first node first becomes a secondary and then becomes the primary
 			//should consider that initialization is completed only after the node has become the primary
 			result := client.Database("admin").RunCommand(context.TODO(), bson.D{bson.E{Key: "isMaster", Value: 1}})
-			r, err := result.DecodeBytes()
-			if err != nil {
-				return err
-			}
-			err = bson.Unmarshal(r, &status)
-			if err != nil {
+			if err := result.Decode(&status); err != nil {
 				return err
 			}
 			if status.IsMaster {


### PR DESCRIPTION
## What changed

Replace the deprecated `SingleResult.DecodeBytes` call with `SingleResult.Decode`.

This keeps the MongoDB test compatible with both the current driver version and `v1.17.7`, where `DecodeBytes` causes a `staticcheck` failure. It unblocks #1429.

## Testing

```sh
go test ./database/mongodb -run '^$'